### PR TITLE
Do not delete old reviews

### DIFF
--- a/src/AutoMerge/github.jl
+++ b/src/AutoMerge/github.jl
@@ -59,6 +59,7 @@ function delete_merged_branch!(repo::GitHub.Repo, pr::GitHub.PullRequest; auth::
 end
 
 function delete_pr_review!(repo::GitHub.Repo, pr::GitHub.PullRequest, r::GitHub.Review; auth::GitHub.Authorization)
+    return nothing
     repo_full_name = full_name(repo)
     pr_number = number(pr)
     review_id = r.id


### PR DESCRIPTION
If there are multiple reviews, we use the most recent one. So actually there is no need to try to delete old reviews.

Fixes #24 