### PR TITLE
Put approve-comment in the review

### DIFF
--- a/src/AutoMerge/github.jl
+++ b/src/AutoMerge/github.jl
@@ -1,16 +1,20 @@
 function approve!(repo::GitHub.Repo,
                   pr::GitHub.PullRequest,
                   pr_head_commit_sha_to_approve::String;
-                  auth::GitHub.Authorization)
+                  auth::GitHub.Authorization,
+                  body::String="")
     whoami = username(auth)
     if pr.user.login == whoami
     else
         repo_full_name = full_name(repo)
         pr_number = number(pr)
         endpoint = "/repos/$(repo_full_name)/pulls/$(pr_number)/reviews"
-        approving_review_body = string("<!---",
-                                       "approved_pr_head_commit_sha=\"$(pr_head_commit_sha_to_approve)\"",
-                                       "--->")
+        approving_review_body = """
+                $body
+                <!---
+                approved_pr_head_commit_sha=\"$(pr_head_commit_sha_to_approve)\"
+                --->
+                """
         myparams = Dict("event" => "APPROVE",
                         "body" => approving_review_body)
         GitHub.gh_post_json(GitHub.DEFAULT_API,

--- a/src/AutoMerge/new-package.jl
+++ b/src/AutoMerge/new-package.jl
@@ -53,9 +53,8 @@ function travis_pull_request_build(::NewPackage,
                                                              suggest_onepointzero,
                                                              version)
                     my_retry(() -> delete_all_of_my_reviews!(registry, pr; auth = auth, whoami = whoami))
-                    my_retry(() -> approve!(registry, pr, current_pr_head_commit_sha; auth = auth))
+                    my_retry(() -> approve!(registry, pr, current_pr_head_commit_sha; auth = auth, body = newp_commenttextpass))
                     my_retry(() -> GitHub.create_status(registry, current_pr_head_commit_sha; auth=auth, params=Dict("state" => "success", "context" => "automerge/new-package", "description" => "$(current_pr_head_commit_sha)")))
-                    my_retry(() -> post_comment!(registry, pr, newp_commenttextpass; auth = auth))
                     return nothing
                 else
                     newp_commenttext6and7 = comment_text_fail(NewPackage(),

--- a/src/AutoMerge/new-package.jl
+++ b/src/AutoMerge/new-package.jl
@@ -55,6 +55,7 @@ function travis_pull_request_build(::NewPackage,
                     my_retry(() -> delete_all_of_my_reviews!(registry, pr; auth = auth, whoami = whoami))
                     my_retry(() -> approve!(registry, pr, current_pr_head_commit_sha; auth = auth, body = newp_commenttextpass))
                     my_retry(() -> GitHub.create_status(registry, current_pr_head_commit_sha; auth=auth, params=Dict("state" => "success", "context" => "automerge/new-package", "description" => "$(current_pr_head_commit_sha)")))
+                    # my_retry(() -> post_comment!(registry, pr, newp_commenttextpass; auth = auth))
                     return nothing
                 else
                     newp_commenttext6and7 = comment_text_fail(NewPackage(),

--- a/src/AutoMerge/new-package.jl
+++ b/src/AutoMerge/new-package.jl
@@ -55,7 +55,6 @@ function travis_pull_request_build(::NewPackage,
                     my_retry(() -> delete_all_of_my_reviews!(registry, pr; auth = auth, whoami = whoami))
                     my_retry(() -> approve!(registry, pr, current_pr_head_commit_sha; auth = auth, body = newp_commenttextpass))
                     my_retry(() -> GitHub.create_status(registry, current_pr_head_commit_sha; auth=auth, params=Dict("state" => "success", "context" => "automerge/new-package", "description" => "$(current_pr_head_commit_sha)")))
-                    # my_retry(() -> post_comment!(registry, pr, newp_commenttextpass; auth = auth))
                     return nothing
                 else
                     newp_commenttext6and7 = comment_text_fail(NewPackage(),

--- a/src/AutoMerge/new-version.jl
+++ b/src/AutoMerge/new-version.jl
@@ -58,7 +58,6 @@ function travis_pull_request_build(::NewVersion,
                     my_retry(() -> delete_all_of_my_reviews!(registry, pr; auth = auth, whoami = whoami))
                     my_retry(() -> approve!(registry, pr, current_pr_head_commit_sha; auth = auth, body = newv_commenttextpass))
                     my_retry(() -> GitHub.create_status(registry, current_pr_head_commit_sha; auth=auth, params=Dict("state" => "success", "context" => "automerge/new-version", "description" => "$(current_pr_head_commit_sha)")))
-                    # my_retry(() -> post_comment!(registry, pr, newv_commenttextpass; auth = auth))
                     return nothing
                 else
                     newv_commenttext4and5 = comment_text_fail(NewVersion(),

--- a/src/AutoMerge/new-version.jl
+++ b/src/AutoMerge/new-version.jl
@@ -56,9 +56,8 @@ function travis_pull_request_build(::NewVersion,
                                                              suggest_onepointzero,
                                                              version)
                     my_retry(() -> delete_all_of_my_reviews!(registry, pr; auth = auth, whoami = whoami))
-                    my_retry(() -> approve!(registry, pr, current_pr_head_commit_sha; auth = auth))
+                    my_retry(() -> approve!(registry, pr, current_pr_head_commit_sha; auth = auth, body = newv_commenttextpass))
                     my_retry(() -> GitHub.create_status(registry, current_pr_head_commit_sha; auth=auth, params=Dict("state" => "success", "context" => "automerge/new-version", "description" => "$(current_pr_head_commit_sha)")))
-                    my_retry(() -> post_comment!(registry, pr, newv_commenttextpass; auth = auth))
                     return nothing
                 else
                     newv_commenttext4and5 = comment_text_fail(NewVersion(),

--- a/src/AutoMerge/new-version.jl
+++ b/src/AutoMerge/new-version.jl
@@ -58,6 +58,7 @@ function travis_pull_request_build(::NewVersion,
                     my_retry(() -> delete_all_of_my_reviews!(registry, pr; auth = auth, whoami = whoami))
                     my_retry(() -> approve!(registry, pr, current_pr_head_commit_sha; auth = auth, body = newv_commenttextpass))
                     my_retry(() -> GitHub.create_status(registry, current_pr_head_commit_sha; auth=auth, params=Dict("state" => "success", "context" => "automerge/new-version", "description" => "$(current_pr_head_commit_sha)")))
+                    # my_retry(() -> post_comment!(registry, pr, newv_commenttextpass; auth = auth))
                     return nothing
                 else
                     newv_commenttext4and5 = comment_text_fail(NewVersion(),


### PR DESCRIPTION
Put approve-comment in the review instead of as a separate comment, fixes #8.