### PR TITLE
Add the `always_assert` function

### DIFF
--- a/src/AutoMerge/AutoMerge.jl
+++ b/src/AutoMerge/AutoMerge.jl
@@ -9,6 +9,8 @@ import TimeZones
 
 import ..RegistryCI
 
+include("assert.jl")
+
 include("types.jl")
 
 include("public.jl")

--- a/src/AutoMerge/assert.jl
+++ b/src/AutoMerge/assert.jl
@@ -1,0 +1,20 @@
+struct AlwaysAssertionError <: Exception
+    msg::AbstractString
+end
+AlwaysAssertionError() = AlwaysAssertionError("")
+
+# The documentation for the `@assert` macro says: "Warning: An assert might be
+# disabled at various optimization levels."
+# Therefore, we have the `@always_assert` macro. `@always_assert` is like
+# `@assert`, except that `@always_assert` will always run and will never be
+# disabled.
+macro always_assert(ex)
+    result = quote
+        if $(ex)
+            nothing
+        else
+            throw(AlwaysAssertionError($(string(ex))))
+        end
+    end
+    return result
+end

--- a/src/AutoMerge/assert.jl
+++ b/src/AutoMerge/assert.jl
@@ -5,16 +5,10 @@ AlwaysAssertionError() = AlwaysAssertionError("")
 
 # The documentation for the `@assert` macro says: "Warning: An assert might be
 # disabled at various optimization levels."
-# Therefore, we have the `@always_assert` macro. `@always_assert` is like
-# `@assert`, except that `@always_assert` will always run and will never be
+# Therefore, we have the `always_assert` function. `always_assert` is like
+# `@assert`, except that `always_assert` will always run and will never be
 # disabled.
-macro always_assert(ex)
-    result = quote
-        if $(ex)
-            nothing
-        else
-            throw(AlwaysAssertionError($(string(ex))))
-        end
-    end
-    return result
+function always_assert(cond::Bool)
+    cond || throw(AlwaysAssertionError())
+    return nothing
 end

--- a/test/automerge-unit.jl
+++ b/test/automerge-unit.jl
@@ -88,7 +88,7 @@ end
 
 @testset "Unit tests" begin
     @testset "assert.jl" begin
-        @test nothing == @test_nowarn AutoMerge.@always_assert 1 == 1
-        @test_throws AutoMerge.AlwaysAssertionError AutoMerge.@always_assert 1 == 2
+        @test nothing == @test_nowarn AutoMerge.always_assert(1 == 1)
+        @test_throws AutoMerge.AlwaysAssertionError AutoMerge.always_assert(1 == 2)
     end
 end

--- a/test/automerge-unit.jl
+++ b/test/automerge-unit.jl
@@ -85,3 +85,10 @@ end
         @test !AutoMerge.range_did_not_narrow(r3, r2)[1]
     end
 end
+
+@testset "Unit tests" begin
+    @testset "assert.jl" begin
+        @test nothing == @test_nowarn AutoMerge.@always_assert 1 == 1
+        @test_throws AutoMerge.AlwaysAssertionError AutoMerge.@always_assert 1 == 2
+    end
+end


### PR DESCRIPTION
The documentation for the `@assert` macro says:
> Warning: An assert might be disabled at various optimization levels.

This pull request adds the `always_assert` function. `always_assert` is like `@assert`, except that `always_assert` will always run and will never be disabled.