### PR TITLE
Do not consider `PkgA = "0"` to be an upper-bounded compat range

### DIFF
--- a/src/AutoMerge/semver.jl
+++ b/src/AutoMerge/semver.jl
@@ -45,7 +45,7 @@ function julia_compat(pkg::String, version::VersionNumber, registry_path::String
 end
 
 function _has_upper_bound(r::Pkg.Types.VersionRange)
-    return r.upper != Pkg.Types.VersionBound("*")
+    return r.upper != Pkg.Types.VersionBound("*") && r.upper != Pkg.Types.VersionBound("0")
 end
 
 function range_did_not_narrow(r1::Pkg.Types.VersionRange, r2::Pkg.Types.VersionRange)


### PR DESCRIPTION
Before this PR:
- `Pkg.Types.VersionBound("*")` is not an upper bound
- Every other `VersionBound` is an upper bound

After this PR:
- `Pkg.Types.VersionBound("*")` is not an upper bound
- `Pkg.Types.VersionBound("0")` is not an upper bound
- Every other `VersionBound` is an upper bound