### PR TITLE
Always run the unit tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,20 +9,21 @@ using TimeZones
 const AutoMerge = RegistryCI.AutoMerge
 
 @testset "RegistryCI.jl" begin
+    @testset "RegistryCI.jl unit tests" begin
+        @info("Running the RegistryCI.jl unit tests")
+        include("registryci.jl")
+    end
+
+    @testset "AutoMerge.jl unit tests" begin
+        @info("Running the AutoMerge.jl unit tests")
+        include("automerge-unit.jl")
+    end
+
     AUTOMERGE_RUN_INTEGRATION_TESTS = get(ENV, "AUTOMERGE_RUN_INTEGRATION_TESTS", "")::String
     if AUTOMERGE_RUN_INTEGRATION_TESTS == "true"
         @testset "AutoMerge.jl integration tests" begin
             @info("Running the AutoMerge.jl integration tests")
             include("automerge-integration.jl")
-        end
-    else
-        @testset "RegistryCI.jl unit tests" begin
-            @info("Running the RegistryCI.jl unit tests")
-            include("registryci.jl")
-        end
-        @testset "AutoMerge.jl unit tests" begin
-            @info("Running the AutoMerge.jl unit tests")
-            include("automerge-unit.jl")
         end
     end
 end


### PR DESCRIPTION
If the `AUTOMERGE_RUN_INTEGRATION_TESTS` environment variable is set and its value is equal to `true`, then run the unit tests and the integration tests.

Else, run the unit tests only.