### PR TITLE
allow loading external registry deps

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryCI"
 uuid = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
 authors = ["Dilum Aluthge <dilum@aluthge.com>", "Fredrik Ekre <ekrefredrik@gmail.com>"]
-version = "0.4.3"
+version = "0.4.4"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryCI"
 uuid = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
 authors = ["Dilum Aluthge <dilum@aluthge.com>", "Fredrik Ekre <ekrefredrik@gmail.com>"]
-version = "0.3.1"
+version = "0.4.3"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/AutoMerge/public.jl
+++ b/src/AutoMerge/public.jl
@@ -9,12 +9,13 @@ function run(env = ENV,
              #
              master_branch::String = "master",
              master_branch_is_default_branch::Bool = true,
-             suggest_onepointzero::Bool = true)
+             suggest_onepointzero::Bool = true,
+             registry_deps::Vector{<:AbstractString}=AbstractString[])
 
     registry_head = directory_of_cloned_registry(cicfg; env=env)
 
     # Run tests on the registry (these are very quick)
-    RegistryCI.test(registry_head)
+    RegistryCI.test(registry_head, registry_deps=registry_deps)
 
     # Figure out what type of build this is
     run_pr_build = conditions_met_for_pr_build(cicfg; env=env, master_branch=master_branch)


### PR DESCRIPTION
This allows the UUIDs tested to be loaded from external registries instead of just the registry being tested. 