### PR TITLE
Run all package-loads under xvfb

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryCI"
 uuid = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
 authors = ["Dilum Aluthge <dilum@aluthge.com>", "Fredrik Ekre <ekrefredrik@gmail.com>"]
-version = "0.3.1"
+version = "0.4.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/AutoMerge/guidelines.jl
+++ b/src/AutoMerge/guidelines.jl
@@ -174,6 +174,10 @@ function meets_version_can_be_loaded(working_directory::String,
               env = Dict("PATH" => ENV["PATH"],
                          "PYTHON" => "",
                          "JULIA_DEPOT_PATH" => tmp_dir))
+    # GUI toolkits may need a display just to load the package
+    if (xvfb = Sys.which("xvfb-run")) !== nothing
+        pushfirst!(cmd.exec, xvfb)
+    end
     @info("Attempting to install the package")
     cmd_ran_successfully = success(pipeline(cmd, stdout=stdout, stderr=stderr))
     rm(tmp_dir; force = true, recursive = true)


### PR DESCRIPTION
May fix Gtk and dependent packages (https://github.com/JuliaRegistries/General/pull/6007, https://github.com/JuliaRegistries/General/pull/5890). Hopefully it isn't much of a burden for other packages.