### PR TITLE
Print the results of `Sys.which("xvfb-run")` as a debug message

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryCI"
 uuid = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
 authors = ["Dilum Aluthge <dilum@aluthge.com>", "Fredrik Ekre <ekrefredrik@gmail.com>"]
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/AutoMerge/guidelines.jl
+++ b/src/AutoMerge/guidelines.jl
@@ -175,7 +175,9 @@ function meets_version_can_be_loaded(working_directory::String,
                          "PYTHON" => "",
                          "JULIA_DEPOT_PATH" => tmp_dir))
     # GUI toolkits may need a display just to load the package
-    if (xvfb = Sys.which("xvfb-run")) !== nothing
+    xvfb = Sys.which("xvfb-run")
+    @debug("xvfb: ", xvfb)
+    if xvfb !== nothing
         pushfirst!(cmd.exec, xvfb)
     end
     @info("Attempting to install the package")


### PR DESCRIPTION
That way, we can look at the logs and know whether or not AutoMerge found `xvfb-run` in the `PATH`.