### PR TITLE
If a non-JLL package has a JLL package as a dependency, we will not require you to have a compat entry for the JLL package

### DIFF
--- a/src/AutoMerge/guidelines.jl
+++ b/src/AutoMerge/guidelines.jl
@@ -9,8 +9,8 @@ function meets_compat_for_all_deps(working_directory::AbstractString, pkg, versi
     for version_range in keys(deps)
         if version in Pkg.Types.VersionRange(version_range)
             for name in keys(deps[version_range])
-                if !is_julia_stdlib(name)
-                    @debug("Found a new dependency: $(name)")
+                if (!is_jll_name(name)) & (!is_julia_stdlib(name))
+                    @debug("Found a new (non-stdlib non-JLL) dependency: $(name)")
                     dep_has_compat_with_upper_bound[name] = false
                 end
             end

--- a/src/AutoMerge/jll.jl
+++ b/src/AutoMerge/jll.jl
@@ -1,0 +1,3 @@
+function is_jll_name(name::AbstractString)::Bool
+    return endswith(name, "_jll")
+end


### PR DESCRIPTION
If a non-JLL package has a JLL package as a dependency, we will not require you to have a compat entry for the JLL package.

E.g. suppose you have a package `Example.jl`. And `Example.jl` has a dependency `Foo_jll.jl`. We will not require that `Example.jl` has a compat entry for `Foo_jll.jl`.