### PR TITLE
Require at least Julia 1.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,7 @@ GitHub = "5.1.1"
 HTTP = "0.8"
 JSON = "0.19, 0.20, 0.21"
 TimeZones = "0.10"
-julia = "1"
+julia = "1.3"
 
 [extras]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/test/automerge-integration-utils.jl
+++ b/test/automerge-integration-utils.jl
@@ -1,6 +1,7 @@
 using Dates
 using GitCommand
 using GitHub
+using JSON
 using Pkg
 using Printf
 using RegistryCI

--- a/test/automerge-integration.jl
+++ b/test/automerge-integration.jl
@@ -1,6 +1,7 @@
 using Dates
 using GitCommand
 using GitHub
+using JSON
 using Pkg
 using Printf
 using RegistryCI

--- a/test/automerge-unit.jl
+++ b/test/automerge-unit.jl
@@ -1,6 +1,7 @@
 using Dates
 using GitCommand
 using GitHub
+using JSON
 using Pkg
 using Printf
 using RegistryCI

--- a/test/registryci_registry_testing.jl
+++ b/test/registryci_registry_testing.jl
@@ -1,6 +1,7 @@
 using Dates
 using GitCommand
 using GitHub
+using JSON
 using Pkg
 using Printf
 using RegistryCI

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using Dates
 using GitCommand
 using GitHub
+using JSON
 using Pkg
 using Printf
 using RegistryCI


### PR DESCRIPTION
RegistryCI now uses GitCommand. GitCommand uses Git_jll. Git_jll uses Artifacts. And Artifacts require at least Julia 1.3. So Registry CI now requires at least Julia 1.3.