### PR TITLE
When computing length of package name, exclude `_jll`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryCI"
 uuid = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
 authors = ["Dilum Aluthge <dilum@aluthge.com>", "Fredrik Ekre <ekrefredrik@gmail.com>"]
-version = "0.9.1"
+version = "0.9.2"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/AutoMerge/guidelines.jl
+++ b/src/AutoMerge/guidelines.jl
@@ -110,6 +110,15 @@ function meets_name_length(pkg)
     end
 end
 
+function meets_jll_name_length(pkg)
+    meets_this_guideline = length(pkg) >= 9
+    if meets_this_guideline
+        return true, ""
+    else
+        return false, "Name (excluding the `_jll` suffix) is not at least five characters long"
+    end
+end
+
 function meets_normal_capitalization(pkg)
     meets_this_guideline = occursin(r"^[A-Z]\w*[a-z][0-9]?$", pkg)
     if meets_this_guideline

--- a/src/AutoMerge/new-package.jl
+++ b/src/AutoMerge/new-package.jl
@@ -72,7 +72,11 @@ function pull_request_build(::NewPackage,
             g2 = true
             m2 = ""
             g3, m3 = meets_normal_capitalization(pkg)
-            g4, m4 = meets_name_length(pkg)
+            if this_is_jll_package
+                g4, m4 = meets_jll_name_length(pkg)
+            else
+                g4, m4 = meets_name_length(pkg)
+            end
             if this_is_jll_package
                 g5 = true
                 m5 = ""


### PR DESCRIPTION
We require package names to be at least 5 characters long to be automerged.

For JLL packages, the `_jll` part of the name should not count towards those 5 characters.

This PR fixes that bug.