### PR TITLE
If the PR is not eligible for automerge, the job should exit with an error

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryCI"
 uuid = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
 authors = ["Dilum Aluthge <dilum@aluthge.com>", "Fredrik Ekre <ekrefredrik@gmail.com>"]
-version = "0.10.1"
+version = "0.11.0-DEV"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/AutoMerge/new-package.jl
+++ b/src/AutoMerge/new-package.jl
@@ -7,7 +7,7 @@ function pull_request_build(::NewPackage,
                             registry_head::String,
                             registry_master::String,
                             suggest_onepointzero::Bool,
-                            whoami::String)
+                            whoami::String)::Nothing
     # first check if the PR is open, and the author is authorized - if not, then quit
     # then, delete ALL reviews by me
     # then check rules 1-8. if fail, post comment.
@@ -181,15 +181,11 @@ function pull_request_build(::NewPackage,
                                                          auth = auth,
                                                          whoami = whoami))
                 throw(AutoMergeGuidelinesNotMet("The automerge guidelines were not met."))
-                return nothing
             end
         else
-            @info("Author $(pr_author_login) is not authorized to automerge. Exiting...")
-            return nothing
+            throw(AutoMergeAuthorNotAuthorized("Author $(pr_author_login) is not authorized to automerge. Exiting...")) 
         end
     else
-        @info("The pull request is not open. Exiting...")
-        return nothing
+        throw(AutoMergePullRequestNotOpen("The pull request is not open. Exiting..."))
     end
-    return nothing
 end

--- a/src/AutoMerge/new-version.jl
+++ b/src/AutoMerge/new-version.jl
@@ -7,7 +7,7 @@ function pull_request_build(::NewVersion,
                             registry_head::String,
                             registry_master::String,
                             suggest_onepointzero::Bool,
-                            whoami::String)
+                            whoami::String)::Nothing
     # first check if the PR is open, and the author is authorized - if not, then quit
     # then, delete ALL reviews by me
     # then check rules 1-6. if fail, post comment.
@@ -170,15 +170,11 @@ function pull_request_build(::NewVersion,
                                                          auth = auth,
                                                          whoami = whoami))
                 throw(AutoMergeGuidelinesNotMet("The automerge guidelines were not met."))
-                return nothing
             end
         else
-            @info("Author $(pr_author_login) is not authorized to automerge. Exiting...")
-            return nothing
+            throw(AutoMergeAuthorNotAuthorized("Author $(pr_author_login) is not authorized to automerge. Exiting..."))
         end
     else
-        @info("The pull request is not open. Exiting...")
-        return nothing
+        throw(AutoMergePullRequestNotOpen("The pull request is not open. Exiting..."))
     end
-    return nothing
 end

--- a/src/AutoMerge/public.jl
+++ b/src/AutoMerge/public.jl
@@ -14,7 +14,7 @@ function run(env = ENV,
              #
              master_branch::String = "master",
              master_branch_is_default_branch::Bool = true,
-             suggest_onepointzero::Bool = true)
+             suggest_onepointzero::Bool = true)::Nothing
     all_statuses = deepcopy(additional_statuses)
     all_check_runs = deepcopy(additional_check_runs)
     push!(all_statuses, "automerge/decision")
@@ -31,8 +31,7 @@ function run(env = ENV,
     run_merge_build = conditions_met_for_merge_build(cicfg; env=env, master_branch=master_branch)
 
     if !(run_pr_build || run_merge_build)
-        @info "Build not determined to be either a PR build or a merge build. Exiting."
-        return nothing
+        throw(AutoMergeWrongBuildType("Build not determined to be either a PR build or a merge build. Exiting."))
     end
 
     # Authentication
@@ -55,7 +54,8 @@ function run(env = ENV,
                            suggest_onepointzero = suggest_onepointzero,
                            whoami = whoami)
         return nothing
-    elseif run_merge_build
+    else
+        always_assert(run_merge_build)
         cron_or_api_build(registry_repo;
                           auth = auth,
                           authorized_authors = authorized_authors,
@@ -69,7 +69,5 @@ function run(env = ENV,
                           all_statuses = all_statuses,
                           all_check_runs = all_check_runs)
         return nothing
-    else
-        error("This should not happen.")
     end
 end

--- a/src/AutoMerge/pull-requests.jl
+++ b/src/AutoMerge/pull-requests.jl
@@ -59,7 +59,7 @@ function pull_request_build(pr::GitHub.PullRequest,
                             master_branch::String,
                             master_branch_is_default_branch::Bool,
                             suggest_onepointzero::Bool,
-                            whoami::String)
+                            whoami::String)::Nothing
     if is_new_package(pr)
         registry_master = clone_repo(registry)
         if !master_branch_is_default_branch
@@ -93,7 +93,6 @@ function pull_request_build(pr::GitHub.PullRequest,
                            whoami=whoami)
         rm(registry_master; force = true, recursive = true)
     else
-        @info("Neither a new package nor a new version. Exiting...")
-        return nothing
+        throw(AutoMergeNeitherNewPackageNorNewVersion("Neither a new package nor a new version. Exiting..."))
     end
 end

--- a/src/AutoMerge/pull-requests.jl
+++ b/src/AutoMerge/pull-requests.jl
@@ -31,7 +31,7 @@ function pull_request_build(pr_number::Integer,
                             authorized_authors::Vector{String},
                             master_branch::String,
                             master_branch_is_default_branch::Bool,
-                            suggest_onepointzero::Bool)
+                            suggest_onepointzero::Bool)::Nothing
     pr = my_retry(() -> GitHub.pull_request(registry, pr_number; auth=auth))
     _github_api_pr_head_commit_sha = pull_request_head_sha(pr)
     if current_pr_head_commit_sha != _github_api_pr_head_commit_sha

--- a/src/AutoMerge/pull-requests.jl
+++ b/src/AutoMerge/pull-requests.jl
@@ -35,7 +35,7 @@ function pull_request_build(pr_number::Integer,
     pr = my_retry(() -> GitHub.pull_request(registry, pr_number; auth=auth))
     _github_api_pr_head_commit_sha = pull_request_head_sha(pr)
     if current_pr_head_commit_sha != _github_api_pr_head_commit_sha
-        error("Current commit sha (\"$(current_pr_head_commit_sha)\") does not match what the GitHub API tells us (\"$(_github_api_pr_head_commit_sha)\")")
+        throw(AutoMergeShaMismatch("Current commit sha (\"$(current_pr_head_commit_sha)\") does not match what the GitHub API tells us (\"$(_github_api_pr_head_commit_sha)\")"))
     end
     result = pull_request_build(pr,
                                 current_pr_head_commit_sha,

--- a/src/AutoMerge/types.jl
+++ b/src/AutoMerge/types.jl
@@ -16,6 +16,10 @@ struct AutoMergeGuidelinesNotMet <: AutoMergeException
     msg::String
 end
 
+struct AutoMergeNeitherNewPackageNorNewVersion <: AutoMergeException
+    msg::String
+end
+
 struct AutoMergePullRequestNotOpen <: AutoMergeException
     msg::String
 end

--- a/src/AutoMerge/types.jl
+++ b/src/AutoMerge/types.jl
@@ -28,7 +28,6 @@ struct AutoMergeShaMismatch <: AutoMergeException
     msg::String
 end
 
-
 struct AutoMergeWrongBuildType <: AutoMergeException
     msg::String
 end

--- a/src/AutoMerge/types.jl
+++ b/src/AutoMerge/types.jl
@@ -23,3 +23,8 @@ end
 struct AutoMergeShaMismatch <: AutoMergeException
     msg::String
 end
+
+
+struct AutoMergeWrongBuildType <: AutoMergeException
+    msg::String
+end

--- a/src/AutoMerge/types.jl
+++ b/src/AutoMerge/types.jl
@@ -1,10 +1,21 @@
 struct NewPackage end
 struct NewVersion end
 
-struct AutoMergeCronJobError <: Exception
+abstract type AutoMergeException <: Exception
+end
+
+struct AutoMergeCronJobError <: AutoMergeException
     msg::String
 end
 
-struct AutoMergeGuidelinesNotMet <: Exception
+struct AutoMergeGuidelinesNotMet <: AutoMergeException
+    msg::String
+end
+
+struct AutoMergeAuthorNotAuthorized <: AutoMergeException
+    msg::String
+end
+
+struct AutoMergePullRequestNotOpen <: AutoMergeException
     msg::String
 end

--- a/src/AutoMerge/types.jl
+++ b/src/AutoMerge/types.jl
@@ -4,6 +4,10 @@ struct NewVersion end
 abstract type AutoMergeException <: Exception
 end
 
+struct AutoMergeAuthorNotAuthorized <: AutoMergeException
+    msg::String
+end
+
 struct AutoMergeCronJobError <: AutoMergeException
     msg::String
 end
@@ -12,10 +16,10 @@ struct AutoMergeGuidelinesNotMet <: AutoMergeException
     msg::String
 end
 
-struct AutoMergeAuthorNotAuthorized <: AutoMergeException
+struct AutoMergePullRequestNotOpen <: AutoMergeException
     msg::String
 end
 
-struct AutoMergePullRequestNotOpen <: AutoMergeException
+struct AutoMergeShaMismatch <: AutoMergeException
     msg::String
 end


### PR DESCRIPTION
Fixes #189 

It is very confusing to see that automerge "passed" on a pull request, when in reality that pull request was not eligible to be evaluated for automerge, so automerge did not evaluate it and simply exited.