### PR TITLE
Permit specifying dependency registries

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryCI"
 uuid = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
 authors = ["Dilum Aluthge <dilum@aluthge.com>", "Fredrik Ekre <ekrefredrik@gmail.com>"]
-version = "0.12.0"
+version = "0.11.2"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryCI"
 uuid = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
 authors = ["Dilum Aluthge <dilum@aluthge.com>", "Fredrik Ekre <ekrefredrik@gmail.com>"]
-version = "0.11.1"
+version = "0.12.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/AutoMerge/public.jl
+++ b/src/AutoMerge/public.jl
@@ -14,7 +14,8 @@ function run(env = ENV,
              #
              master_branch::String = "master",
              master_branch_is_default_branch::Bool = true,
-             suggest_onepointzero::Bool = true)::Nothing
+             suggest_onepointzero::Bool = true,
+             registry_deps::Vector{<:AbstractString} = String[])::Nothing
     all_statuses = deepcopy(additional_statuses)
     all_check_runs = deepcopy(additional_check_runs)
     push!(all_statuses, "automerge/decision")
@@ -24,7 +25,7 @@ function run(env = ENV,
     registry_head = directory_of_cloned_registry(cicfg; env=env)
 
     # Run tests on the registry (these are very quick)
-    RegistryCI.test(registry_head)
+    RegistryCI.test(registry_head, registry_deps)
 
     # Figure out what type of build this is
     run_pr_build = conditions_met_for_pr_build(cicfg; env=env, master_branch=master_branch)

--- a/src/AutoMerge/public.jl
+++ b/src/AutoMerge/public.jl
@@ -25,7 +25,7 @@ function run(env = ENV,
     registry_head = directory_of_cloned_registry(cicfg; env=env)
 
     # Run tests on the registry (these are very quick)
-    RegistryCI.test(registry_head, registry_deps)
+    RegistryCI.test(registry_head; registry_deps = registry_deps)
 
     # Figure out what type of build this is
     run_pr_build = conditions_met_for_pr_build(cicfg; env=env, master_branch=master_branch)

--- a/src/RegistryCI.jl
+++ b/src/RegistryCI.jl
@@ -4,5 +4,6 @@ import GitCommand
 
 include("AutoMerge/AutoMerge.jl")
 include("registry_testing.jl")
+include("utils.jl")
 
 end # module

--- a/src/registry_testing.jl
+++ b/src/registry_testing.jl
@@ -14,6 +14,11 @@ end
 # another dependency registry. For example, packages registered at the BioJuliaRegistry
 # that have General dependencies. BJW.
 function load_registry_dep_uuids(registry_deps_urls::Vector{<:AbstractString} = String[])
+    temp_depot = mktempdir() # make a temp depot
+    atexit(() -> rm(temp_depot; force = true, recursive = true))
+    original_depot_path = deepcopy(Base.DEPOT_PATH)
+    empty!(Base.DEPOT_PATH)
+    push!(Base.DEPOT_PATH, temp_depot) # use the temp depot
     # Get the registries!
     for url in registry_deps_urls
         Pkg.Registry.add(Pkg.RegistrySpec(url = url))
@@ -30,6 +35,11 @@ function load_registry_dep_uuids(registry_deps_urls::Vector{<:AbstractString} = 
             end
         end
     end
+    empty!(Base.DEPOT_PATH)
+    for x in original_depot_path
+        push!(Base.DEPOT_PATH, x) # restore the original DEPOT_PATH
+    end
+    rm(temp_depot; force = true, recursive = true)
     return extrauuids
 end
 

--- a/src/registry_testing.jl
+++ b/src/registry_testing.jl
@@ -16,7 +16,7 @@ end
 function load_registry_dep_uuids(registry_deps_urls::Vector{<:AbstractString} = String[])
     # Get the registries!
     for url in registry_deps_urls
-        Pkg.Registry.add(url)
+        Pkg.Registry.add(Pkg.RegistrySpec(url = url))
     end
     # Now use the RegistrySpec's to find the Project.toml's. I know
     # .julia/registires/XYZ/ABC is the most likely place, but this way the

--- a/src/registry_testing.jl
+++ b/src/registry_testing.jl
@@ -10,6 +10,29 @@ function gather_stdlib_uuids()
     end
 end
 
+# For when you have a registry that has packages with dependencies obtained from
+# another dependency registry. For example, packages registered at the BioJuliaRegistry
+# that have General dependencies. BJW.
+function load_registry_dep_uuids(registry_deps_urls::Vector{<:AbstractString} = String[])
+    # Get the registries!
+    for url in registry_deps_urls
+        Pkg.Registry.add(url)
+    end
+    # Now use the RegistrySpec's to find the Project.toml's. I know
+    # .julia/registires/XYZ/ABC is the most likely place, but this way the
+    # function never has to assume. BJW.
+    extrauuids = Set{Base.UUID}()
+    for spec in Pkg.Types.collect_registries()
+        if spec.url ∈ registry_deps_urls
+            reg = Pkg.TOML.parsefile(joinpath(spec.path, "/Registry.toml"))
+            for x in keys(reg["packages"])
+                push!(extrauuids, Base.UUID(x))
+            end
+        end
+    end
+    return extrauuids
+end
+
 #########################
 # Testing of registries #
 #########################
@@ -21,13 +44,19 @@ Run various checks on the registry located at `path`.
 Checks for example that all files are parsable and
 understandable by Pkg and consistency between Registry.toml
 and each Package.toml.
+
+If your registry has packages that have dependencies that are registered in other
+registries elsewhere, then you may provide the github urls for those registries
+using the `registry_deps` parameter.
 """
-function test(path=pwd())
+function test(path = pwd();
+              registry_deps::Vector{<:AbstractString} = String[])
     Test.@testset "(Registry|Package|Versions|Deps|Compat).toml" begin; cd(path) do
         reg = Pkg.TOML.parsefile("Registry.toml")
         reguuids = Set{Base.UUID}(Base.UUID(x) for x in keys(reg["packages"]))
         stdlibuuids = gather_stdlib_uuids()
-        alluuids = reguuids ∪ stdlibuuids
+        registry_dep_uuids = load_registry_dep_uuids(registry_deps)
+        alluuids = reguuids ∪ stdlibuuids ∪ registry_dep_uuids
 
         # Test that each entry in Registry.toml has a corresponding Package.toml
         # at the expected path with the correct uuid and name

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,0 +1,27 @@
+function with_temp_dir(f::Function)
+    original_working_directory = pwd()
+    
+    temp_dir = mktempdir()
+    atexit(() -> rm(temp_dir; force = true, recursive = true))
+    
+    cd(temp_dir)
+    result = f(temp_dir)
+    
+    cd(original_working_directory)
+    rm(temp_dir; force = true, recursive = true)
+    return result
+end
+
+function with_temp_depot(f::Function)
+    original_depot_path = deepcopy(Base.DEPOT_PATH)
+    result = with_temp_dir() do temp_depot
+        empty!(Base.DEPOT_PATH)
+        push!(Base.DEPOT_PATH, temp_depot)
+        return f()
+    end
+    empty!(Base.DEPOT_PATH)
+    for x in original_depot_path
+        push!(Base.DEPOT_PATH, x)
+    end
+    return result
+end

--- a/test/registryci_registry_testing.jl
+++ b/test/registryci_registry_testing.jl
@@ -14,7 +14,7 @@ const path = joinpath(DEPOT_PATH[1], "registries", "General")
 RegistryCI.test(path)
 
 # Test the BioJuliaRegistry
-Pkg.Registry.add("https://github.com/BioJulia/BioJuliaRegistry.git")
+Pkg.Registry.add(Pkg.RegistrySpec(url = "https://github.com/BioJulia/BioJuliaRegistry.git"))
 # Test this will validate the BioJuliaRegistry, when providing General as an
 # optional dependency. BJW.
 const biopath = joinpath(DEPOT_PATH[1], "registries", "BioJuliaRegistry")

--- a/test/registryci_registry_testing.jl
+++ b/test/registryci_registry_testing.jl
@@ -17,4 +17,5 @@ RegistryCI.test(path)
 Pkg.Registry.add("https://github.com/BioJulia/BioJuliaRegistry.git")
 # Test this will validate the BioJuliaRegistry, when providing General as an
 # optional dependency. BJW.
-RegistryCI.test(joinpath(DEPOT_PATH[1], "registries", "BioJuliaRegistry"), ["https://github.com/JuliaRegistries/General.git"])
+const biopath = joinpath(DEPOT_PATH[1], "registries", "BioJuliaRegistry")
+RegistryCI.test(biopath, ["https://github.com/JuliaRegistries/General.git"])

--- a/test/registryci_registry_testing.jl
+++ b/test/registryci_registry_testing.jl
@@ -12,3 +12,9 @@ const AutoMerge = RegistryCI.AutoMerge
 
 const path = joinpath(DEPOT_PATH[1], "registries", "General")
 RegistryCI.test(path)
+
+# Test the BioJuliaRegistry
+Pkg.Registry.add("https://github.com/BioJulia/BioJuliaRegistry.git")
+# Test this will validate the BioJuliaRegistry, when providing General as an
+# optional dependency. BJW.
+RegistryCI.test(joinpath(DEPOT_PATH[1], "registries", "BioJuliaRegistry"), "https://github.com/JuliaRegistries/General.git")

--- a/test/registryci_registry_testing.jl
+++ b/test/registryci_registry_testing.jl
@@ -14,8 +14,10 @@ const path = joinpath(DEPOT_PATH[1], "registries", "General")
 RegistryCI.test(path)
 
 # Test the BioJuliaRegistry
-Pkg.Registry.add(Pkg.RegistrySpec(url = "https://github.com/BioJulia/BioJuliaRegistry.git"))
-# Test this will validate the BioJuliaRegistry, when providing General as an
-# optional dependency. BJW.
-const biopath = joinpath(DEPOT_PATH[1], "registries", "BioJuliaRegistry")
-RegistryCI.test(biopath, ["https://github.com/JuliaRegistries/General.git"])
+with_temp_depot() do
+    Pkg.Registry.add(Pkg.RegistrySpec(url = "https://github.com/BioJulia/BioJuliaRegistry.git"))
+    # Test this will validate the BioJuliaRegistry, when providing General as an
+    # optional dependency. BJW.
+    biopath = joinpath(DEPOT_PATH[1], "registries", "BioJuliaRegistry")
+    RegistryCI.test(biopath, registry_deps = ["https://github.com/JuliaRegistries/General.git"])
+end

--- a/test/registryci_registry_testing.jl
+++ b/test/registryci_registry_testing.jl
@@ -17,4 +17,4 @@ RegistryCI.test(path)
 Pkg.Registry.add("https://github.com/BioJulia/BioJuliaRegistry.git")
 # Test this will validate the BioJuliaRegistry, when providing General as an
 # optional dependency. BJW.
-RegistryCI.test(joinpath(DEPOT_PATH[1], "registries", "BioJuliaRegistry"), "https://github.com/JuliaRegistries/General.git")
+RegistryCI.test(joinpath(DEPOT_PATH[1], "registries", "BioJuliaRegistry"), ["https://github.com/JuliaRegistries/General.git"])

--- a/test/registryci_registry_testing.jl
+++ b/test/registryci_registry_testing.jl
@@ -14,7 +14,7 @@ const path = joinpath(DEPOT_PATH[1], "registries", "General")
 RegistryCI.test(path)
 
 # Test the BioJuliaRegistry
-with_temp_depot() do
+RegistryCI.with_temp_depot() do
     Pkg.Registry.add(Pkg.RegistrySpec(url = "https://github.com/BioJulia/BioJuliaRegistry.git"))
     # Test this will validate the BioJuliaRegistry, when providing General as an
     # optional dependency. BJW.


### PR DESCRIPTION
Closes #118 

This is a redux of #118.
I've used Pkg.Registry.add as suggested by @fredrikekre, which also allowed me to use Pkg, to find and get the UUIDs from the Registry.toml files, without assuming where the registries were stored.