### PR TITLE
Drop the "can’t narrow Julia compat in a patch release" requirement for pre-1.0 packages

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryCI"
 uuid = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
 authors = ["Dilum Aluthge <dilum@aluthge.com>", "Fredrik Ekre <ekrefredrik@gmail.com>"]
-version = "0.11.8"
+version = "0.12.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/AutoMerge/guidelines.jl
+++ b/src/AutoMerge/guidelines.jl
@@ -90,7 +90,7 @@ function meets_patch_release_does_not_narrow_julia_compat(pkg::String,
     if meets_this_guideline
         return true, ""
     else
-        if (old_version >= v"1") | (new_version >= v"1")
+        if (old_version >= v"1") || (new_version >= v"1")
             msg = string("A patch release is not allowed to narrow the ",
                          "supported ranges of Julia versions. ",
                          "The ranges have changed from ",

--- a/src/AutoMerge/guidelines.jl
+++ b/src/AutoMerge/guidelines.jl
@@ -90,14 +90,19 @@ function meets_patch_release_does_not_narrow_julia_compat(pkg::String,
     if meets_this_guideline
         return true, ""
     else
-        msg = string("A patch release is not allowed to narrow the ",
-                     "supported ranges of Julia versions. ",
-                     "The ranges have changed from ",
-                     "$(julia_compats_for_old_version) ",
-                     "(in $(old_version)) ",
-                     "to $(julia_compats_for_new_version) ",
-                     "(in $(new_version)).")
-        return false, msg
+        if (old_version >= v"1") | (new_version >= v"1")
+            msg = string("A patch release is not allowed to narrow the ",
+                         "supported ranges of Julia versions. ",
+                         "The ranges have changed from ",
+                         "$(julia_compats_for_old_version) ",
+                         "(in $(old_version)) ",
+                         "to $(julia_compats_for_new_version) ",
+                         "(in $(new_version)).")
+            return false, msg
+        else
+            @info("Narrows Julia compat, but it's OK since package is pre-1.0")
+            return true, ""
+        end
     end
 end
 


### PR DESCRIPTION
Fixes #204 