### PR TITLE
AutoMerge cron job should not exit with error if Travis CI failed on a pull request

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryCI"
 uuid = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
 authors = ["Dilum Aluthge <dilum@aluthge.com>", "Fredrik Ekre <ekrefredrik@gmail.com>"]
-version = "1.0.0"
+version = "1.1.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"


### PR DESCRIPTION
Currently, if Travis CI fails on a pull request but AutoMerge passes on that pull request, then every AutoMerge cron job will exit with an error.

This is very annoying because my inbox fills up with notifications that the AutoMerge cron jobs are "failing." In reality, they are not actually failing.