### PR TITLE
Remove the dependency on GitCommand

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,11 +1,10 @@
 name = "RegistryCI"
 uuid = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
 authors = ["Dilum Aluthge <dilum@aluthge.com>", "Fredrik Ekre <ekrefredrik@gmail.com>"]
-version = "2.1.0"
+version = "2.2.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
-GitCommand = "49b5b516-ca3f-4003-a081-42bdcf55082d"
 GitHub = "bc5e4493-9b4d-5f90-b8aa-2b2bcaad7a26"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
@@ -16,7 +15,6 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 
 [compat]
-GitCommand = "1"
 GitHub = "5.1.1"
 HTTP = "0.8"
 JSON = "0.19, 0.20, 0.21"

--- a/bin/remember_to_update_registryci.jl
+++ b/bin/remember_to_update_registryci.jl
@@ -1,6 +1,6 @@
 module RememberToUpdateRegistryCI
 
-using GitCommand
+# using GitCommand
 using GitHub
 using Pkg
 

--- a/src/AutoMerge/AutoMerge.jl
+++ b/src/AutoMerge/AutoMerge.jl
@@ -1,7 +1,7 @@
 module AutoMerge
 
 import Dates
-import GitCommand
+# import GitCommand
 import GitHub
 import HTTP
 import LibGit2

--- a/src/RegistryCI.jl
+++ b/src/RegistryCI.jl
@@ -1,6 +1,6 @@
 module RegistryCI
 
-import GitCommand
+# import GitCommand
 
 include("AutoMerge/AutoMerge.jl")
 include("registry_testing.jl")

--- a/src/registry_testing.jl
+++ b/src/registry_testing.jl
@@ -1,5 +1,5 @@
 import Pkg
-import GitCommand
+# import GitCommand
 import RegistryTools
 import Test
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,5 @@
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
-GitCommand = "49b5b516-ca3f-4003-a081-42bdcf55082d"
 GitHub = "bc5e4493-9b4d-5f90-b8aa-2b2bcaad7a26"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
@@ -9,7 +8,6 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 
 [compat]
-GitCommand = "1"
 GitHub = "5.1.1"
 JSON = "0.19, 0.20, 0.21"
 TimeZones = "1"

--- a/test/automerge-integration-utils.jl
+++ b/test/automerge-integration-utils.jl
@@ -1,5 +1,5 @@
 using Dates
-using GitCommand
+# using GitCommand
 using GitHub
 using JSON
 using Pkg

--- a/test/automerge-integration.jl
+++ b/test/automerge-integration.jl
@@ -1,5 +1,5 @@
 using Dates
-using GitCommand
+# using GitCommand
 using GitHub
 using JSON
 using Pkg

--- a/test/automerge-unit.jl
+++ b/test/automerge-unit.jl
@@ -1,5 +1,5 @@
 using Dates
-using GitCommand
+# using GitCommand
 using GitHub
 using JSON
 using Pkg

--- a/test/registryci_registry_testing.jl
+++ b/test/registryci_registry_testing.jl
@@ -1,5 +1,5 @@
 using Dates
-using GitCommand
+# using GitCommand
 using GitHub
 using JSON
 using Pkg

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using Dates
-using GitCommand
+# using GitCommand
 using GitHub
 using JSON
 using Pkg


### PR DESCRIPTION
Git_jll requires a lot of artifacts.

It is getting really annoying to have to download those every time a Travis build needs to use RegistryCI.