### PR TITLE
Disable the "URL ends in /name.jl.git" check

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryCI"
 uuid = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
 authors = ["Dilum Aluthge <dilum@aluthge.com>", "Fredrik Ekre <ekrefredrik@gmail.com>"]
-version = "2.2.1"
+version = "2.3.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/AutoMerge/new-package.jl
+++ b/src/AutoMerge/new-package.jl
@@ -29,7 +29,7 @@ function pull_request_build(::NewPackage,
     #     - you can register names shorter than this, but doing so requires someone to approve
     # 5. Standard initial version number - one of 0.0.1, 0.1.0, 1.0.0
     #     - does not apply to JLL packages
-    # 6. Repo URL ends with /$name.jl.git where name is the package name
+    # 6. DISABLED. Repo URL ends with /$name.jl.git where name is the package name. Now that we have support for multiple packages in different subdirectories of a repo, we have disabled this check.
     # 7. Compat for all dependencies
     #     - there should be a [compat] entry for Julia
     #     - all [deps] should also have [compat] entries
@@ -106,8 +106,11 @@ function pull_request_build(::NewPackage,
             else
                 g5, m5 = meets_standard_initial_version_number(version)
             end
-            g6, m6 = meets_repo_url_requirement(pkg;
-                                                registry_head = registry_head)
+
+            # g6, m6 = meets_repo_url_requirement(pkg; registry_head = registry_head)
+            g6 = true
+            m6 = ""
+ 
             g7, m7 = meets_compat_for_all_deps(registry_head,
                                                pkg,
                                                version)


### PR DESCRIPTION
We used to require that the repo URL ended in `/PackageName.jl.git` for new package registrations.

But now we support having multiple registered packages inside a single Git repo.

So this repo URL check no longer makes sense,

This PR disables that check.

cc: @StefanKarpinski 