### PR TITLE
Allow new package names to end with uppercase

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryCI"
 uuid = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
 authors = ["Dilum Aluthge <dilum@aluthge.com>", "Fredrik Ekre <ekrefredrik@gmail.com>"]
-version = "2.3.0"
+version = "2.4.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Note that commenting on a pull request will automatically disable automerging on
 
 1. Normal capitalization
 
-    The package name should match `r"^[A-Z]\w*[a-z][0-9]?$"`, i.e. start with a capital letter, contain ASCII alphanumerics only, end in lowercase.
+    The package name should match `r"^[A-Z]\w*[a-z]\w*[0-9]?$"`, i.e. start with a capital letter, contain ASCII alphanumerics only, contain at 1 lowercase letter.
 
 2. Not too short
 
@@ -49,7 +49,7 @@ Note that commenting on a pull request will automatically disable automerging on
 4. Version can be loaded
 
     Once it's been installed (and built?), can we load the code?
-    
+
 ## RegistryCI.jl integration tests
 
 For instructions on how to run the RegistryCI.jl integration tests on your local machine, see [`INTEGRATION_TESTS.md`](INTEGRATION_TESTS.md).

--- a/src/AutoMerge/guidelines.jl
+++ b/src/AutoMerge/guidelines.jl
@@ -116,11 +116,11 @@ function meets_name_length(pkg)
 end
 
 function meets_normal_capitalization(pkg)
-    meets_this_guideline = occursin(r"^[A-Z]\w*[a-z][0-9]?$", pkg)
+    meets_this_guideline = occursin(r"^[A-Z]\w*[a-z]\w*[0-9]?$", pkg)
     if meets_this_guideline
         return true, ""
     else
-        return false, "Name does not meet all of the following: starts with an uppercase letter, ASCII alphanumerics only, ends in a lowercase letter. **Important note: It is okay to have a package name that ends in an uppercase letter. However, you will need to wait until a registry maintainer manually approves the name.**"
+        return false, "Name does not meet all of the following: starts with an uppercase letter, ASCII alphanumerics only, not all letters are uppercase.**"
     end
 end
 

--- a/src/AutoMerge/new-package.jl
+++ b/src/AutoMerge/new-package.jl
@@ -22,8 +22,8 @@ function pull_request_build(::NewPackage,
     #     - `E/Example/Versions.toml`
     # 2. TODO: implement this check. When implemented, this check will make sure that the changes to `Registry.toml` only modify the specified package.
     # 3. Normal capitalization
-    #     - name should match r"^[A-Z]\w*[a-z][0-9]?$"
-    #     - i.e. starts with a capital letter, ASCII alphanumerics only, ends in lowercase
+    #     - name should match r"^[A-Z]\w*[a-z]\w*[0-9]?$"
+    #     - i.e. starts with a capital letter, ASCII alphanumerics only, contains at least 1 lowercase letter
     # 4. Not too short
     #     - at least five letters
     #     - you can register names shorter than this, but doing so requires someone to approve
@@ -110,7 +110,7 @@ function pull_request_build(::NewPackage,
             # g6, m6 = meets_repo_url_requirement(pkg; registry_head = registry_head)
             g6 = true
             m6 = ""
- 
+
             g7, m7 = meets_compat_for_all_deps(registry_head,
                                                pkg,
                                                version)

--- a/test/automerge-unit.jl
+++ b/test/automerge-unit.jl
@@ -20,8 +20,8 @@ const AutoMerge = RegistryCI.AutoMerge
         @test AutoMerge.meets_normal_capitalization("ForwardDiff2")[1]
         @test !AutoMerge.meets_normal_capitalization("JSON2")[1]
         @test !AutoMerge.meets_normal_capitalization("JSON2")[1]
-        @test AutoMerge.meets_normal_capitalization("LightXML")[1]
-        @test AutoMerge.meets_normal_capitalization("LightXML")[1]
+        @test AutoMerge.meets_normal_capitalization("RegistryCI")[1]
+        @test AutoMerge.meets_normal_capitalization("RegistryCI")[1]
     end
     @testset "Not too short - at least five letters" begin
         @test AutoMerge.meets_name_length("Zygote")[1]

--- a/test/automerge-unit.jl
+++ b/test/automerge-unit.jl
@@ -16,6 +16,12 @@ const AutoMerge = RegistryCI.AutoMerge
         @test AutoMerge.meets_normal_capitalization("Zygote")[1]
         @test !AutoMerge.meets_normal_capitalization("HTTP")[1]
         @test !AutoMerge.meets_normal_capitalization("HTTP")[1]
+        @test AutoMerge.meets_normal_capitalization("ForwardDiff2")[1]
+        @test AutoMerge.meets_normal_capitalization("ForwardDiff2")[1]
+        @test !AutoMerge.meets_normal_capitalization("JSON2")[1]
+        @test !AutoMerge.meets_normal_capitalization("JSON2")[1]
+        @test AutoMerge.meets_normal_capitalization("LightXML")[1]
+        @test AutoMerge.meets_normal_capitalization("LightXML")[1]
     end
     @testset "Not too short - at least five letters" begin
         @test AutoMerge.meets_name_length("Zygote")[1]

--- a/test/automerge-unit.jl
+++ b/test/automerge-unit.jl
@@ -12,15 +12,15 @@ const AutoMerge = RegistryCI.AutoMerge
 
 @testset "Guidelines for new packages" begin
     @testset "Normal capitalization" begin
+        @test AutoMerge.meets_normal_capitalization("Zygote")[1]  # Regular name
         @test AutoMerge.meets_normal_capitalization("Zygote")[1]
-        @test AutoMerge.meets_normal_capitalization("Zygote")[1]
+        @test !AutoMerge.meets_normal_capitalization("HTTP")[1]  # All uppercase
         @test !AutoMerge.meets_normal_capitalization("HTTP")[1]
-        @test !AutoMerge.meets_normal_capitalization("HTTP")[1]
+        @test AutoMerge.meets_normal_capitalization("ForwardDiff2")[1]  # Ends with a number
         @test AutoMerge.meets_normal_capitalization("ForwardDiff2")[1]
-        @test AutoMerge.meets_normal_capitalization("ForwardDiff2")[1]
+        @test !AutoMerge.meets_normal_capitalization("JSON2")[1]  # All uppercase and ends with number
         @test !AutoMerge.meets_normal_capitalization("JSON2")[1]
-        @test !AutoMerge.meets_normal_capitalization("JSON2")[1]
-        @test AutoMerge.meets_normal_capitalization("RegistryCI")[1]
+        @test AutoMerge.meets_normal_capitalization("RegistryCI")[1]  # Ends with uppercase
         @test AutoMerge.meets_normal_capitalization("RegistryCI")[1]
     end
     @testset "Not too short - at least five letters" begin


### PR DESCRIPTION
This follows up to #200

Rather than just making it print a message that "Its OK to end with uppercase"
this just changes it to allow it.
I don't get what the motivation of #200 was, TBH.

The requirement to not end in uppercase is not listed in the summary in 
https://github.com/JuliaRegistries/General/blob/master/README.md#automatic-merging-of-pull-requests
which says
> Package name: Should start with a capital letter, contain only ASCII alphanumeric characters, and be at least 5 characters long.