### PR TITLE
Improving usability for private registry, outside of github.com

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryCI"
 uuid = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
 authors = ["Dilum Aluthge <dilum@aluthge.com>", "Fredrik Ekre <ekrefredrik@gmail.com>"]
-version = "2.4.0"
+version = "2.5.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
@@ -15,7 +15,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 
 [compat]
-GitHub = "5.1.1"
+GitHub = "5.1.6"
 HTTP = "0.8"
 JSON = "0.19, 0.20, 0.21"
 RegistryTools = "1.2"

--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ Note that commenting on a pull request will automatically disable automerging on
 
 For instructions on how to run the RegistryCI.jl integration tests on your local machine, see [`INTEGRATION_TESTS.md`](INTEGRATION_TESTS.md).
 
+## TeamCity support
+
+There is support also for TeamCity, but it does not work out-of the box, it requires Pull Request build feature to be added, and passing few build variables as environment variables.
+
+To make it work in TeamCity, see [this Kotlin DSL snippet](teamcity_settings.kts) and put following parts into your DSL/add them in GUI.
+
 ## Acknowledgements
 
 Dilum Aluthge would like to acknowledge the following:

--- a/src/AutoMerge/automerge_comment.jl
+++ b/src/AutoMerge/automerge_comment.jl
@@ -1,9 +1,11 @@
-function update_automerge_comment!(repo::GitHub.Repo,
+function update_automerge_comment!(api::GitHub.GitHubAPI,
+                                   repo::GitHub.Repo,
                                    pr::GitHub.PullRequest;
                                    body::AbstractString,
                                    auth::GitHub.Authorization,
                                    whoami)::Nothing
-    my_comments = my_retry(() -> get_all_my_pull_request_comments(repo,
+    my_comments = my_retry(() -> get_all_my_pull_request_comments(api,
+                                                                  repo,
                                                                   pr;
                                                                   auth = auth,
                                                                   whoami = whoami))
@@ -18,7 +20,7 @@ function update_automerge_comment!(repo::GitHub.Repo,
         for i = 2:num_comments
             comment_to_delete = my_comments[i]
             try
-                my_retry(() -> delete_comment!(repo,
+                my_retry(() -> delete_comment!(api, repo,
                                                pr,
                                                comment_to_delete;
                                                auth = auth))
@@ -28,7 +30,7 @@ function update_automerge_comment!(repo::GitHub.Repo,
         end
         comment_to_update = my_comments[1]
         if strip(comment_to_update.body) != strip(_body)
-            my_retry(() -> edit_comment!(repo,
+            my_retry(() -> edit_comment!(api, repo,
                                          pr,
                                          comment_to_update,
                                          _body;
@@ -37,7 +39,7 @@ function update_automerge_comment!(repo::GitHub.Repo,
     elseif num_comments == 1
         comment_to_update = my_comments[1]
         if strip(comment_to_update.body) != strip(_body)
-            my_retry(() -> edit_comment!(repo,
+            my_retry(() -> edit_comment!(api, repo,
                                          pr,
                                          comment_to_update,
                                          _body;
@@ -45,7 +47,7 @@ function update_automerge_comment!(repo::GitHub.Repo,
         end
     else
         always_assert(num_comments < 1)
-        my_retry(() -> post_comment!(repo,
+        my_retry(() -> post_comment!(api, repo,
                                      pr,
                                      _body;
                                      auth = auth))

--- a/src/AutoMerge/changed_files.jl
+++ b/src/AutoMerge/changed_files.jl
@@ -16,7 +16,8 @@ function allowed_changed_files(::NewVersion, pkg::String)
     return result
 end
 
-function pr_only_changes_allowed_files(t::Union{NewPackage, NewVersion},
+function pr_only_changes_allowed_files(api::GitHub.GitHubAPI,
+                                       t::Union{NewPackage, NewVersion},
                                        registry::GitHub.Repo,
                                        pr::GitHub.PullRequest,
                                        pkg::String;
@@ -29,7 +30,7 @@ function pr_only_changes_allowed_files(t::Union{NewPackage, NewVersion},
         m0 = "This PR is allowed to modify at most $(_num_allowed_changed_files) files, but it actually modified $(this_pr_num_changed_files) files."
         return g0, m0
     else
-        this_pr_changed_files = get_changed_filenames(registry, pr; auth = auth)
+        this_pr_changed_files = get_changed_filenames(api, registry, pr; auth = auth)
         if length(this_pr_changed_files) != this_pr_num_changed_files
             g0 = false
             m0 = "Something weird happened when I tried to get the list of changed files"

--- a/src/AutoMerge/guidelines.jl
+++ b/src/AutoMerge/guidelines.jl
@@ -226,7 +226,7 @@ function meets_version_can_be_pkg_added(working_directory::String,
     code = """
         import Pkg;
         Pkg.pkg"add HTTP";
-        using HTTP;
+        import HTTP;
         is_valid_url(str::AbstractString) = !isempty(HTTP.URI(str).scheme) && isvalid(HTTP.URI(str));
         Pkg.Registry.add(Pkg.RegistrySpec(path=\"$(working_directory)\"));
         _registry_deps = $(_registry_deps);
@@ -273,7 +273,7 @@ function meets_version_can_be_imported(working_directory::String,
     code = """
         import Pkg;
         Pkg.pkg"add HTTP";
-        using HTTP;
+        import HTTP;
         is_valid_url(str::AbstractString) = !isempty(HTTP.URI(str).scheme) && isvalid(HTTP.URI(str));
         Pkg.Registry.add(Pkg.RegistrySpec(path=\"$(working_directory)\"));
         _registry_deps = $(_registry_deps);

--- a/src/AutoMerge/new-package.jl
+++ b/src/AutoMerge/new-package.jl
@@ -1,4 +1,5 @@
-function pull_request_build(::NewPackage,
+function pull_request_build(api::GitHub.GitHubAPI,
+                            ::NewPackage,
                             pr::GitHub.PullRequest,
                             current_pr_head_commit_sha::String,
                             registry::GitHub.Repo;
@@ -56,7 +57,8 @@ function pull_request_build(::NewPackage,
             params = Dict("state" => "pending",
                           "context" => "automerge/decision",
                           "description" => description)
-            my_retry(() -> GitHub.create_status(registry,
+            my_retry(() -> GitHub.create_status(api,
+                                                registry,
                                                 current_pr_head_commit_sha;
                                                 auth = auth,
                                                 params = params))
@@ -84,7 +86,8 @@ function pull_request_build(::NewPackage,
                 end
             end
 
-            g1, m1 = pr_only_changes_allowed_files(NewPackage(),
+            g1, m1 = pr_only_changes_allowed_files(api,
+                                                   NewPackage(),
                                                    registry,
                                                    pr,
                                                    pkg;
@@ -166,7 +169,8 @@ function pull_request_build(::NewPackage,
                 params = Dict("state" => "failure",
                               "context" => "automerge/decision",
                               "description" => description)
-                my_retry(() -> GitHub.create_status(registry,
+                my_retry(() -> GitHub.create_status(api,
+                                                    registry,
                                                     current_pr_head_commit_sha;
                                                     auth = auth,
                                                     params = params))
@@ -212,14 +216,16 @@ function pull_request_build(::NewPackage,
                 params = Dict("state" => "success",
                               "context" => "automerge/decision",
                               "description" => description)
-                my_retry(() -> GitHub.create_status(registry,
+                my_retry(() -> GitHub.create_status(api,
+                                                    registry,
                                                     current_pr_head_commit_sha;
                                                     auth = auth,
                                                     params = params))
                 this_pr_comment_pass = comment_text_pass(NewPackage(),
                                                          suggest_onepointzero,
                                                          version)
-                my_retry(() -> update_automerge_comment!(registry,
+                my_retry(() -> update_automerge_comment!(api,
+                                                         registry,
                                                          pr;
                                                          auth = auth,
                                                          body = this_pr_comment_pass,
@@ -230,7 +236,8 @@ function pull_request_build(::NewPackage,
                 params = Dict("state" => "failure",
                               "context" => "automerge/decision",
                               "description" => description)
-                my_retry(() -> GitHub.create_status(registry,
+                my_retry(() -> GitHub.create_status(api,
+                                                    registry,
                                                     current_pr_head_commit_sha;
                                                     auth = auth,
                                                     params = params))
@@ -239,7 +246,8 @@ function pull_request_build(::NewPackage,
                                                          failingmessages0through10,
                                                          suggest_onepointzero,
                                                          version)
-                my_retry(() -> update_automerge_comment!(registry,
+                my_retry(() -> update_automerge_comment!(api,
+                                                         registry,
                                                          pr;
                                                          body = this_pr_comment_fail,
                                                          auth = auth,

--- a/src/AutoMerge/new-version.jl
+++ b/src/AutoMerge/new-version.jl
@@ -1,4 +1,5 @@
-function pull_request_build(::NewVersion,
+function pull_request_build(api::GitHub.GitHubAPI,
+                            ::NewVersion,
                             pr::GitHub.PullRequest,
                             current_pr_head_commit_sha::String,
                             registry::GitHub.Repo;
@@ -48,7 +49,7 @@ function pull_request_build(::NewVersion,
             params = Dict("state" => "pending",
                           "context" => "automerge/decision",
                           "description" => description)
-            my_retry(() -> GitHub.create_status(registry,
+            my_retry(() -> GitHub.create_status(api, registry,
                                                 current_pr_head_commit_sha;
                                                 auth = auth,
                                                 params=params))
@@ -76,7 +77,8 @@ function pull_request_build(::NewVersion,
                 end
             end
 
-            g1, m1 = pr_only_changes_allowed_files(NewVersion(),
+            g1, m1 = pr_only_changes_allowed_files(api,
+                                                   NewVersion(),
                                                    registry,
                                                    pr,
                                                    pkg;
@@ -145,7 +147,7 @@ function pull_request_build(::NewVersion,
                 params = Dict("state" => "failure",
                               "context" => "automerge/decision",
                               "description" => description)
-                my_retry(() -> GitHub.create_status(registry,
+                my_retry(() -> GitHub.create_status(api, registry,
                                                     current_pr_head_commit_sha;
                                                     auth = auth,
                                                     params = params))
@@ -185,14 +187,16 @@ function pull_request_build(::NewVersion,
                 params = Dict("state" => "success",
                               "context" => "automerge/decision",
                               "description" => description)
-                my_retry(() -> GitHub.create_status(registry,
+                my_retry(() -> GitHub.create_status(api,
+                                                    registry,
                                                     current_pr_head_commit_sha;
                                                     auth = auth,
                                                     params = params))
                 this_pr_comment_pass = comment_text_pass(NewVersion(),
                                                          suggest_onepointzero,
                                                          version)
-                my_retry(() -> update_automerge_comment!(registry,
+                my_retry(() -> update_automerge_comment!(api,
+                                                         registry,
                                                          pr;
                                                          auth = auth,
                                                          body = this_pr_comment_pass,
@@ -203,7 +207,7 @@ function pull_request_build(::NewVersion,
                 params = Dict("state" => "failure",
                               "context" => "automerge/decision",
                               "description" => description)
-                my_retry(() -> GitHub.create_status(registry,
+                my_retry(() -> GitHub.create_status(api, registry,
                                                     current_pr_head_commit_sha;
                                                     auth=auth,
                                                     params=params))
@@ -212,7 +216,8 @@ function pull_request_build(::NewVersion,
                                                          failingmessages0through7,
                                                          suggest_onepointzero,
                                                          version)
-                my_retry(() -> update_automerge_comment!(registry,
+                my_retry(() -> update_automerge_comment!(api,
+                                                         registry,
                                                          pr;
                                                          body = this_pr_comment_fail,
                                                          auth = auth,

--- a/src/registry_testing.jl
+++ b/src/registry_testing.jl
@@ -95,11 +95,6 @@ function test(path = pwd();
                 # Require all deps to exist in the General registry or be a stdlib
                 depuuids = Set{Base.UUID}(Base.UUID(x) for (_, d) in deps for (_, x) in d)
                 Test.@test depuuids ⊆ alluuids
-                # Test that the way Pkg loads this data works
-                T1 = Dict{VersionNumber,Dict{String,Any}}
-                T2 = Dict{VersionNumber,Dict{String,Base.UUID}}
-                T = Union{T1, T2}
-                Test.@test Pkg.Operations.load_package_data(Base.UUID, depsfile, VersionNumber.(collect(keys(vers)))) isa T
             end
 
             # Compat.toml testing
@@ -113,11 +108,6 @@ function test(path = pwd();
                     push!(depnames, "julia") # All packages has an implicit dependency on julia
                     @assert compatnames ⊆ depnames
                 end
-                # Test that the way Pkg loads this data works
-                T1 = Dict{VersionNumber,Dict{String,Any}}
-                T2 = Dict{VersionNumber,Dict{String,Base.UUID}}
-                T = Union{T1, T2}
-                Test.@test Pkg.Operations.load_package_data(parse_compat_entry, compatfile, VersionNumber.(collect(keys(vers)))) isa T
             end
         end
     end end

--- a/src/registry_testing.jl
+++ b/src/registry_testing.jl
@@ -1,6 +1,6 @@
 import Pkg
 # import GitCommand
-using HTTP
+import HTTP
 import RegistryTools
 import Test
 

--- a/teamcity_settings.kts
+++ b/teamcity_settings.kts
@@ -1,0 +1,25 @@
+package _Self.buildTypes
+
+import jetbrains.buildServer.configs.kotlin.v2019_2.*
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.PullRequests
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.pullRequests
+
+object Test : BuildType({
+    // following parts are only stubs, to make them work, incorporate them into your CI settings
+    params {
+        param("env.vcsroot_branch", "%vcsroot.branch%")
+        param("env.teamcity_pullRequest_title", "%teamcity.pullRequest.title%")
+        param("env.teamcity_pullRequest_source_branch", "%teamcity.pullRequest.source.branch%")
+        param("env.teamcity_pullRequest_number", "%teamcity.pullRequest.number%")
+        param("teamcity.git.fetchAllHeads", "true")
+    }
+
+    features {
+        pullRequests {
+            provider = github {
+                filterAuthorRole = PullRequests.GitHubRoleFilter.EVERYBODY
+            }
+        }
+    }
+
+})

--- a/test/automerge-integration-utils.jl
+++ b/test/automerge-integration-utils.jl
@@ -12,23 +12,24 @@ const AutoMerge = RegistryCI.AutoMerge
 
 const timestamp_regex = r"integration\/(\d\d\d\d-\d\d-\d\d-\d\d-\d\d-\d\d-\d\d\d)\/"
 
-function wait_pr_compute_mergeability(repo::GitHub.Repo, pr::GitHub.PullRequest; auth::GitHub.Authorization)
+function wait_pr_compute_mergeability(api::GitHub.GitHubAPI, repo::GitHub.Repo, pr::GitHub.PullRequest; auth::GitHub.Authorization)
     while !(pr.mergeable isa Bool)
         sleep(5)
-        pr = GitHub.pull_request(repo, pr.number; auth = auth)
+        pr = GitHub.pull_request(api, repo, pr.number; auth = auth)
     end
     return pr
 end
 
-function close_all_pull_requests(repo::GitHub.Repo;
+function close_all_pull_requests(api::GitHub.GitHubAPI,
+                                 repo::GitHub.Repo;
                                  auth::GitHub.Authorization,
                                  state::String)
-    all_pull_requests = AutoMerge.get_all_pull_requests(repo,
+    all_pull_requests = AutoMerge.get_all_pull_requests(api, repo,
                                                         state;
                                                         auth = auth)
     for pr in all_pull_requests
         try
-            GitHub.close_pull_request(repo, pr; auth = auth)
+            GitHub.close_pull_request(api, repo, pr; auth = auth)
         catch
         end
     end

--- a/test/automerge-integration.jl
+++ b/test/automerge-integration.jl
@@ -16,14 +16,14 @@ AUTOMERGE_INTEGRATION_TEST_REPO = ENV["AUTOMERGE_INTEGRATION_TEST_REPO"]::String
 TEST_USER_GITHUB_TOKEN = ENV["BCBI_TEST_USER_GITHUB_TOKEN"]::String
 GIT = "git"
 auth = GitHub.authenticate(TEST_USER_GITHUB_TOKEN)
-whoami = RegistryCI.AutoMerge.username(auth)
+whoami = RegistryCI.AutoMerge.username(GitHub.DEFAULT_API, auth)
 repo_url_without_auth = "https://github.com/$(AUTOMERGE_INTEGRATION_TEST_REPO)"
 repo_url_with_auth = "https://$(whoami):$(TEST_USER_GITHUB_TOKEN)@github.com/$(AUTOMERGE_INTEGRATION_TEST_REPO)"
 repo = GitHub.repo(AUTOMERGE_INTEGRATION_TEST_REPO; auth = auth)
 @test success(`$(GIT) --version`)
 @info("Authenticated to GitHub as \"$(whoami)\"")
 
-close_all_pull_requests(repo; auth = auth, state = "open")
+close_all_pull_requests(GitHub.DEFAULT_API, repo; auth = auth, state = "open")
 delete_stale_branches(repo_url_with_auth; GIT = GIT)
 
 @testset "Integration tests" begin
@@ -45,7 +45,7 @@ delete_stale_branches(repo_url_with_auth; GIT = GIT)
                               "head" => head,
                               "base" => base)
                 pr = GitHub.create_pull_request(repo; auth = auth, params = params)
-                pr = wait_pr_compute_mergeability(repo, pr; auth = auth)
+                pr = wait_pr_compute_mergeability(GitHub.DEFAULT_API, repo, pr; auth = auth)
                 @test pr.mergeable
                 with_pr_merge_commit(pr, repo_url_without_auth; GIT = GIT) do build_dir
                     withenv("AUTOMERGE_GITHUB_TOKEN" => TEST_USER_GITHUB_TOKEN,

--- a/test/registryci_registry_testing.jl
+++ b/test/registryci_registry_testing.jl
@@ -12,12 +12,3 @@ const AutoMerge = RegistryCI.AutoMerge
 
 const path = joinpath(DEPOT_PATH[1], "registries", "General")
 RegistryCI.test(path)
-
-# Test the BioJuliaRegistry
-RegistryCI.with_temp_depot() do
-    Pkg.Registry.add(Pkg.RegistrySpec(url = "https://github.com/BioJulia/BioJuliaRegistry.git"))
-    # Test this will validate the BioJuliaRegistry, when providing General as an
-    # optional dependency. BJW.
-    biopath = joinpath(DEPOT_PATH[1], "registries", "BioJuliaRegistry")
-    RegistryCI.test(biopath, registry_deps = ["https://github.com/JuliaRegistries/General.git"])
-end

--- a/test/templates/feature_1/R/Requires/Versions.toml
+++ b/test/templates/feature_1/R/Requires/Versions.toml
@@ -1,2 +1,2 @@
 ["1.0.0"]
-git-tree-sha1 = "f6fbf4ba64d295e146e49e021207993b6b48c7d1"
+git-tree-sha1 = "999513b7dea8ac17359ed50ae8ea089e4464e35e"

--- a/test/templates/feature_2/R/Requires/Versions.toml
+++ b/test/templates/feature_2/R/Requires/Versions.toml
@@ -1,5 +1,5 @@
 ["1.0.0"]
-git-tree-sha1 = "f6fbf4ba64d295e146e49e021207993b6b48c7d1"
+git-tree-sha1 = "999513b7dea8ac17359ed50ae8ea089e4464e35e"
 
 ["2.0.0"]
-git-tree-sha1 = "f6fbf4ba64d295e146e49e021207993b6b48c7d1"
+git-tree-sha1 = "999513b7dea8ac17359ed50ae8ea089e4464e35e"

--- a/test/templates/feature_3/R/Req/Versions.toml
+++ b/test/templates/feature_3/R/Req/Versions.toml
@@ -1,2 +1,2 @@
 ["1.0.0"]
-git-tree-sha1 = "f6fbf4ba64d295e146e49e021207993b6b48c7d1"
+git-tree-sha1 = "999513b7dea8ac17359ed50ae8ea089e4464e35e"

--- a/test/templates/feature_4/R/Requires/Versions.toml
+++ b/test/templates/feature_4/R/Requires/Versions.toml
@@ -1,5 +1,5 @@
 ["1.0.0"]
-git-tree-sha1 = "f6fbf4ba64d295e146e49e021207993b6b48c7d1"
+git-tree-sha1 = "999513b7dea8ac17359ed50ae8ea089e4464e35e"
 
 ["2.0.1"]
-git-tree-sha1 = "f6fbf4ba64d295e146e49e021207993b6b48c7d1"
+git-tree-sha1 = "999513b7dea8ac17359ed50ae8ea089e4464e35e"

--- a/test/templates/feature_5/R/Requires/Versions.toml
+++ b/test/templates/feature_5/R/Requires/Versions.toml
@@ -1,5 +1,5 @@
 ["1.0.0"]
-git-tree-sha1 = "f6fbf4ba64d295e146e49e021207993b6b48c7d1"
+git-tree-sha1 = "999513b7dea8ac17359ed50ae8ea089e4464e35e"
 
 ["2.0.0"]
-git-tree-sha1 = "f6fbf4ba64d295e146e49e021207993b6b48c7d1"
+git-tree-sha1 = "999513b7dea8ac17359ed50ae8ea089e4464e35e"

--- a/test/templates/master_2/R/Requires/Versions.toml
+++ b/test/templates/master_2/R/Requires/Versions.toml
@@ -1,2 +1,2 @@
 ["1.0.0"]
-git-tree-sha1 = "f6fbf4ba64d295e146e49e021207993b6b48c7d1"
+git-tree-sha1 = "999513b7dea8ac17359ed50ae8ea089e4464e35e"

--- a/test/templates/master_3/R/Requires/Versions.toml
+++ b/test/templates/master_3/R/Requires/Versions.toml
@@ -1,2 +1,2 @@
 ["1.0.0"]
-git-tree-sha1 = "f6fbf4ba64d295e146e49e021207993b6b48c7d1"
+git-tree-sha1 = "999513b7dea8ac17359ed50ae8ea089e4464e35e"


### PR DESCRIPTION
Fixes #247 
Fixes #248 
Fixes #249 

I'll keep it as drawn until https://github.com/JuliaWeb/GitHub.jl/pull/163 is merged because it is required for this to work properly.
Any feedback welcome. I hope this will make private registry more accessible by enabling such great tooling as is RegistryCI to support passing dependency registry by name without need for full URL, and allowing to parametrize the base API URI.

Later, I plan to add also support for TeamCity.