### PR TITLE
Make temp dirs writable before deleting them

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryCI"
 uuid = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
 authors = ["Dilum Aluthge <dilum@aluthge.com>", "Fredrik Ekre <ekrefredrik@gmail.com>"]
-version = "2.5.0"
+version = "2.5.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/AutoMerge/guidelines.jl
+++ b/src/AutoMerge/guidelines.jl
@@ -345,7 +345,9 @@ function _run_pkg_commands(working_directory::String,
     @info(before_message)
     cmd_ran_successfully = success(pipeline(cmd, stdout=stdout, stderr=stderr))
     cd(original_directory)
+    chmod(tmp_dir_1, 0o700, recursive=true)
     rm(tmp_dir_1; force = true, recursive = true)
+    chmod(tmp_dir_2, 0o700, recursive=true)
     rm(tmp_dir_2; force = true, recursive = true)
     if cmd_ran_successfully
         @info(success_message)


### PR DESCRIPTION
A few automerge jobs are failing with this error:
```
IOError: unlink: permission denied (EACCES)
Stacktrace:
 [1] uv_error at ./libuv.jl:97 [inlined]
 [2] unlink(::String) at ./file.jl:888
 [3] rm(::String; force::Bool, recursive::Bool) at ./file.jl:268
 [4] rm(::String; force::Bool, recursive::Bool) at ./file.jl:278 (repeats 5 times)
 [5] (::RegistryCI.AutoMerge.var"#76#78"{String})() at /home/runner/.julia/packages/RegistryCI/1gUch/src/AutoMerge/guidelines.jl:317
 [6] _atexit() at ./initdefs.jl:316
 [7] exit at ./initdefs.jl:28 [inlined]
 [8] _start() at ./client.jl:487
┌ Warning: temp cleanup
│   exception =
│    IOError: unlink: permission denied (EACCES)
│    Stacktrace:
│     [1] uv_error at ./libuv.jl:97 [inlined]
│     [2] unlink(::String) at ./file.jl:888
│     [3] rm(::String; force::Bool, recursive::Bool) at ./file.jl:268
│     [4] rm(::String; force::Bool, recursive::Bool) at ./file.jl:278 (repeats 5 times)
│     [5] temp_cleanup_purge(::Bool) at ./file.jl:487
│     [6] temp_cleanup_purge() at ./file.jl:481
│     [7] _atexit() at ./initdefs.jl:316
│     [8] exit at ./initdefs.jl:28 [inlined]
│     [9] _start() at ./client.jl:487
└ @ Base.Filesystem file.jl:491
```
This is chocking on these lines: https://github.com/JuliaRegistries/RegistryCI.jl/blob/729889777565fb0275110034ee933bd509b8962e/src/AutoMerge/guidelines.jl#L348-L349  I couldn't reproduce this error locally -- hence, I don't have a test I can offer -- but I'm proposing the same change as https://github.com/JuliaPackaging/PkgServer.jl/pull/35, which looks like was addressing a similar issue.