### PR TITLE
Reenable and fix tests that check Pkg can read the entries

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryCI"
 uuid = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
 authors = ["Dilum Aluthge <dilum@aluthge.com>", "Fredrik Ekre <ekrefredrik@gmail.com>"]
-version = "2.7.1"
+version = "2.7.2"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"


### PR DESCRIPTION
Reenable and fix tests that check Pkg can read and understand compat and deps entries in the registry.

This thus also reverts commit 9c6f8fc2ce7393695c9040cb0ec10bd1adc1ba5f.