### PR TITLE
Give each tested package in a registry a named testset

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryCI"
 uuid = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
 authors = ["Dilum Aluthge <dilum@aluthge.com>", "Fredrik Ekre <ekrefredrik@gmail.com>"]
-version = "2.8.0"
+version = "2.9.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/registry_testing.jl
+++ b/src/registry_testing.jl
@@ -85,7 +85,7 @@ function test(path = pwd();
 
         # Test that each entry in Registry.toml has a corresponding Package.toml
         # at the expected path with the correct uuid and name
-        for (uuid, data) in reg["packages"]
+        Test.@testset "$(get(data, "name", uuid))" for (uuid, data) in reg["packages"]
             # Package.toml testing
             pkg = Pkg.TOML.parsefile(abspath(data["path"], "Package.toml"))
             Test.@test Base.UUID(uuid) == Base.UUID(pkg["uuid"])


### PR DESCRIPTION
When tests failed here I was not able to tell from the CI logs which packages were failing. Now this is possible!