### PR TITLE
Do not automerge packages that have `[compat]` entries of the form `PkgA = "0"`, etc.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryCI"
 uuid = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
 authors = ["Dilum Aluthge <dilum@aluthge.com>", "Fredrik Ekre <ekrefredrik@gmail.com>"]
-version = "2.9.0"
+version = "3.0.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/AutoMerge/guidelines.jl
+++ b/src/AutoMerge/guidelines.jl
@@ -73,7 +73,11 @@ function meets_compat_for_all_deps(working_directory::AbstractString, pkg, versi
                          "then a compat entry `foo = x.y.z` implies a compatibility upper bound ",
                          "for packages following semver. You can additionally include earlier versions ",
                          "your package is compatible with. ",
-                         "See https://julialang.github.io/Pkg.jl/v1/compatibility/ for details.")
+                         "See https://julialang.github.io/Pkg.jl/v1/compatibility/ for details. ",
+                         "Please note: in order to satisfy this guideline, each compat entry ",
+                         "must only include a finite number of breaking releases. ",
+                         "Compat entries of the form `PkgA = \"0\"` include an infinite number of ",
+                         "breaking releases and therefore do not meet this guideline.")
         return false, message
     end
 end

--- a/src/AutoMerge/semver.jl
+++ b/src/AutoMerge/semver.jl
@@ -97,7 +97,13 @@ function julia_compat(pkg::String, version::VersionNumber, registry_path::String
 end
 
 function _has_upper_bound(r::Pkg.Types.VersionRange)
-    return r.upper != Pkg.Types.VersionBound("*")
+    a = r.upper != Pkg.Types.VersionBound("*")
+    b = r.upper != Pkg.Types.VersionBound("0")
+    c = !(Base.VersionNumber(0, typemax(Base.VInt), typemax(Base.VInt)) in r)
+    d = !(Base.VersionNumber(typemax(Base.VInt), typemax(Base.VInt), typemax(Base.VInt)) in r)
+    e = !(typemax(Base.VersionNumber) in r)
+    result = a && b && c && d && e
+    return result
 end
 
 function range_did_not_narrow(r1::Pkg.Types.VersionRange, r2::Pkg.Types.VersionRange)

--- a/test/automerge-unit.jl
+++ b/test/automerge-unit.jl
@@ -184,6 +184,16 @@ end
         @test AutoMerge.difference(v"1", v"2") == v"1"
         @test_throws ArgumentError AutoMerge.difference(v"1", v"1")
         @test_throws ArgumentError AutoMerge.difference(v"2", v"1")
+        @test !AutoMerge._has_upper_bound(Pkg.Types.VersionRange("0"))
+        @test AutoMerge._has_upper_bound(Pkg.Types.VersionRange("1"))
+        @test !AutoMerge._has_upper_bound(Pkg.Types.VersionRange("*"))
+        @test !AutoMerge._has_upper_bound(Pkg.Types.VersionRange("0-1"))
+        @test AutoMerge._has_upper_bound(Pkg.Types.VersionRange("1-2"))
+        @test !AutoMerge._has_upper_bound(Pkg.Types.VersionRange("1-*"))
+        @test !AutoMerge._has_upper_bound(Pkg.Types.VersionRange("0-0"))
+        @test !AutoMerge._has_upper_bound(Pkg.Types.VersionRange("0-*"))
+        @test !AutoMerge._has_upper_bound(Pkg.Types.VersionRange("0.2-0"))
+        @test !AutoMerge._has_upper_bound(Pkg.Types.VersionRange("0.2-*"))
     end
 end
 


### PR DESCRIPTION
I have realized that some people have `[compat]` entries of the form:
```toml
[compat]
PkgA = "0"
```

This `[compat]` entry includes an infinite number of breaking releases, which defeats the purpose of having upper-bounded `[compat]` entries.

**The good news**: [RetroCap.jl](https://github.com/bcbi/RetroCap.jl) already recognizes that these `[compat]` entries are not true upper-bounded `[compat]` entries. Therefore, when we did the recent retrocapping in https://github.com/JuliaRegistries/General/pull/11114, RetroCap.jl fixed these `[compat]` entries, replacing entries like this:
```toml
[compat]
PkgA = "0"
```

With something like this:
```toml
[compat]
PkgA = "0.0.0 - 0.3.7"
```

Where `0.3.7` would be the latest registered version of `PkgA`.

**The bad news**: AutoMerge currently considers `PkgA = "0"` to be an upper-bounded `[compat]` entry. Therefore, AutoMerge is currently merging packages that have these `[compat]` entries, which is thus actively undoing the work we did in https://github.com/JuliaRegistries/General/pull/11114.

This pull request patches AutoMerge so that it no longer considers `PkgA = "0"` to be an upper-bounded `[compat]` entry.
