### PR TITLE
Allow Artifacts and JLLWrappers as deps of JLLs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryCI"
 uuid = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
 authors = ["Dilum Aluthge <dilum@aluthge.com>", "Fredrik Ekre <ekrefredrik@gmail.com>"]
-version = "3.0.0"
+version = "3.0.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/AutoMerge/jll.jl
+++ b/src/AutoMerge/jll.jl
@@ -21,16 +21,18 @@ end
 function meets_allowed_jll_nonrecursive_dependencies(working_directory::AbstractString,
                                                      pkg,
                                                      version)
-    # If you are a JLL package, you are only allowed to have three kinds of dependencies:
+    # If you are a JLL package, you are only allowed to have five kinds of dependencies:
     # 1. Pkg
     # 2. Libdl
-    # 3. other JLL packages
+    # 3. Artifacts
+    # 4. JLLWrappers
+    # 5. other JLL packages
     all_dependencies = _get_all_dependencies_nonrecursive(working_directory,
                                                           pkg,
                                                           version)
     for dep in all_dependencies
-        if !((dep == "Pkg") | (dep == "Libdl") | (is_jll_name(dep)))
-            return false, "JLL packages are only allowed to depend on Pkg, Libdl, and other JLL packages"
+        if !((dep == "Pkg") | (dep == "Libdl") | (dep == "Artifacts") | (dep == "JLLWrappers") | (is_jll_name(dep)))
+            return false, "JLL packages are only allowed to depend on Pkg, Libdl, Artifacts, JLLWrappers and other JLL packages"
         end
     end
     return true, ""


### PR DESCRIPTION
New jll packages are going to have two additional dependencies: `Artifacts` (a new stdlib in Julia v1.6, [this package](https://github.com/JuliaPackaging/Artifacts.jl) for the other versions) and [`JLLWrappers`](https://github.com/JuliaPackaging/JLLWrappers.jl).

Automerge in https://github.com/JuliaRegistries/General/pull/21815 also complains about `Artifacts.toml` not having a compat bound.  Not sure what to with that one, since it's a new stdlib, maybe we should set [v1.3](https://github.com/JuliaPackaging/Artifacts.jl/blob/258eaa57c9ec0d488c2082743644cd03b7691408/Project.toml#L3) as minimum version?