### PR TITLE
Add ASCII check, distance check, visual distance check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ notifications:
 os:
   - linux
 
-script: julia --code-coverage --inline=no -e 'using Pkg; Pkg.build(); Pkg.test(coverage=true)'
+script: julia --code-coverage -e 'using Pkg; Pkg.build(); Pkg.test(coverage=true)'
 
 after_success: julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; get(ENV, "AUTOMERGE_RUN_INTEGRATION_TESTS", "") == "true" && Codecov.submit(process_folder())'
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryCI"
 uuid = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
 authors = ["Dilum Aluthge <dilum@aluthge.com>", "Fredrik Ekre <ekrefredrik@gmail.com>"]
-version = "3.2.0"
+version = "4.0.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
@@ -10,14 +10,21 @@ HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 RegistryTools = "d1eb7eb1-105f-429d-abf5-b0f65cb9e2c4"
+StringDistances = "88034a9c-02f8-509d-84a9-84ec65e18404"
+TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
+VisualStringDistances = "089bb0c6-1854-47b9-96f7-327dbbe09dca"
 
 [compat]
 GitHub = "5.1.6"
 HTTP = "0.8"
 JSON = "0.19, 0.20, 0.21"
 RegistryTools = "1.2"
+StringDistances = "0.9"
+TOML = "1"
 TimeZones = "1"
+VisualStringDistances = "0.1"
 julia = "1.3"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,29 @@ Note that commenting on a pull request will automatically disable automerging on
 
 3. Standard initial version number: one of `0.0.1`, `0.1.0`, `1.0.0`.
 
-4. Repo URL ends with `/$name.jl.git` where `name` is the package name.
+4. Package name is not too similar to an existing package's name.
+
+    We currently test this via three checks:
+    
+    - requiring that the [Damerau–Levenshtein distance](https://en.wikipedia.org/wiki/Damerau%E2%80%93Levenshtein_distance) between the package name and the name of any existing package is at least 3
+    - requiring that the Damerau–Levenshtein distance between the lowercased version of a package name and the lowercased version of the name of any existing package is at least 2
+    - requiring that a visual distance from [VisualStringDistances.jl](https://github.com/ericphanson/VisualStringDistances.jl) between the package name and any existing package exceeds a certain a hand-chosen threshold.
+
+    These tolerances and methodology are subject to change in order to improve the process.
+
+    To test yourself that a tentative package name, say `MyPackage` meets these checks, you can use the following code (after adding the RegistryCI package to your Julia environment):
+
+    ```julia
+    using RegistryCI
+    using RegistryCI.AutoMerge
+    all_pkg_names = AutoMerge.get_all_non_jll_package_names(path_to_registry)
+    AutoMerge.meets_distance_check("MyPackage", all_pkg_names)
+    ```
+
+    where `path_to_registry` is a path to the folder containing the registry of interest. For the General Julia registry, usually `path_to_registry = joinpath(DEPOT_PATH[1], "registries", "General")` if you haven't changed your `DEPOT_PATH`. This will return a boolean, indicating whether or not your tentative package name passed the check, as well as a string, indicating what the problem is in the event the check did not pass.
+
+
+Reminder: these automerge guidelines are deliberately conservative: it is very possible for a perfectly good name to not pass the automatic checks and require manually merging. They simply exist to provide a fast path so that manual review is not required for every new package.
 
 ### New version of an existing package
 

--- a/src/AutoMerge/AutoMerge.jl
+++ b/src/AutoMerge/AutoMerge.jl
@@ -8,7 +8,10 @@ import LibGit2
 import Pkg
 import TimeZones
 import JSON
-
+import VisualStringDistances
+import StringDistances
+import TOML
+import Printf
 import ..RegistryCI
 
 include("assert.jl")

--- a/src/AutoMerge/guidelines.jl
+++ b/src/AutoMerge/guidelines.jl
@@ -106,6 +106,63 @@ function meets_name_length(pkg)
     end
 end
 
+function meets_name_ascii(pkg)
+    if isascii(pkg)
+        return true, ""
+    else
+        return false, "Name is not ASCII"
+    end
+end
+
+damerau_levenshtein(name1, name2) = StringDistances.DamerauLevenshtein()(name1, name2)
+sqrt_normalized_vd(name1, name2) = VisualStringDistances.visual_distance(name1, name2; normalize=x -> 5 + sqrt(x))
+
+function meets_distance_check(pkg_name, other_packages; DL_lowercase_cutoff = 1, DL_cutoff = 2, sqrt_normalized_vd_cutoff = 2.5)
+    problem_messages = String[]
+    for other_pkg in other_packages
+        if pkg_name == other_pkg
+            # We short-circuit in this case; more information doesn't help.
+            return  (false, "Package name already exists in the registry.")
+        elseif lowercase(pkg_name) == lowercase(other_pkg)
+            push!(problem_messages, "Package name matches existing package name $(other_pkg) up to case.")
+        else
+            msg = ""
+
+            # Distance check 1: DL distance
+            dl = damerau_levenshtein(pkg_name, other_pkg)
+            if dl <= DL_cutoff
+                msg = string(msg, " Damerau-Levenshtein distance $dl is at or below cutoff of $(DL_cutoff).")
+            end
+
+            # Distance check 2: lowercase DL distance
+            dl_lowercase = damerau_levenshtein(lowercase(pkg_name), lowercase(other_pkg))
+            if dl <= DL_lowercase_cutoff
+                msg = string(msg, " Damerau-Levenshtein distance $(dl_lowercase) between lowercased names is at or below cutoff of $(DL_lowercase_cutoff).")
+            end
+            
+            # Distance check 3: normalized visual distance,
+            # gated by a `dl` check for speed.
+            if (sqrt_normalized_vd_cutoff > 0 && dl <= 4)
+                nrm_vd = sqrt_normalized_vd(pkg_name, other_pkg)
+                if nrm_vd <= sqrt_normalized_vd_cutoff
+                    msg = string(msg, " Normalized visual distance ", Printf.@sprintf("%.2f", nrm_vd), " is at or below cutoff of ", Printf.@sprintf("%.2f", sqrt_normalized_vd_cutoff), ".")
+                end
+            end
+
+            if msg != ""
+                # We must have found a clash.
+                push!(problem_messages, string("Similar to $(other_pkg).", msg))
+            end
+        end
+    end
+    
+    isempty(problem_messages) && return (true, "")
+    header = string("Package name similar to $(length(problem_messages)) existing package",
+                    length(problem_messages) > 1 ? "s" : "", ".\n")
+    numbered_list_string = join(join.(zip(1:length(problem_messages), problem_messages), Ref(". ")), '\n')
+    return (false, string(header, numbered_list_string))
+end
+
 function meets_normal_capitalization(pkg)
     meets_this_guideline = occursin(r"^[A-Z]\w*[a-z]\w*[0-9]?$", pkg)
     if meets_this_guideline

--- a/src/AutoMerge/util.jl
+++ b/src/AutoMerge/util.jl
@@ -180,3 +180,10 @@ function time_is_already_in_utc(dt::Dates.DateTime)
     utc = TimeZones.tz"UTC"
     return TimeZones.ZonedDateTime(dt, utc; from_utc = true)
 end
+
+function get_all_non_jll_package_names(registry_dir::AbstractString)
+    packages = [x["name"] for x in values(TOML.parsefile(joinpath(registry_dir, "Registry.toml"))["packages"])]
+    filter!(x -> !endswith(x, "_jll"), packages)
+    unique!(packages)
+    return packages
+end

--- a/test/automerge-integration.jl
+++ b/test/automerge-integration.jl
@@ -37,6 +37,7 @@ delete_stale_branches(repo_url_with_auth; GIT = GIT)
             (7, "master_4", "feature_7", "New version: HelloWorldC_jll v1.0.8+0", true),   # OK: new JLL version
             (8, "master_1", "feature_8", "New package: HelloWorldC_jll v1.0.6+0", false),  # FAIL: unallowed dependency
         ]
+        @info "Performing integration tests with settings" test_number master_dir feature_dir title pass
         with_master_branch(templates(master_dir), "master"; GIT = GIT, repo_url = repo_url_with_auth) do master
             with_feature_branch(templates(feature_dir), master; GIT = GIT, repo_url = repo_url_with_auth) do feature
                 head = feature

--- a/test/automerge-unit.jl
+++ b/test/automerge-unit.jl
@@ -29,6 +29,26 @@ const AutoMerge = RegistryCI.AutoMerge
         @test !AutoMerge.meets_name_length("Flux")[1]
         @test !AutoMerge.meets_name_length("Flux")[1]
     end
+    @testset "Package names is ASCII" begin
+        @test !AutoMerge.meets_name_ascii("ábc")[1]
+        @test AutoMerge.meets_name_ascii("abc")[1]
+    end
+    @info "Starting distance checks..."
+    @time @testset "Package name distance" begin
+        @info "Starting distance check 1..."
+        @time @test AutoMerge.meets_distance_check("Flux", ["Abc", "Def"])[1]
+        @info "Starting distance check 2..."
+        @time @test !AutoMerge.meets_distance_check("Flux", ["FIux", "Abc", "Def"])[1]
+        @info "Starting distance check 3..."
+        @time @test !AutoMerge.meets_distance_check("Websocket", ["WebSockets"])[1]
+        @info "Starting distance check 4..."
+        @time @test !AutoMerge.meets_distance_check("ThreabTooIs", ["ThreadTools"])[1]
+        @info "Starting distance check 5..."
+        @time @test !AutoMerge.meets_distance_check("JiII", ["Jill"])[1]
+        @info "Starting distance check 6..."
+        @time @test !AutoMerge.meets_distance_check("ReallyLooooongNameCD", ["ReallyLooooongNameAB"])[1]
+        @info "Completed distance checks."
+    end
     @testset "Standard initial version number" begin
         @test AutoMerge.meets_standard_initial_version_number(v"0.0.1")[1]
         @test AutoMerge.meets_standard_initial_version_number(v"0.1.0")[1]


### PR DESCRIPTION
My attempt to fix #10 and close #273. There's three semi-arbitrarily chosen cutoffs that might need more tuning, and if any are hit, then the package is flagged.

1. DL distance is <= 1 (which would catch Websocket vs Websockets)
2. A normalized DL distance catch long package names with more than 1 edit but only a few. I ended up going with a weird `5 + sqrt(max(len1, len2))` normalization just because it seemed like just dividing by the length made long packages get flagged too much.
3. Finally, there's the visual distance check, which can catch package names with more edits than allowed by the other checks if the edits are hard to distinguish visually, like `Jill` vs `JiII` (that's 2 edits of lowercase-ell to uppercase-eye, so the straight DL doesn't catch, short name so the normalized one doesn't catch it, but very similar looking letters, so the visual one catches it). I put a `DL <= 2` guard on the calculation so we don't have to perform the expensive visual check too often.

I also added an ASCII check; I saw that's in the guidelines but doesn't appear to be implemented.

I added some unit tests but not an integration test (out of lazyness / time constraints).


P.S. https://ericphanson.github.io/VisualStringDistances.jl/dev/packagenames/ has some short discussion of VisualStringDistances for this problem, and https://github.com/ericphanson/VisualStringDistances.jl/tree/master/scripts/packagenames has some messy/exploratory code for playing around with distances and cutoffs.

---

DL = Damerau–Levenshtein distance