### PR TITLE
Sort names, collapse comment, fix bug

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryCI"
 uuid = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
 authors = ["Dilum Aluthge <dilum@aluthge.com>", "Fredrik Ekre <ekrefredrik@gmail.com>"]
-version = "4.0.3"
+version = "4.1.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/test/automerge-unit.jl
+++ b/test/automerge-unit.jl
@@ -33,21 +33,14 @@ const AutoMerge = RegistryCI.AutoMerge
         @test !AutoMerge.meets_name_ascii("ábc")[1]
         @test AutoMerge.meets_name_ascii("abc")[1]
     end
-    @info "Starting distance checks..."
-    @time @testset "Package name distance" begin
-        @info "Starting distance check 1..."
-        @time @test AutoMerge.meets_distance_check("Flux", ["Abc", "Def"])[1]
-        @info "Starting distance check 2..."
-        @time @test !AutoMerge.meets_distance_check("Flux", ["FIux", "Abc", "Def"])[1]
-        @info "Starting distance check 3..."
-        @time @test !AutoMerge.meets_distance_check("Websocket", ["WebSockets"])[1]
-        @info "Starting distance check 4..."
-        @time @test !AutoMerge.meets_distance_check("ThreabTooIs", ["ThreadTools"])[1]
-        @info "Starting distance check 5..."
-        @time @test !AutoMerge.meets_distance_check("JiII", ["Jill"])[1]
-        @info "Starting distance check 6..."
-        @time @test !AutoMerge.meets_distance_check("ReallyLooooongNameCD", ["ReallyLooooongNameAB"])[1]
-        @info "Completed distance checks."
+    @testset "Package name distance" begin
+        @test AutoMerge.meets_distance_check("Flux", ["Abc", "Def"])[1]
+        @test !AutoMerge.meets_distance_check("Flux", ["FIux", "Abc", "Def"])[1]
+        @test !AutoMerge.meets_distance_check("Websocket", ["WebSockets"])[1]
+        @test !AutoMerge.meets_distance_check("ThreabTooIs", ["ThreadTools"])[1]
+        @test !AutoMerge.meets_distance_check("JiII", ["Jill"])[1]
+        @test !AutoMerge.meets_distance_check("FooBar", ["FOO8ar"], DL_cutoff=0, sqrt_normalized_vd_cutoff=0, DL_lowercase_cutoff=1)[1]
+        @test !AutoMerge.meets_distance_check("ReallyLooooongNameCD", ["ReallyLooooongNameAB"])[1]
     end
     @testset "Standard initial version number" begin
         @test AutoMerge.meets_standard_initial_version_number(v"0.0.1")[1]


### PR DESCRIPTION
There was a really silly bug where I put `dl` instead of `dl_lowercase`, so that check wasn't correct .

This fixes that and also sorts the names and adds comment-collapse markup for > 10 packages.

## Examples:
Here I set the cutoff to 8 so we can see the effect of exceeding the limit:
```julia
julia> AutoMerge.meets_distance_check("MKL", all_pkg_names, comment_collapse_cutoff=8)[2] |> println
Package name similar to 10 existing packages.
<details>
<summary>Similar package names</summary>

1. Similar to HSL. Damerau-Levenshtein distance 2 is at or below cutoff of 2.
2. Similar to MLJ. Damerau-Levenshtein distance 2 is at or below cutoff of 2.
3. Similar to MD5. Damerau-Levenshtein distance 2 is at or below cutoff of 2.
4. Similar to GSL. Damerau-Levenshtein distance 2 is at or below cutoff of 2.
5. Similar to Mux. Damerau-Levenshtein distance 2 is at or below cutoff of 2.
6. Similar to QML. Damerau-Levenshtein distance 2 is at or below cutoff of 2.
7. Similar to MPI. Damerau-Levenshtein distance 2 is at or below cutoff of 2.
8. Similar to VSL. Damerau-Levenshtein distance 2 is at or below cutoff of 2.
9. Similar to LSL. Damerau-Levenshtein distance 2 is at or below cutoff of 2.
10. Similar to MAT. Damerau-Levenshtein distance 2 is at or below cutoff of 2.
</details>
```

Here we see some useful sorting:
```julia
julia> AutoMerge.meets_distance_check("FIux", all_pkg_names)[2] |> println
Package name similar to 3 existing packages.
1. Similar to Flux. Damerau-Levenshtein distance 1 is at or below cutoff of 2. Damerau-Levenshtein distance 1 between lowercased names is at or below cutoff of 1. Normalized visual distance 0.46 is at or below cutoff of 2.50.
2. Similar to FIB. Damerau-Levenshtein distance 2 is at or below cutoff of 2.
3. Similar to Mux. Damerau-Levenshtein distance 2 is at or below cutoff of 2.
```

And if I take out the `first.()` call so print the distances too, we get
```julia
julia> AutoMerge.meets_distance_check("MKL", all_pkg_names, comment_collapse_cutoff=8)[2] |> println
Package name similar to 10 existing packages.
<details>
<summary>Similar package names</summary>

1. ("Similar to HSL. Damerau-Levenshtein distance 2 is at or below cutoff of 2.", (2.0, 2.0, 2.9528660315569137))
2. ("Similar to MLJ. Damerau-Levenshtein distance 2 is at or below cutoff of 2.", (2.0, 2.0, 4.1009029760569495))
3. ("Similar to MD5. Damerau-Levenshtein distance 2 is at or below cutoff of 2.", (2.0, 2.0, 4.122961174607436))
4. ("Similar to GSL. Damerau-Levenshtein distance 2 is at or below cutoff of 2.", (2.0, 2.0, 4.205321647277623))
5. ("Similar to Mux. Damerau-Levenshtein distance 2 is at or below cutoff of 2.", (2.0, 2.0, 4.217983302769896))
6. ("Similar to QML. Damerau-Levenshtein distance 2 is at or below cutoff of 2.", (2.0, 2.0, 4.220901499782644))
7. ("Similar to MPI. Damerau-Levenshtein distance 2 is at or below cutoff of 2.", (2.0, 2.0, 4.353258334821372))
8. ("Similar to VSL. Damerau-Levenshtein distance 2 is at or below cutoff of 2.", (2.0, 2.0, 4.874622321696524))
9. ("Similar to LSL. Damerau-Levenshtein distance 2 is at or below cutoff of 2.", (2.0, 2.0, 5.006232753811422))
10. ("Similar to MAT. Damerau-Levenshtein distance 2 is at or below cutoff of 2.", (2.0, 2.0, 5.1399180517066085))
</details>

```
so we can see the sorting is working.