### PR TITLE
Check name distance to standard libraries

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryCI"
 uuid = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
 authors = ["Dilum Aluthge <dilum@aluthge.com>", "Fredrik Ekre <ekrefredrik@gmail.com>"]
-version = "4.1.0"
+version = "4.1.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/AutoMerge/AutoMerge.jl
+++ b/src/AutoMerge/AutoMerge.jl
@@ -12,6 +12,7 @@ import VisualStringDistances
 import StringDistances
 import TOML
 import Printf
+import RegistryTools
 import ..RegistryCI
 
 include("assert.jl")

--- a/src/AutoMerge/util.jl
+++ b/src/AutoMerge/util.jl
@@ -181,8 +181,16 @@ function time_is_already_in_utc(dt::Dates.DateTime)
     return TimeZones.ZonedDateTime(dt, utc; from_utc = true)
 end
 
+"""
+    get_all_non_jll_package_names(registry_dir::AbstractString) -> Vector{String}
+
+Given a path to the directory holding a registry, returns the names of all the non-JLL packages
+defined in that registry, along with the names of Julia's standard libraries.
+"""
 function get_all_non_jll_package_names(registry_dir::AbstractString)
     packages = [x["name"] for x in values(TOML.parsefile(joinpath(registry_dir, "Registry.toml"))["packages"])]
+    sort!(packages)
+    append!(packages, values(RegistryTools.stdlibs()))
     filter!(x -> !endswith(x, "_jll"), packages)
     unique!(packages)
     return packages

--- a/test/automerge-unit.jl
+++ b/test/automerge-unit.jl
@@ -42,6 +42,13 @@ const AutoMerge = RegistryCI.AutoMerge
         @test !AutoMerge.meets_distance_check("FooBar", ["FOO8ar"], DL_cutoff=0, sqrt_normalized_vd_cutoff=0, DL_lowercase_cutoff=1)[1]
         @test !AutoMerge.meets_distance_check("ReallyLooooongNameCD", ["ReallyLooooongNameAB"])[1]
     end
+    @testset "`get_all_non_jll_package_names`" begin
+        registry_path = joinpath(DEPOT_PATH[1], "registries", "General")
+        packages = AutoMerge.get_all_non_jll_package_names(registry_path)
+        @test "RegistryCI" ∈ packages
+        @test "Logging" ∈ packages
+        @test "Poppler_jll" ∉ packages
+    end
     @testset "Standard initial version number" begin
         @test AutoMerge.meets_standard_initial_version_number(v"0.0.1")[1]
         @test AutoMerge.meets_standard_initial_version_number(v"0.1.0")[1]


### PR DESCRIPTION
As came up in https://github.com/JuliaRegistries/General/pull/23128

I first thought to do this by adding the stdlibs to the `all_pkg_names` variable here https://github.com/JuliaRegistries/RegistryCI.jl/blob/e4fff963024a5091b4d852fbcdab7284aab18db5/src/AutoMerge/new-package.jl#L140

But then I remembered I had added to the [General registry's docs](https://github.com/JuliaRegistries/General#automatic-merging-of-pull-requests) the following:

> To test yourself that a tentative package name, say MyPackage meets these checks, you can use the following code (after adding the RegistryCI package to your Julia environment):
> ```julia
> using RegistryCI
> using RegistryCI.AutoMerge
> all_pkg_names = AutoMerge.get_all_non_jll_package_names(path_to_registry)
> AutoMerge.meets_distance_check("MyPackage", all_pkg_names)
> ```
> where path_to_registry is a path to the folder containing the registry of interest. 

and I wanted to keep that working and keep it as simple as possible. So I decided to just add the stdlibs to the return value of `AutoMerge.get_all_non_jll_package_names`. I also added a docstring to that function to make it more obvious that it returns the stdlibs and not just packages from the registry.