### PR TITLE
make RegistryCI tests less reliant on Pkg internals

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ git:
 julia:
   - "1.3"
   - "1" # "1" expands to the latest 1.y.z release of Julia
-  # - nightly
+  - nightly
 
 language: julia
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ git:
 julia:
   - "1.3"
   - "1" # "1" expands to the latest 1.y.z release of Julia
-  - nightly
+  # - nightly
 
 language: julia
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryCI"
 uuid = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
 authors = ["Dilum Aluthge <dilum@aluthge.com>", "Fredrik Ekre <ekrefredrik@gmail.com>"]
-version = "4.3.0"
+version = "4.3.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"


### PR DESCRIPTION
The signature changed for this in 1.6 and will further be changed on master. Might make sense to just use a snapshotted copy here.