### PR TITLE
Use TagBot token for merging stuff

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryCI"
 uuid = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
 authors = ["Dilum Aluthge <dilum@aluthge.com>", "Fredrik Ekre <ekrefredrik@gmail.com>"]
-version = "4.3.2"
+version = "4.3.3"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/example_github_workflow_files/automerge.yml
+++ b/example_github_workflow_files/automerge.yml
@@ -23,5 +23,6 @@ jobs:
       - name: AutoMerge.run
         env:
           AUTOMERGE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AUTOMERGE_TAGBOT_TOKEN: ${{ secrets.TAGBOT_TOKEN }}
           JULIA_DEBUG: RegistryCI,AutoMerge
-        run: julia --project=.ci/ -e 'using RegistryCI; using Dates; RegistryCI.AutoMerge.run(merge_new_packages = true, merge_new_versions = true, new_package_waiting_period = Day(3), new_jll_package_waiting_period = Minute(15), new_version_waiting_period = Minute(15), new_jll_version_waiting_period = Minute(15), registry = "JuliaRegistries/General", authorized_authors = String["JuliaRegistrator"], authorized_authors_special_jll_exceptions = String["jlbuild"], suggest_onepointzero = false, additional_statuses = String[], additional_check_runs = String["Travis CI - Pull Request"])'
+        run: julia --project=.ci/ -e 'using RegistryCI; using Dates; RegistryCI.AutoMerge.run(merge_new_packages = true, merge_new_versions = true, new_package_waiting_period = Day(3), new_jll_package_waiting_period = Minute(15), new_version_waiting_period = Minute(15), new_jll_version_waiting_period = Minute(15), registry = "JuliaRegistries/General", tagbot_enabled=true, authorized_authors = String["JuliaRegistrator"], authorized_authors_special_jll_exceptions = String["jlbuild"], suggest_onepointzero = false, additional_statuses = String[], additional_check_runs = String["Travis CI - Pull Request"])'

--- a/src/AutoMerge/public.jl
+++ b/src/AutoMerge/public.jl
@@ -8,6 +8,8 @@ function run(env = ENV,
              new_jll_version_waiting_period,
              registry::String,
              #
+             tagbot_enabled::Bool=false,
+             #
              authorized_authors::Vector{String},
              authorized_authors_special_jll_exceptions::Vector{String},
              #
@@ -41,7 +43,8 @@ function run(env = ENV,
     end
 
     # Authentication
-    auth = my_retry(() -> GitHub.authenticate(api, env["AUTOMERGE_GITHUB_TOKEN"]))
+    key = run_pr_build || !tagbot_enabled ? "AUTOMERGE_GITHUB_TOKEN" : "AUTOMERGE_TAGBOT_TOKEN"
+    auth = my_retry(() -> GitHub.authenticate(api, env[key]))
     whoami = my_retry(() -> username(api, cicfg; auth=auth))
     @info("Authenticated to GitHub as \"$(whoami)\"")
     registry_repo = my_retry(() -> GitHub.repo(api, registry; auth=auth))


### PR DESCRIPTION
When Automerge merges PRs, it does not trigger the TagBot notifier because actions can't trigger other actions with the default token. So for cron jobs, use a user token.