### PR TITLE
Filter out pull requests when looking for a trigger issue

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,9 +1,12 @@
 name: TagBot
 on:
-  schedule:
-    - cron: 0 * * * *
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch:
 jobs:
   TagBot:
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
     runs-on: ubuntu-latest
     steps:
       - uses: JuliaRegistries/TagBot@v1

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryCI"
 uuid = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
 authors = ["Dilum Aluthge <dilum@aluthge.com>", "Fredrik Ekre <ekrefredrik@gmail.com>"]
-version = "4.3.3"
+version = "4.3.4"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/TagBot/TagBot.jl
+++ b/src/TagBot/TagBot.jl
@@ -65,6 +65,7 @@ function get_repo_notification_issue(repo)
     # TODO: Get the authenticated user (how?) and use it as `creator`.
     params = (; creator="JuliaTagBot", state="closed")
     issues, _ = GH.issues(repo; auth=AUTH[], params=params)
+    filter!(x -> x.pull_request === nothing, issues)
     return if isempty(issues)
         @info "Creating new notification issue"
         params = (; title=ISSUE_TITLE, body=ISSUE_BODY)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,7 +17,7 @@ const AutoMerge = RegistryCI.AutoMerge
     end
 
     @testset "TagBot.jl unit tests" begin
-        if v"1.0" <= VERSION < v"1.6"
+        if v"1.0" <= VERSION < VersionNumber(1, 5, typemax(UInt32))
             @info("Running the TagBot.jl unit tests", VERSION)
             include("tagbot-unit.jl")
         else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,11 +17,11 @@ const AutoMerge = RegistryCI.AutoMerge
     end
 
     @testset "TagBot.jl unit tests" begin
-        if v"1.0" <= Base.VERSION <= v"1.5"
-            @info("Running the TagBot.jl unit tests", Base.VERSION)
+        if v"1.0" <= VERSION < v"1.6"
+            @info("Running the TagBot.jl unit tests", VERSION)
             include("tagbot-unit.jl")
         else
-            @warn("Skipping the TagBot.jl unit tests", Base.VERSION)
+            @warn("Skipping the TagBot.jl unit tests", VERSION)
         end
     end
 


### PR DESCRIPTION
Slight oversight: When looking for a closed issue by JuliaTagBot, it also includes PRs. So it picks up the PR adding the TagBot action from way back when: https://github.com/JuliaRegistries/RegistryCI.jl/pull/214