### PR TITLE
The "new package name should not include `julia` in the name" check should apply to all packages (including JLL packages)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryCI"
 uuid = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
 authors = ["Dilum Aluthge <dilum@aluthge.com>", "Fredrik Ekre <ekrefredrik@gmail.com>"]
-version = "4.4.1"
+version = "4.5.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/AutoMerge/new-package.jl
+++ b/src/AutoMerge/new-package.jl
@@ -107,15 +107,13 @@ function pull_request_build(api::GitHub.GitHubAPI,
             if this_pr_can_use_special_jll_exceptions
                 g3 = true
                 g4 = true
-                g5 = true
                 m3 = ""
                 m4 = ""
-                m5 = ""
             else
                 g3, m3 = meets_normal_capitalization(pkg)
                 g4, m4 = meets_name_length(pkg)
-                g5, m5 = meets_julia_name_check(pkg)
             end
+            g5, m5 = meets_julia_name_check(pkg)
             if this_pr_can_use_special_jll_exceptions
                 g6 = true
                 m6 = ""


### PR DESCRIPTION
If for some reason a new JLL package wants to include "julia" in its name, I think it's perfectly fine to require manual merge in that case.