### PR TITLE
Simplification of code using undef.

### DIFF
--- a/src/AutoMerge/cron.jl
+++ b/src/AutoMerge/cron.jl
@@ -70,20 +70,7 @@ function pr_has_no_blocking_comments(api::GitHub.GitHubAPI,
                                      pr::GitHub.PullRequest;
                                      auth::GitHub.Authorization)
     all_pr_comments = get_all_pull_request_comments(api, registry, pr; auth = auth)
-    if isempty(all_pr_comments)
-        return true
-    else
-        num_comments = length(all_pr_comments)
-        comment_is_blocking = BitVector(undef, num_comments)
-        for i = 1:num_comments
-            comment_is_blocking[i] = pr_comment_is_blocking(all_pr_comments[i])
-        end
-        if any(comment_is_blocking)
-            return false
-        else
-            return true
-        end
-    end
+    return !any(pr_comment_is_blocking.(all_pr_comments))
 end
 
 function pr_is_old_enough(pr_type::Symbol,

--- a/src/AutoMerge/github.jl
+++ b/src/AutoMerge/github.jl
@@ -66,7 +66,7 @@ function get_all_my_pull_request_comments(api::GitHub.GitHubAPI,
     all_comments = get_all_pull_request_comments(api, repo,
                                                  pr;
                                                  auth = auth)
-    my_comments = Vector{GitHub.Comment}(undef, 0)
+    my_comments = GitHub.Comment[]
     for c in all_comments
         if c.user.login == whoami
             push!(my_comments, c)
@@ -81,7 +81,7 @@ function get_all_pull_request_comments(api::GitHub.GitHubAPI,
                                        repo::GitHub.Repo,
                                        pr::GitHub.PullRequest;
                                        auth::GitHub.Authorization)
-    all_comments = Vector{GitHub.Comment}(undef, 0)
+    all_comments = GitHub.Comment[]
     myparams = Dict("per_page" => 100, "page" => 1)
     cs, page_data = GitHub.comments(api, repo, pr, :pr; auth=auth, params = myparams, page_limit = 100)
     append!(all_comments, cs)
@@ -98,7 +98,7 @@ function get_all_pull_requests(api::GitHub.GitHubAPI,
                                repo::GitHub.Repo,
                                state::String;
                                auth::GitHub.Authorization)
-    all_pull_requests = Vector{GitHub.PullRequest}(undef, 0)
+    all_pull_requests = GitHub.PullRequest[]
     myparams = Dict("state" => state, "per_page" => 100, "page" => 1)
     prs, page_data = GitHub.pull_requests(api, repo; auth=auth, params = myparams, page_limit = 100)
     append!(all_pull_requests, prs)
@@ -112,12 +112,7 @@ end
 
 function get_changed_filenames(api::GitHub.GitHubAPI, repo::GitHub.Repo, pull_request::GitHub.PullRequest; auth::GitHub.Authorization)
     files = GitHub.pull_request_files(api, repo, pull_request; auth=auth)
-    n = length(files)
-    filenames = Vector{String}(undef, n)
-    for i = 1:n
-        filenames[i] = files[i].filename
-    end
-    return filenames
+    return [file.filename for file in files]
 end
 
 is_merged(pull_request::GitHub.PullRequest) = pull_request.merged

--- a/src/AutoMerge/guidelines.jl
+++ b/src/AutoMerge/guidelines.jl
@@ -298,10 +298,7 @@ function meets_version_can_be_pkg_added(working_directory::String,
     pkg_add_command = _generate_pkg_add_command(pkg,
                                                 version)
     _registry_deps = convert(Vector{String}, registry_deps)
-    _registry_deps_is_valid_url = Vector{Bool}(undef, length(_registry_deps))
-    for i = 1:length(_registry_deps)
-        _registry_deps_is_valid_url[i] = is_valid_url(_registry_deps[i])
-    end
+    _registry_deps_is_valid_url = is_valid_url.(_registry_deps)
     code = """
         import Pkg;
         Pkg.Registry.add(Pkg.RegistrySpec(path=\"$(working_directory)\"));
@@ -348,10 +345,7 @@ function meets_version_can_be_imported(working_directory::String,
     pkg_add_command = _generate_pkg_add_command(pkg,
                                                 version)
     _registry_deps = convert(Vector{String}, registry_deps)
-    _registry_deps_is_valid_url = Vector{Bool}(undef, length(_registry_deps))
-    for i = 1:length(_registry_deps)
-        _registry_deps_is_valid_url[i] = is_valid_url(_registry_deps[i])
-    end
+    _registry_deps_is_valid_url = is_valid_url.(_registry_deps)
     code = """
         import Pkg;
         Pkg.Registry.add(Pkg.RegistrySpec(path=\"$(working_directory)\"));

--- a/src/AutoMerge/jll.jl
+++ b/src/AutoMerge/jll.jl
@@ -5,7 +5,7 @@ end
 function _get_all_dependencies_nonrecursive(working_directory::AbstractString,
                                             pkg,
                                             version)
-    all_dependencies = Vector{String}(undef, 0)
+    all_dependencies = String[]
     deps = Pkg.TOML.parsefile(joinpath(working_directory, uppercase(pkg[1:1]), pkg, "Deps.toml"))
     for version_range in keys(deps)
         if version in Pkg.Types.VersionRange(version_range)

--- a/src/AutoMerge/semver.jl
+++ b/src/AutoMerge/semver.jl
@@ -68,7 +68,7 @@ end
 latest_version(pkg::String, registry_path::String) = maximum(all_versions(pkg, registry_path))
 
 function julia_compat(pkg::String, version::VersionNumber, registry_path::String)
-    all_compat_entries_for_julia = Vector{Pkg.Types.VersionRange}(undef, 0)
+    all_compat_entries_for_julia = Pkg.Types.VersionRange[]
     compat = Pkg.TOML.parsefile(joinpath(registry_path, uppercase(pkg[1:1]), pkg, "Compat.toml"))
     for version_range in keys(compat)
         if version in Pkg.Types.VersionRange(version_range)


### PR DESCRIPTION
This PR removes all occurrences of `undef`. Not because there's anything wrong with `undef` but because all uses could be simplified. There should be no functional differences.