### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci_integration.yml
+++ b/.github/workflows/ci_integration.yml
@@ -1,8 +1,11 @@
 name: CI (integration tests)
+
+# We only run the integration tests with Bors. There is a specific reason for
+# this. Using Bors makes it easier for us to limit the total number of
+# concurrent jobs. This is important because it keeps us from triggering 
+# GitHub's abuse rate limits.
+
 on:
-  pull_request:
-    branches:
-      - master
   push:
     branches:
       - master
@@ -11,11 +14,11 @@ on:
     tags: '*'
 jobs:
   integration:
-    # If the pull request is made from a fork, you'll need to use Bors to run the integration tests.
-    if: (github.event_name != 'pull_request') || (github.repository == github.event.pull_request.head.repo.full_name)
+    if: github.event_name == 'push'
     name: Integration/Julia ${{ matrix.version }}/${{ matrix.os }}/${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
     strategy:
+      max-parallel: 1
       fail-fast: false
       matrix:
         arch:

--- a/test/automerge-integration.jl
+++ b/test/automerge-integration.jl
@@ -52,6 +52,7 @@ delete_old_pull_request_branches(
                 pr = GitHub.create_pull_request(repo; auth = auth, params = params)
                 pr = wait_pr_compute_mergeability(GitHub.DEFAULT_API, repo, pr; auth = auth)
                 @test pr.mergeable
+                sleep(1)
                 with_pr_merge_commit(pr, repo_url_without_auth; GIT = GIT) do build_dir
                     withenv("AUTOMERGE_GITHUB_TOKEN" => TEST_USER_GITHUB_TOKEN,
                             "TRAVIS_BRANCH" => master,
@@ -60,6 +61,7 @@ delete_old_pull_request_branches(
                             "TRAVIS_PULL_REQUEST" => string(pr.number),
                             "TRAVIS_PULL_REQUEST_SHA" => string(AutoMerge.pull_request_head_sha(pr)),
                             "TRAVIS_REPO_SLUG" => AUTOMERGE_INTEGRATION_TEST_REPO) do
+                        sleep(1)
                         run_thunk = () -> AutoMerge.run(;
                                       merge_new_packages = true,
                                       merge_new_versions = true,
@@ -87,6 +89,7 @@ delete_old_pull_request_branches(
                             "TRAVIS_PULL_REQUEST" => "false",
                             "TRAVIS_PULL_REQUEST_SHA" => "",
                             "TRAVIS_REPO_SLUG" => AUTOMERGE_INTEGRATION_TEST_REPO) do
+                        sleep(1)
                         AutoMerge.run(;
                                       merge_new_packages = true,
                                       merge_new_versions = true,
@@ -99,6 +102,7 @@ delete_old_pull_request_branches(
                                       authorized_authors_special_jll_exceptions = String[whoami],
                                       master_branch = master,
                                       master_branch_is_default_branch = false)
+                        sleep(1)
                         AutoMerge.run(;
                                       merge_new_packages = true,
                                       merge_new_versions = true,


### PR DESCRIPTION
1. Only run integration tests with Bors
2. Limit parallelism
3. Add sleep statements

These steps are necessary to keep us from triggering GitHub's abuse rate limits.