### PR TITLE
Only run the integration tests on the `staging` and `trying` branches

### DIFF
--- a/.github/workflows/ci_integration.yml
+++ b/.github/workflows/ci_integration.yml
@@ -2,16 +2,16 @@ name: CI (integration tests)
 
 # We only run the integration tests with Bors. There is a specific reason for
 # this. Using Bors makes it easier for us to limit the total number of
-# concurrent jobs. This is important because it keeps us from triggering 
+# concurrent jobs. This is important because it keeps us from triggering
 # GitHub's abuse rate limits.
 
 on:
   push:
     branches:
-      - master
+      # - master
       - staging
       - trying
-    tags: '*'
+    # tags: '*'
 jobs:
   integration:
     if: github.event_name == 'push'

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 [![Code Coverage][codecov-img]][codecov-url]
 [![Bors][bors-img]][bors-url]
 
-[ci-unit-img]: https://github.com/JuliaRegistries/RegistryCI.jl/workflows/CI%20(unit%20tests)/badge.svg "Continuous Integration (Unit Tests)"
+[ci-unit-img]: https://github.com/JuliaRegistries/RegistryCI.jl/workflows/CI%20(unit%20tests)/badge.svg?branch=master "Continuous Integration (Unit Tests)"
 [ci-unit-url]: https://github.com/JuliaRegistries/RegistryCI.jl/actions?query=workflow%3A%22CI+%28unit+tests%29%22
-[ci-integration-img]: https://github.com/JuliaRegistries/RegistryCI.jl/workflows/CI%20(integration%20tests)/badge.svg "Continuous Integration (Integration Tests)"
+[ci-integration-img]: https://github.com/JuliaRegistries/RegistryCI.jl/workflows/CI%20(integration%20tests)/badge.svg?branch=staging "Continuous Integration (Integration Tests)"
 [ci-integration-url]: https://github.com/JuliaRegistries/RegistryCI.jl/actions?query=workflow%3A%22CI+%28integration+tests%29%22
 [codecov-img]: https://codecov.io/gh/JuliaRegistries/RegistryCI.jl/branch/master/graph/badge.svg "Code Coverage"
 [codecov-url]: https://codecov.io/gh/JuliaRegistries/RegistryCI.jl/branch/master

--- a/test/automerge-integration.jl
+++ b/test/automerge-integration.jl
@@ -49,7 +49,7 @@ delete_old_pull_request_branches(
                 params = Dict("title" => title,
                               "head" => head,
                               "base" => base)
-                sleep(30)
+                sleep(1)
                 pr = GitHub.create_pull_request(repo; auth = auth, params = params)
                 pr = wait_pr_compute_mergeability(GitHub.DEFAULT_API, repo, pr; auth = auth)
                 @test pr.mergeable


### PR DESCRIPTION
There's not really any point in running the integration tests on the `master` branch. After all, we use Bors. And Bors only fast-forwards `master` to point to `staging` if the integration tests have already passed on `staging`. So it's redundant to run them again on `master`, since we know that they have already passed on the exact same commit that `master` now points to.