### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci_integration.yml
+++ b/.github/workflows/ci_integration.yml
@@ -25,9 +25,8 @@ jobs:
         os:
           - ubuntu-latest
         version:
-          # - '1.3'
-          - '1'
-          # - 'nightly'
+          - '^1.6.0-0' # TODO: remove this line once Julia 1.6 is released
+          # - '1'      # TODO: uncomment this line once Julia 1.6 is released
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/ci_unit.yml
+++ b/.github/workflows/ci_unit.yml
@@ -21,8 +21,9 @@ jobs:
         os:
           - ubuntu-latest
         version:
-          - '1.3'
-          - '1'
+          - '^1.6.0-0' # TODO: remove this line once Julia 1.6 is released
+          # - '1.6'    # TODO: uncomment this line once Julia 1.6 is released
+          # - '1'      # TODO: uncomment this line once Julia 1.6 is released
           - 'nightly'
     steps:
       - uses: actions/checkout@v2

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryCI"
 uuid = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
 authors = ["Dilum Aluthge <dilum@aluthge.com>", "Fredrik Ekre <ekrefredrik@gmail.com>", "contributors"]
-version = "6.1.1"
+version = "6.2.0-DEV"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/bors.toml
+++ b/bors.toml
@@ -14,4 +14,4 @@ status = [
     # "codecov/project",
 ]
 
-timeout_sec = 7200
+timeout_sec = 1800

--- a/bors.toml
+++ b/bors.toml
@@ -3,11 +3,11 @@ block_labels = [ "DO NOT MERGE" ]
 delete_merged_branches = true
 
 status = [
-    # "Integration/Julia 1.3/ubuntu-latest/x64",
-    "Integration/Julia 1/ubuntu-latest/x64",
-    # "Integration/Julia nightly/ubuntu-latest/x64",
-    "Unit/Julia 1.3/ubuntu-latest/x64",
-    "Unit/Julia 1/ubuntu-latest/x64",
+    # "Integration/Julia 1/ubuntu-latest/x64", # TODO: uncomment this line once Julia 1.6 is released
+    "Integration/Julia ^1.6.0-0/ubuntu-latest/x64", # TODO: delete this line once Julia 1.6 is released
+    # "Unit/Julia 1.6/ubuntu-latest/x64", # TODO: uncomment this line once Julia 1.6 is released
+    # "Unit/Julia 1/ubuntu-latest/x64", # TODO: uncomment this line once Julia 1.6 is released
+    "Unit/Julia ^1.6.0-0/ubuntu-latest/x64", # TODO: delete this line once Julia 1.6 is released
     "Unit/Julia nightly/ubuntu-latest/x64",
     "VersionVigilante",
     # "codecov/patch",


### PR DESCRIPTION
The General registry now has a version of a package (CUDA 2.5) that relies on some Julia 1.6-specific stuff. So tests are expected to fail on Julia 1.5 and earlier.