### PR TITLE
Centralize authorization checks.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryCI"
 uuid = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
 authors = ["Dilum Aluthge <dilum@aluthge.com>", "Fredrik Ekre <ekrefredrik@gmail.com>", "contributors"]
-version = "6.2.1"
+version = "6.3.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/AutoMerge/jll.jl
+++ b/src/AutoMerge/jll.jl
@@ -1,9 +1,3 @@
-# This is a somewhat artificial guideline that always fails. The point
-# is the messages.
-const guideline_jll_only_authorization =
-    Guideline("JLL-only authors cannot register non-JLL packages.",
-              data -> (false, "This package is not a JLL package. The author of this pull request is not authorized to register non-JLL packages."))
-
 function is_jll_name(name::AbstractString)::Bool
     return endswith(name, "_jll")
 end

--- a/src/AutoMerge/new-version.jl
+++ b/src/AutoMerge/new-version.jl
@@ -1,6 +1,5 @@
 function pull_request_build(data::GitHubAutoMergeData, ::NewVersion)::Nothing
     # Rules:
-    # 0. A JLL-only author (e.g. `jlbuild`) is not allowed to register non-JLL packages.
     # 1. Only changes a subset of the following files:
     #     - `E/Example/Compat.toml`
     #     - `E/Example/Deps.toml`
@@ -25,7 +24,6 @@ function pull_request_build(data::GitHubAutoMergeData, ::NewVersion)::Nothing
     # 7. Version can be loaded
     #     - once it's been installed (and built?), can we load the code?
     #     - i.e. can we run `import Foo`
-    pr_author_login = author_login(data.pr)
     this_is_jll_package = is_jll_name(data.pkg)
     @info("This is a new package pull request",
           pkg = data.pkg,
@@ -37,22 +35,8 @@ function pull_request_build(data::GitHubAutoMergeData, ::NewVersion)::Nothing
                   context = "automerge/decision",
                   description = "New version. Pending.")
 
-    if this_is_jll_package
-        if pr_author_login in data.authorized_authors_special_jll_exceptions
-            this_pr_can_use_special_jll_exceptions = true
-        else
-            this_pr_can_use_special_jll_exceptions = false
-        end
-    else
-        this_pr_can_use_special_jll_exceptions = false
-    end
-
-    # If this is true it means that the author only is authorized for
-    # jll packages but this is is a normal package.
-    # TODO: Do all authorization checks in one place before calling
-    # this function.
-    jll_only_authorization = (!this_is_jll_package
-                              && pr_author_login ∉ data.authorized_authors)
+    this_pr_can_use_special_jll_exceptions =
+        this_is_jll_package && data.authorization == :jll
 
     # Each element is a tuple of a guideline and whether it's
     # applicable. Instead of a guideline there can be the symbol
@@ -60,8 +44,7 @@ function pull_request_build(data::GitHubAutoMergeData, ::NewVersion)::Nothing
     # with the results so far before continuing to the following
     # guidelines.
     guidelines =
-        [(guideline_jll_only_authorization, jll_only_authorization), #0
-         (guideline_pr_only_changes_allowed_files, true), # 1
+        [(guideline_pr_only_changes_allowed_files, true), # 1
          (guideline_sequential_version_number,
           !this_pr_can_use_special_jll_exceptions), # 2
          (guideline_compat_for_all_deps, true), # 3

--- a/src/AutoMerge/pull-requests.jl
+++ b/src/AutoMerge/pull-requests.jl
@@ -6,6 +6,38 @@ is_new_package(pull_request::GitHub.PullRequest) = occursin(new_package_title_re
 
 is_new_version(pull_request::GitHub.PullRequest) = occursin(new_version_title_regex, title(pull_request))
 
+function check_authorization(pkg, pr_author_login, authorized_authors,
+                             authorized_authors_special_jll_exceptions,
+                             error_exit_if_automerge_not_applicable)
+    if pr_author_login ∉ vcat(authorized_authors,
+                              authorized_authors_special_jll_exceptions)
+        throw_not_automerge_applicable(
+            AutoMergeAuthorNotAuthorized,
+            "Author $(pr_author_login) is not authorized to automerge. Exiting...";
+            error_exit_if_automerge_not_applicable = error_exit_if_automerge_not_applicable
+        )
+        return :not_authorized
+    end
+
+    # A JLL-only author (e.g. `jlbuild`) is not allowed to register
+    # non-JLL packages.
+    this_is_jll_package = is_jll_name(pkg)
+    if (!this_is_jll_package && pr_author_login ∉ authorized_authors)
+        throw_not_automerge_applicable(
+            AutoMergeAuthorNotAuthorized,
+            "This package is not a JLL package. Author $(pr_author_login) is not authorized to register non-JLL packages. Exiting...";
+            error_exit_if_automerge_not_applicable = error_exit_if_automerge_not_applicable
+        )
+        return :not_authorized
+    end
+
+    if pr_author_login ∈ authorized_authors_special_jll_exceptions
+        return :jll
+    end
+
+    return :normal
+end
+
 function parse_pull_request_title(::NewVersion,
                                   pull_request::GitHub.PullRequest)
     m = match(new_version_title_regex, title(pull_request))
@@ -78,7 +110,6 @@ function pull_request_build(api::GitHub.GitHubAPI,
     # If the PR is open and the author is authorized,
     # then determine if it is a new package or new version of an
     # existing package, and then call the appropriate method.
-    pr_author_login = author_login(pr)
     if !is_open(pr)
         throw_not_automerge_applicable(
             AutoMergePullRequestNotOpen,
@@ -88,13 +119,14 @@ function pull_request_build(api::GitHub.GitHubAPI,
         return nothing
     end
 
-    if pr_author_login ∉ vcat(authorized_authors,
-                              authorized_authors_special_jll_exceptions)
-        throw_not_automerge_applicable(
-            AutoMergeAuthorNotAuthorized,
-            "Author $(pr_author_login) is not authorized to automerge. Exiting...";
-            error_exit_if_automerge_not_applicable = error_exit_if_automerge_not_applicable
-        )
+    pkg, version = parse_pull_request_title(registration_type, pr)
+    pr_author_login = author_login(pr)
+    authorization = check_authorization(pkg, pr_author_login,
+                                        authorized_authors,
+                                        authorized_authors_special_jll_exceptions,
+                                        error_exit_if_automerge_not_applicable)
+
+    if authorization == :not_authorized
         return nothing
     end
 
@@ -115,7 +147,6 @@ function pull_request_build(api::GitHub.GitHubAPI,
     if !master_branch_is_default_branch
         checkout_branch(registry_master, master_branch)
     end
-    pkg, version = parse_pull_request_title(registration_type, pr)
     data = GitHubAutoMergeData(;api = api,
                                registration_type = registration_type,
                                pr = pr,
@@ -124,9 +155,7 @@ function pull_request_build(api::GitHub.GitHubAPI,
                                current_pr_head_commit_sha = current_pr_head_commit_sha,
                                registry = registry,
                                auth = auth,
-                               authorized_authors = authorized_authors,
-                               authorized_authors_special_jll_exceptions = authorized_authors_special_jll_exceptions,
-                               error_exit_if_automerge_not_applicable = error_exit_if_automerge_not_applicable,
+                               authorization = authorization,
                                registry_head = registry_head,
                                registry_master = registry_master,
                                suggest_onepointzero = suggest_onepointzero,

--- a/src/AutoMerge/types.jl
+++ b/src/AutoMerge/types.jl
@@ -85,8 +85,8 @@ end
 # Constructor that requires all fields as named arguments.
 function GitHubAutoMergeData(;kwargs...)
     fields = fieldnames(GitHubAutoMergeData)
-    @assert Set(keys(kwargs)) == Set(fields)
-    @assert kwargs[:authorization] ∈ (:normal, :jll)
+    always_assert(Set(keys(kwargs)) == Set(fields))
+    always_assert(kwargs[:authorization] ∈ (:normal, :jll))
     return GitHubAutoMergeData(getindex.(Ref(kwargs), fields)...)
 end
 

--- a/src/AutoMerge/types.jl
+++ b/src/AutoMerge/types.jl
@@ -59,14 +59,10 @@ struct GitHubAutoMergeData
     # GitHub authorization data.
     auth::GitHub.Authorization
 
-    # List of GitHub users who are authorized to make automergable registry PRs.
-    authorized_authors::Vector{String}
-
-    # The same but for registration of jll packages.
-    authorized_authors_special_jll_exceptions::Vector{String}
-
-    # Whether to exit with fail or success if the PR is not applicable.
-    error_exit_if_automerge_not_applicable::Bool
+    # Type of authorization for automerge. This can be either:
+    # :jll - special jll exceptions are allowed,
+    # :normal - normal automerge rules.
+    authorization::Symbol
 
     # Directory of a registry clone that includes the PR.
     registry_head::String
@@ -90,6 +86,7 @@ end
 function GitHubAutoMergeData(;kwargs...)
     fields = fieldnames(GitHubAutoMergeData)
     @assert Set(keys(kwargs)) == Set(fields)
+    @assert kwargs[:authorization] ∈ (:normal, :jll)
     return GitHubAutoMergeData(getindex.(Ref(kwargs), fields)...)
 end
 


### PR DESCRIPTION
Do all authorization checks in one place.
