### PR TITLE
Test that we can `Pkg.dev` the package (in addition to being able to `Pkg.add` the package)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryCI"
 uuid = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
 authors = ["Dilum Aluthge <dilum@aluthge.com>", "Fredrik Ekre <ekrefredrik@gmail.com>", "contributors"]
-version = "6.7.5"
+version = "6.8.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/AutoMerge/new-package.jl
+++ b/src/AutoMerge/new-package.jl
@@ -10,53 +10,57 @@ end
 
 function pull_request_build(data::GitHubAutoMergeData, ::NewPackage; check_license)::Nothing
     # Rules:
-    # 1. Only changes a subset of the following files:
-    #     - `Registry.toml`,
-    #     - `E/Example/Compat.toml`
-    #     - `E/Example/Deps.toml`
-    #     - `E/Example/Package.toml`
-    #     - `E/Example/Versions.toml`
-    # 2. TODO: implement this check. When implemented, this check will make sure that the changes to `Registry.toml` only modify the specified package.
-    # 3. Normal capitalization
-    #     - name should match r"^[A-Z]\w*[a-z]\w*[0-9]?$"
-    #     - i.e. starts with a capital letter, ASCII alphanumerics only, contains at least 1 lowercase letter
-    # 4. Not too short
-    #     - at least five letters
-    #     - you can register names shorter than this, but doing so requires someone to approve
-    # 5. Meets julia name check
-    #     - does not include the string "julia" with any case
-    #     - does not start with "Ju"
-    # 6. DISABLED. Standard initial version number - one of 0.0.1, 0.1.0, 1.0.0, X.0.0
-    #     - does not apply to JLL packages
-    # 7. Repo URL ends with /$name.jl.git where name is the package name. We only apply this check if the package is not a subdirectory package.
-    # 8. Compat for all dependencies
-    #     - there should be a [compat] entry for Julia
-    #     - all [deps] should also have [compat] entries
-    #     - all [compat] entries should have upper bounds
-    #     - dependencies that are standard libraries do not need [compat] entries
-    #     - dependencies that are JLL packages do not need [compat] entries
-    # 9. (only applies to JLL packages) The only dependencies of the package are:
-    #     - Pkg
-    #     - Libdl
-    #     - other JLL packages
+    # 1.  Only changes a subset of the following files:
+    #         - `Registry.toml`,
+    #         - `E/Example/Compat.toml`
+    #         - `E/Example/Deps.toml`
+    #         - `E/Example/Package.toml`
+    #         - `E/Example/Versions.toml`
+    # 2.  TODO: implement this check. When implemented, this check will make sure that the changes to `Registry.toml` only modify the specified package.
+    # 3.  Normal capitalization
+    #         - name should match r"^[A-Z]\w*[a-z]\w*[0-9]?$"
+    #         - i.e. starts with a capital letter, ASCII alphanumerics only, contains at least 1 lowercase letter
+    # 4.  Not too short
+    #         - at least five letters
+    #         - you can register names shorter than this, but doing so requires someone to approve
+    # 5.  Meets julia name check
+    #         - does not include the string "julia" with any case
+    #         - does not start with "Ju"
+    # 6.  [DISABLED] Standard initial version number - one of 0.0.1, 0.1.0, 1.0.0, X.0.0
+    #         - does not apply to JLL packages
+    # 7.  Repo URL ends with /$name.jl.git where name is the package name. We only apply this check if the package is not a subdirectory package.
+    # 8.  Compat for all dependencies
+    #         - there should be a [compat] entry for Julia
+    #         - all [deps] should also have [compat] entries
+    #         - all [compat] entries should have upper bounds
+    #         - dependencies that are standard libraries do not need [compat] entries
+    #         - dependencies that are JLL packages do not need [compat] entries
+    # 9.  (only applies to JLL packages) The only dependencies of the package are:
+    #         - Pkg
+    #         - Libdl
+    #         - other JLL packages
     # 10. Package's name is sufficiently far from existing package names in the registry
-    #     - We exclude JLL packages from the "existing names"
-    #     - We use three checks:
+    #         - We exclude JLL packages from the "existing names"
+    #         - We use three checks:
     #         - that the lowercased name is at least 1 away in Damerau Levenshtein distance from any other lowercased name
     #         - that the name is at least 2 away in Damerau Levenshtein distance from any other name
     #         - that the name is sufficiently far in a visual distance from any other name
     # 11. Package's name has only ASCII characters
-    # 12. Version can be installed
-    #     - given the proposed changes to the registry, can we resolve and install the new version of the package?
-    #     - i.e. can we run `Pkg.add("Foo")`
+    # 12. Version can be installed (added)
+    #         - given the proposed changes to the registry, can we resolve and install the new version of the package?
+    #         - i.e. can we run `Pkg.add("Foo")`
     # 13. Package repository contains only OSI-approved license(s) in the license file at toplevel in the version being registered
-    # 14. Version can be loaded
-    #     - once it's been installed (and built?), can we load the code?
-    #     - i.e. can we run `import Foo`
-    # 15. Package UUID doesn't conflict with an UUID in the provided
-    #     list of package registries. The exception is if also the
-    #     package name *and* package URL matches those in the other
-    #     registry, in which case this is a valid co-registration.
+    # 14. Version can be loaded (imported)
+    #         - once it's been installed (and built?), can we load the code?
+    #         - i.e. can we run `import Foo`
+    # 15. Version can be `Pkg.dev`ed
+    #         - i.e. can we run `Pkg.dev("Foo")`
+    # 16. Dependency confusion check
+    #         - Package UUID doesn't conflict with an UUID in the provided
+    #         - list of package registries. The exception is if also the
+    #         - package name *and* package URL matches those in the other
+    #         - registry, in which case this is a valid co-registration.
+
     this_is_jll_package = is_jll_name(data.pkg)
     @info("This is a new package pull request",
           pkg = data.pkg,
@@ -76,31 +80,29 @@ function pull_request_build(data::GitHubAutoMergeData, ::NewPackage; check_licen
     # `:update_status` in which case the PR status will be updated
     # with the results so far before continuing to the following
     # guidelines.
-    guidelines =
-        [(guideline_pr_only_changes_allowed_files, true), # 1
-         #(guideline_only_changes_specified_package, true), # 2 (unimplemented)
-         (guideline_normal_capitalization,
-          !this_pr_can_use_special_jll_exceptions), # 3
-         (guideline_name_length,
-          !this_pr_can_use_special_jll_exceptions), # 4
-         (guideline_julia_name_check, true), # 5
-         #(guideline_standard_initial_version_number,
-         # !this_pr_can_use_special_jll_exceptions), # 6 (deactivated)
-         (guideline_repo_url_requirement, true), # 7
-         (guideline_compat_for_all_deps, true), # 8
-         (guideline_allowed_jll_nonrecursive_dependencies,
-          this_is_jll_package), # 9
-         (guideline_distance_check, true), # 10
-         (guideline_name_ascii, true), # 11
-         (:update_status, true),
-         (guideline_version_can_be_pkg_added, true), # 12
-          # `guideline_version_has_osi_license` must be run after
-         # `guideline_version_can_be_pkg_added` so that it can use the downloaded code!
-         (guideline_version_has_osi_license, check_license), # 13
-         (guideline_version_can_be_imported, true), # 14
-         (:update_status, true),
-         (guideline_dependency_confusion, true)] # 15
-
+    guidelines = [
+        (guideline_pr_only_changes_allowed_files, true),          # rule 1
+        # TODO: implement rule 2
+        (guideline_normal_capitalization,                         # rule 3
+             !this_pr_can_use_special_jll_exceptions),
+        (guideline_name_length,                                   # rule 4
+             !this_pr_can_use_special_jll_exceptions),
+        (guideline_julia_name_check,              true),          # rule 5
+        # rule 6 is disabled
+        (guideline_repo_url_requirement,          true),          # rule 7
+        (guideline_compat_for_all_deps,           true),          # rule 8
+        (guideline_allowed_jll_nonrecursive_dependencies,         # rule 9
+             this_is_jll_package),
+        (guideline_distance_check,                true),          # rule 10
+        (guideline_name_ascii,                    true),          # rule 11
+        (:update_status,                          true),
+        (guideline_version_can_be_pkg_added,      true),          # rule 12
+        (guideline_version_has_osi_license,       check_license), # rule 13
+        (guideline_version_can_be_imported,       true),          # rule 14
+        (guideline_version_can_be_pkg_deved,      true),          # rule 15
+        (:update_status,                          true),
+        (guideline_dependency_confusion,          true),          # rule 16
+    ]
 
     checked_guidelines = Guideline[]
 

--- a/src/AutoMerge/new-version.jl
+++ b/src/AutoMerge/new-version.jl
@@ -1,31 +1,33 @@
 function pull_request_build(data::GitHubAutoMergeData, ::NewVersion; check_license)::Nothing
     # Rules:
-    # 1. Only changes a subset of the following files:
-    #     - `E/Example/Compat.toml`
-    #     - `E/Example/Deps.toml`
-    #     - `E/Example/Versions.toml`
-    # 2. Sequential version number
-    #     - if the last version was 1.2.3 then the next can be 1.2.4, 1.3.0 or 2.0.0
-    #     - does not apply to JLL packages
-    # 3. Compat for all dependencies
-    #     - there should be a [compat] entry for Julia
-    #     - all [deps] should also have [compat] entries
-    #     - all [compat] entries should have upper bounds
-    #     - dependencies that are standard libraries do not need [compat] entries
-    #     - dependencies that are JLL packages do not need [compat] entries
-    # 4. If it is a patch release, then it does not narrow the Julia compat range
-    # 5. (only applies to JLL packages) The only dependencies of the package are:
-    #     - Pkg
-    #     - Libdl
-    #     - other JLL packages
-    # 6. Version can be installed
-    #     - given the proposed changes to the registry, can we resolve and install the new version of the package?
-    #     - i.e. can we run `Pkg.add("Foo")`
-    # 7. Package repository contains only OSI-approved license(s) in the license file at toplevel in the version being registered
-    # 8. Version can be loaded
-    #     - once it's been installed (and built?), can we load the code?
-    #     - i.e. can we run `import Foo`
-        
+    # 1.  Only changes a subset of the following files:
+    #         - `E/Example/Compat.toml`
+    #         - `E/Example/Deps.toml`
+    #         - `E/Example/Versions.toml`
+    # 2.  Sequential version number
+    #         - if the last version was 1.2.3 then the next can be 1.2.4, 1.3.0 or 2.0.0
+    #         - does not apply to JLL packages
+    # 3.  Compat for all dependencies
+    #         - there should be a [compat] entry for Julia
+    #         - all [deps] should also have [compat] entries
+    #         - all [compat] entries should have upper bounds
+    #         - dependencies that are standard libraries do not need [compat] entries
+    #         - dependencies that are JLL packages do not need [compat] entries
+    # 4.  If it is a patch release, then it does not narrow the Julia compat range
+    # 5.  (only applies to JLL packages) The only dependencies of the package are:
+    #         - Pkg
+    #         - Libdl
+    #         - other JLL packages
+    # 6.  Version can be installed (added)
+    #         - given the proposed changes to the registry, can we resolve and install the new version of the package?
+    #         - i.e. can we run `Pkg.add("Foo")`
+    # 7.  Package repository contains only OSI-approved license(s) in the license file at toplevel in the version being registered
+    # 8.  Version can be loaded (imported)
+    #         - once it's been installed (and built?), can we load the code?
+    #         - i.e. can we run `import Foo`
+    # 9.  Version can be `Pkg.dev`ed
+    #         - i.e. can we run `Pkg.dev("Foo")`
+
     this_is_jll_package = is_jll_name(data.pkg)
     @info("This is a new package pull request",
           pkg = data.pkg,
@@ -45,21 +47,21 @@ function pull_request_build(data::GitHubAutoMergeData, ::NewVersion; check_licen
     # `:update_status` in which case the PR status will be updated
     # with the results so far before continuing to the following
     # guidelines.
-    guidelines =
-        [(guideline_pr_only_changes_allowed_files, true), # 1
-         (guideline_sequential_version_number,
-          !this_pr_can_use_special_jll_exceptions), # 2
-         (guideline_compat_for_all_deps, true), # 3
-         (guideline_patch_release_does_not_narrow_julia_compat,
-          !this_pr_can_use_special_jll_exceptions), # 4
-         (guideline_allowed_jll_nonrecursive_dependencies,
-          this_is_jll_package), # 5
-         (:update_status, true),
-         (guideline_version_can_be_pkg_added, true), # 6
-         # `guideline_version_has_osi_license` must be run after
-         # `guideline_version_can_be_pkg_added` so that it can use the downloaded code!
-         (guideline_version_has_osi_license, check_license), # 7
-         (guideline_version_can_be_imported, true)] # 8
+    guidelines = [
+        (guideline_pr_only_changes_allowed_files, true),       # rule 1
+        (guideline_sequential_version_number,                  # rule 2
+             !this_pr_can_use_special_jll_exceptions),
+        (guideline_compat_for_all_deps,           true),       # rule 3
+        (guideline_patch_release_does_not_narrow_julia_compat, # rule 4
+             !this_pr_can_use_special_jll_exceptions),
+        (guideline_allowed_jll_nonrecursive_dependencies,      # rule 5
+             this_is_jll_package),
+        (:update_status,                          true),
+        (guideline_version_can_be_pkg_added,      true),       # rule 6
+        (guideline_version_has_osi_license, check_license),    # rule 7
+        (guideline_version_can_be_imported,       true),       # rule 8
+        (guideline_version_can_be_pkg_deved,      true),       # rule 9
+    ]
 
     checked_guidelines = Guideline[]
 


### PR DESCRIPTION
This is related to issue #349.

This does not fix issue 349. In order to fix issue 349, we also need to do this: (from [this comment](https://github.com/JuliaRegistries/RegistryCI.jl/issues/349#issue-813011226))
> If dev doesn't throw, then at least it is a valid directory, though we probably should go one step further and check that the tree hash of the contents at that path matches the one in the registry. If anyone has any other ideas I'd be happy to hear it.

But this is a good start.