### PR TITLE
Better error message for checking if the UUID of the dependencies is in the registry

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryCI"
 uuid = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
 authors = ["Dilum Aluthge <dilum@aluthge.com>", "Fredrik Ekre <ekrefredrik@gmail.com>", "contributors"]
-version = "6.7.5"
+version = "6.7.6"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/registry_testing.jl
+++ b/src/registry_testing.jl
@@ -145,7 +145,7 @@ function test(path = pwd();
                 deps = Pkg.TOML.parsefile(depsfile)
                 # Require all deps to exist in the General registry or be a stdlib
                 depuuids = Set{Base.UUID}(Base.UUID(x) for (_, d) in deps for (_, x) in d)
-                Test.@test depuuids ⊆ alluuids
+                Test.@test isempty(setdiff(depuuids, alluuids))
                 # Test that the way Pkg loads this data works
                 Test.@test load_deps(depsfile, vnums)
                 # Make sure the content roundtrips through decompression/compression


### PR DESCRIPTION
Credit to @ericphanson 

Rewrite dependency uuid check so that it gives a better error message when an UUID in `depuuids` is not in `alluuids`.