### PR TITLE
fix indentation in pkg name similarity list

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryCI"
 uuid = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
 authors = ["Dilum Aluthge <dilum@aluthge.com>", "Fredrik Ekre <ekrefredrik@gmail.com>", "contributors"]
-version = "6.8.4"
+version = "6.8.5"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/AutoMerge/guidelines.jl
+++ b/src/AutoMerge/guidelines.jl
@@ -235,16 +235,20 @@ function meets_distance_check(pkg_name::AbstractString,
     sort!(problem_messages, by = Base.tail)
     message = string("Package name similar to $(length(problem_messages)) existing package",
                     length(problem_messages) > 1 ? "s" : "", ".\n")
-    if length(problem_messages) > comment_collapse_cutoff
+    use_spoiler = length(problem_messages) > comment_collapse_cutoff
+    # we indent each line by two spaces in all the following
+    # so that it nests properly in the outer list.
+    if use_spoiler
         message *=  """
-                    <details>
-                    <summary>Similar package names</summary>
-
+                      <details>
+                      <summary>Similar package names</summary>
+                      
                     """
     end
-    message *= join(join.(zip(1:length(problem_messages), first.(problem_messages)), Ref(". ")), '\n')
-    if length(problem_messages) > comment_collapse_cutoff
-        message *=  "\n</details>\n"
+    numbers = string.("  ", 1:length(problem_messages))
+    message *= join(join.(zip(numbers, first.(problem_messages)), Ref(". ")), '\n')
+    if use_spoiler
+        message *= "\n\n  </details>\n"
     end
     return (false, message)
 end


### PR DESCRIPTION
I tested this by

```julia
using RegistryCI
using RegistryCI.AutoMerge
using RegistryCI.AutoMerge: meets_distance_check, get_all_non_jll_package_names
registry_master = joinpath(homedir(), ".julia", "registries", "General")
other_packages = get_all_non_jll_package_names(registry_master)
pkg_name = "C"
meets_distance_check(pkg_name, other_packages)[2] |> println
```

then editing the comment in https://github.com/JuliaRegistries/General/pull/31746, copy pasting the result, and clicking preview to check that it works properly even with the spoiler tag:

<img width="807" alt="Screenshot 2021-03-14 at 18 40 41" src="https://user-images.githubusercontent.com/5846501/111078248-cb24b800-84f4-11eb-95b2-84552e9f3aba.png">
