### PR TITLE
Update VersionVigilante_bors.yml

### DIFF
--- a/.github/workflows/VersionVigilante_bors.yml
+++ b/.github/workflows/VersionVigilante_bors.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - staging
       - trying
+    paths-ignore:
+      - '*.md'
+      - 'bors.toml'
+      - 'codecov.toml'
+      - '.github/*'
 
 jobs:
   VersionVigilante:

--- a/.github/workflows/VersionVigilante_bors.yml
+++ b/.github/workflows/VersionVigilante_bors.yml
@@ -9,7 +9,7 @@ on:
       - '*.md'
       - 'bors.toml'
       - 'codecov.toml'
-      - '.github/*'
+      - '.github/**'
 
 jobs:
   VersionVigilante:


### PR DESCRIPTION
Add `paths-ignore` options. Rationale: version bumps are only needed for code changes, i.e. things that affect what happens when you do `using RegistryCI` and onwards.