### PR TITLE
Automatically pass VersionVigilante on the trying branch

### DIFF
--- a/.github/workflows/VersionVigilante_bors.yml
+++ b/.github/workflows/VersionVigilante_bors.yml
@@ -1,11 +1,9 @@
 name: VersionVigilante
-
 on:
   push:
     branches:
       - staging
       - trying
-
 jobs:
   VersionVigilante:
     runs-on: ubuntu-latest
@@ -13,7 +11,7 @@ jobs:
       - uses: actions/checkout@v1.0.0
       - uses: julia-actions/setup-julia@latest
       - name: VersionVigilante.main
-        id: versionvigilante_main
+        if: github.ref != 'refs/heads/trying'
         run: |
           julia -e 'using Pkg; Pkg.add("VersionVigilante")'
           julia -e 'using VersionVigilante; VersionVigilante.main("https://github.com/${{ github.repository }}")'

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryCI"
 uuid = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
 authors = ["Dilum Aluthge <dilum@aluthge.com>", "Fredrik Ekre <ekrefredrik@gmail.com>", "contributors"]
-version = "6.8.7"
+version = "6.8.8"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"


### PR DESCRIPTION
When you are working on a PR, you might want to run `bors try` before you are ready to merge, just to see if the integration tests pass.

So we should not require that VersionVigilante passes on `bors try`.

We should however continue to require that VersionVigilante passes on `bors merge`.