### PR TITLE
Check Julia compat separately.

### DIFF
--- a/src/AutoMerge/guidelines.jl
+++ b/src/AutoMerge/guidelines.jl
@@ -36,7 +36,7 @@ function meets_compat_for_julia(working_directory::AbstractString, pkg, version)
                     return false, "The compat entry for `julia` is unbounded."
                 elseif !isempty(intersect(julia_compat,
                                           Pkg.Types.VersionSpec("2-*")))
-                    return false, "Julia has a compat entry with an upper bound of 2 or higher."
+                    return false, "The compat entry for `julia` has an upper bound of 2 or higher."
                 elseif isempty(intersect(julia_compat,
                                          Pkg.Types.VersionSpec("1")))
                     # For completeness, although this seems rather

--- a/src/AutoMerge/guidelines.jl
+++ b/src/AutoMerge/guidelines.jl
@@ -33,7 +33,7 @@ function meets_compat_for_julia(working_directory::AbstractString, pkg, version)
                 julia_compat = Pkg.Types.VersionSpec(compat[version_range]["julia"])
                 if !isempty(intersect(julia_compat,
                                       Pkg.Types.VersionSpec("$(typemax(Base.VInt))-*")))
-                    return false, "Julia has an unbounded compat entry."
+                    return false, "The compat entry for `julia` is unbounded."
                 elseif !isempty(intersect(julia_compat,
                                           Pkg.Types.VersionSpec("2-*")))
                     return false, "Julia has a compat entry with an upper bound of 2 or higher."

--- a/src/AutoMerge/guidelines.jl
+++ b/src/AutoMerge/guidelines.jl
@@ -24,9 +24,11 @@ const guideline_compat_for_julia =
 
 function meets_compat_for_julia(working_directory::AbstractString, pkg, version)
     compat = Pkg.TOML.parsefile(joinpath(working_directory, uppercase(pkg[1:1]), pkg, "Compat.toml"))
-    # Now, we go through all the compat entries. If a dependency has a compat
-    # entry with an upper bound, we change the corresponding value in the Dict
-    # to true.
+    # Go through all the compat entries looking for the julia compat
+    # of the new version. When found, test
+    # 1. that it is a bounded range,
+    # 2. that the upper bound is not 2 or higher,
+    # 3. that the range includes at least one 1.x version.
     for version_range in keys(compat)
         if version in Pkg.Types.VersionRange(version_range)
             if haskey(compat[version_range], "julia")

--- a/src/AutoMerge/guidelines.jl
+++ b/src/AutoMerge/guidelines.jl
@@ -49,7 +49,7 @@ function meets_compat_for_julia(working_directory::AbstractString, pkg, version)
         end
     end
 
-    return false, "Julia has no compat entry."
+    return false, "There is no compat entry for `julia`."
 end
 
 const guideline_compat_for_all_deps =

--- a/src/AutoMerge/guidelines.jl
+++ b/src/AutoMerge/guidelines.jl
@@ -16,6 +16,42 @@ function meets_registry_consistency_tests_pass(registry_head::String,
     return false, "The registry consistency tests failed"
 end
 
+const guideline_compat_for_julia =
+    Guideline("Compat with upper bound for julia",
+              data -> meets_compat_for_julia(data.registry_head,
+                                             data.pkg,
+                                             data.version))
+
+function meets_compat_for_julia(working_directory::AbstractString, pkg, version)
+    compat = Pkg.TOML.parsefile(joinpath(working_directory, uppercase(pkg[1:1]), pkg, "Compat.toml"))
+    # Now, we go through all the compat entries. If a dependency has a compat
+    # entry with an upper bound, we change the corresponding value in the Dict
+    # to true.
+    for version_range in keys(compat)
+        if version in Pkg.Types.VersionRange(version_range)
+            if haskey(compat[version_range], "julia")
+                julia_compat = Pkg.Types.VersionSpec(compat[version_range]["julia"])
+                if !isempty(intersect(julia_compat,
+                                      Pkg.Types.VersionSpec("$(typemax(Base.VInt))-*")))
+                    return false, "Julia has an unbounded compat entry."
+                elseif !isempty(intersect(julia_compat,
+                                          Pkg.Types.VersionSpec("2-*")))
+                    return false, "Julia has a compat entry with an upper bound of 2 or higher."
+                elseif isempty(intersect(julia_compat,
+                                         Pkg.Types.VersionSpec("1")))
+                    # For completeness, although this seems rather
+                    # unlikely to occur.
+                    return false, "Julia has a compat entry that doesn't include any 1.x version."
+                else
+                    return true, ""
+                end
+            end
+        end
+    end
+
+    return false, "Julia has no compat entry."
+end
+
 const guideline_compat_for_all_deps =
     Guideline("Compat (with upper bound) for all dependencies",
               data -> meets_compat_for_all_deps(data.registry_head,
@@ -28,8 +64,6 @@ function meets_compat_for_all_deps(working_directory::AbstractString, pkg, versi
     # First, we construct a Dict in which the keys are the package's
     # dependencies, and the value is always false.
     dep_has_compat_with_upper_bound = Dict{String, Bool}()
-    @debug("We always have julia as a dependency")
-    dep_has_compat_with_upper_bound["julia"] = false
     for version_range in keys(deps)
         if version in Pkg.Types.VersionRange(version_range)
             for name in keys(deps[version_range])
@@ -45,9 +79,7 @@ function meets_compat_for_all_deps(working_directory::AbstractString, pkg, versi
     # to true.
     for version_range in keys(compat)
         if version in Pkg.Types.VersionRange(version_range)
-            for compat_entry in compat[version_range]
-                name = compat_entry[1]
-                value = compat_entry[2]
+            for (name, value) in compat[version_range]
                 if value isa Vector
                     if !isempty(value)
                         value_ranges = Pkg.Types.VersionRange.(value)

--- a/src/AutoMerge/guidelines.jl
+++ b/src/AutoMerge/guidelines.jl
@@ -41,7 +41,7 @@ function meets_compat_for_julia(working_directory::AbstractString, pkg, version)
                                          Pkg.Types.VersionSpec("1")))
                     # For completeness, although this seems rather
                     # unlikely to occur.
-                    return false, "Julia has a compat entry that doesn't include any 1.x version."
+                    return false, "The compat entry for `julia` doesn't include any 1.x version."
                 else
                     return true, ""
                 end

--- a/src/AutoMerge/new-package.jl
+++ b/src/AutoMerge/new-package.jl
@@ -30,32 +30,36 @@ function pull_request_build(data::GitHubAutoMergeData, ::NewPackage; check_licen
     # 7.  DISABLED. Standard initial version number - one of 0.0.1, 0.1.0, 1.0.0, X.0.0
     #         - does not apply to JLL packages
     # 8.  Repo URL ends with /$name.jl.git where name is the package name. We only apply this check if the package is not a subdirectory package.
-    # 9.  Compat for all dependencies
+    # 9.  Compat for Julia
+    #         - there should be a [compat] entry for Julia
+    #         - the Julia [compat] should have an upper bound
+    #         - the Julia [compat] upper bound must have major version 1
+    # 10.  Compat for all dependencies
     #         - there should be a [compat] entry for Julia
     #         - all [deps] should also have [compat] entries
     #         - all [compat] entries should have upper bounds
     #         - dependencies that are standard libraries do not need [compat] entries
     #         - dependencies that are JLL packages do not need [compat] entries
-    # 10. (only applies to JLL packages) The only dependencies of the package are:
+    # 11. (only applies to JLL packages) The only dependencies of the package are:
     #         - Pkg
     #         - Libdl
     #         - other JLL packages
-    # 11. Package's name has only ASCII characters
-    # 12. Version can be installed
+    # 12. Package's name has only ASCII characters
+    # 13. Version can be installed
     #         - given the proposed changes to the registry, can we resolve and install the new version of the package?
     #         - i.e. can we run `Pkg.add("Foo")`
-    # 13. Package code can be downloaded. Can we `git clone` the repo and get the files corresponding to the tree hash in the PR?
+    # 14. Package code can be downloaded. Can we `git clone` the repo and get the files corresponding to the tree hash in the PR?
     #       - and does that tree hash match what we get by looking at the subdir + commit the registration was triggered from?
-    # 14. Package repository contains only OSI-approved license(s) in the license file at toplevel in the version being registered
-    # 15. Version can be loaded
+    # 15. Package repository contains only OSI-approved license(s) in the license file at toplevel in the version being registered
+    # 16. Version can be loaded
     #         - once it's been installed (and built?), can we load the code?
     #         - i.e. can we run `import Foo`
-    # 16. Dependency confusion check
+    # 17. Dependency confusion check
     #         - Package UUID doesn't conflict with an UUID in the provided
     #           list of package registries. The exception is if also the
     #           package name *and* package URL matches those in the other
     #           registry, in which case this is a valid co-registration.
-    # 17. Package's name is sufficiently far from existing package names in the registry
+    # 18. Package's name is sufficiently far from existing package names in the registry
     #         - We always run this check last.
     #         - We exclude JLL packages from the "existing names"
     #         - We use three checks:
@@ -94,26 +98,27 @@ function pull_request_build(data::GitHubAutoMergeData, ::NewPackage; check_licen
             # (guideline_standard_initial_version_number,       # 7 (deactivated)
             #     !this_pr_can_use_special_jll_exceptions),
             (guideline_repo_url_requirement, true),             # 8
-            (guideline_compat_for_all_deps, true),              # 9
-            (guideline_allowed_jll_nonrecursive_dependencies,   # 10
+            (guideline_compat_for_julia, true),                 # 9
+            (guideline_compat_for_all_deps, true),              # 10
+            (guideline_allowed_jll_nonrecursive_dependencies,   # 11
                 this_is_jll_package),
-            (guideline_name_ascii, true),                       # 11
+            (guideline_name_ascii, true),                       # 12
             (:update_status, true),
-            (guideline_version_can_be_pkg_added, true),         # 12
-            (guideline_code_can_be_downloaded, true),           # 13
+            (guideline_version_can_be_pkg_added, true),         # 13
+            (guideline_code_can_be_downloaded, true),           # 14
             # `guideline_version_has_osi_license` must be run
             # after `guideline_code_can_be_downloaded` so
             # that it can use the downloaded code!
-            (guideline_version_has_osi_license, check_license), # 14
-            (guideline_version_can_be_imported, true),          # 15
+            (guideline_version_has_osi_license, check_license), # 15
+            (guideline_version_can_be_imported, true),          # 16
             (:update_status, true),
-            (guideline_dependency_confusion, true),             # 16
+            (guideline_dependency_confusion, true),             # 17
             # We always run the `guideline_distance_check`
             # check last, because if the check fails, it
             # prints the list of similar package names in
             # the automerge comment. To make the comment easy
             # to read, we want this list to be at the end.
-            (guideline_distance_check, true),                   # 17
+            (guideline_distance_check, true),                   # 18
          ]
 
     checked_guidelines = Guideline[]

--- a/src/AutoMerge/new-version.jl
+++ b/src/AutoMerge/new-version.jl
@@ -8,24 +8,28 @@ function pull_request_build(data::GitHubAutoMergeData, ::NewVersion; check_licen
     # 3. Sequential version number
     #     - if the last version was 1.2.3 then the next can be 1.2.4, 1.3.0 or 2.0.0
     #     - does not apply to JLL packages
-    # 4. Compat for all dependencies
+    # 4.  Compat for Julia
+    #         - there should be a [compat] entry for Julia
+    #         - the Julia [compat] should have an upper bound
+    #         - the Julia [compat] upper bound must have major version 1
+    # 5. Compat for all dependencies
     #     - there should be a [compat] entry for Julia
     #     - all [deps] should also have [compat] entries
     #     - all [compat] entries should have upper bounds
     #     - dependencies that are standard libraries do not need [compat] entries
     #     - dependencies that are JLL packages do not need [compat] entries
-    # 5. If it is a patch release, then it does not narrow the Julia compat range
-    # 6. (only applies to JLL packages) The only dependencies of the package are:
+    # 6. If it is a patch release, then it does not narrow the Julia compat range
+    # 7. (only applies to JLL packages) The only dependencies of the package are:
     #     - Pkg
     #     - Libdl
     #     - other JLL packages
-    # 7. Version can be installed
+    # 8. Version can be installed
     #     - given the proposed changes to the registry, can we resolve and install the new version of the package?
     #     - i.e. can we run `Pkg.add("Foo")`
-    # 8. Package code can be downloaded. Can we `git clone` the repo and get the files corresponding to the tree hash in the PR?
+    # 9. Package code can be downloaded. Can we `git clone` the repo and get the files corresponding to the tree hash in the PR?
     #       - and does that tree hash match what we get by looking at the subdir + commit the registration was triggered from?
-    # 9. Package repository contains only OSI-approved license(s) in the license file at toplevel in the version being registered
-    # 10. Version can be loaded
+    # 10. Package repository contains only OSI-approved license(s) in the license file at toplevel in the version being registered
+    # 11. Version can be loaded
     #     - once it's been installed (and built?), can we load the code?
     #     - i.e. can we run `import Foo`
 
@@ -54,18 +58,19 @@ function pull_request_build(data::GitHubAutoMergeData, ::NewVersion; check_licen
             (guideline_pr_only_changes_allowed_files, true),       # 2
             (guideline_sequential_version_number,                  # 3
                 !this_pr_can_use_special_jll_exceptions),
-            (guideline_compat_for_all_deps, true),                 # 4
-            (guideline_patch_release_does_not_narrow_julia_compat, # 5
+            (guideline_compat_for_julia, true),                    # 4
+            (guideline_compat_for_all_deps, true),                 # 5
+            (guideline_patch_release_does_not_narrow_julia_compat, # 6
                 !this_pr_can_use_special_jll_exceptions),
-            (guideline_allowed_jll_nonrecursive_dependencies,      # 6
+            (guideline_allowed_jll_nonrecursive_dependencies,      # 7
                 this_is_jll_package),
             (:update_status, true),
-            (guideline_version_can_be_pkg_added, true),            # 7
-            (guideline_code_can_be_downloaded, true),              # 8
+            (guideline_version_can_be_pkg_added, true),            # 8
+            (guideline_code_can_be_downloaded, true),              # 9
             # `guideline_version_has_osi_license` must be run after
             # `guideline_code_can_be_downloaded` so that it can use the downloaded code!
-            (guideline_version_has_osi_license, check_license),    # 9
-            (guideline_version_can_be_imported, true),             # 10
+            (guideline_version_has_osi_license, check_license),    # 10
+            (guideline_version_can_be_imported, true),             # 11
         ]
 
     checked_guidelines = Guideline[]


### PR DESCRIPTION
This separates the compat checks of Julia from compat of other packages.
1. To make bad Julia compat more visible in the automerge report.
2. To make additional checks, specifically that the upper bound of Julia is not 2 or higher, which is unreasonable at this time.

Currently General has 12 packages with an upper bound of "2" or "2.0". All of these are probably misunderstandings of hyphen ranges, thinking that the upper end is exclusive, e.g. "1.5 - 2.0".

Additional tests of this have not been added yet.
