### PR TITLE
add `read_only` mode

### DIFF
--- a/src/AutoMerge/automerge_comment.jl
+++ b/src/AutoMerge/automerge_comment.jl
@@ -1,5 +1,9 @@
 function update_automerge_comment!(data::GitHubAutoMergeData,
                                    body::AbstractString)::Nothing
+    if data.read_only
+        @info "`read_only` mode; skipping updating automerge comment."
+        return nothing
+    end
     api = data.api
     repo = data.registry
     pr = data.pr

--- a/src/AutoMerge/cron.jl
+++ b/src/AutoMerge/cron.jl
@@ -175,7 +175,8 @@ function cron_or_api_build(api::GitHub.GitHubAPI,
                            new_jll_version_waiting_period,
                            whoami::String,
                            all_statuses::AbstractVector{<:AbstractString},
-                           all_check_runs::AbstractVector{<:AbstractString})
+                           all_check_runs::AbstractVector{<:AbstractString},
+                           read_only::Bool)
     # first, get a list of ALL open pull requests on this repository
     # then, loop through each of them.
     all_currently_open_pull_requests = my_retry(() -> get_all_pull_requests(api, registry, "open"; auth = auth))
@@ -201,7 +202,8 @@ function cron_or_api_build(api::GitHub.GitHubAPI,
                                                  new_jll_version_waiting_period = new_jll_version_waiting_period,
                                                  whoami = whoami,
                                                  all_statuses = all_statuses,
-                                                 all_check_runs = all_check_runs),
+                                                 all_check_runs = all_check_runs,
+                                                 read_only = read_only),
                          num_retries)
             catch ex
                 at_least_one_exception_was_thrown = true
@@ -231,7 +233,8 @@ function cron_or_api_build(api::GitHub.GitHubAPI,
                            new_jll_version_waiting_period,
                            whoami::String,
                            all_statuses::AbstractVector{<:AbstractString},
-                           all_check_runs::AbstractVector{<:AbstractString})
+                           all_check_runs::AbstractVector{<:AbstractString},
+                           read_only::Bool)
     #       first, see if the author is an authorized author. if not, then skip.
     #       next, see if the title matches either the "New Version" regex or
     #               the "New Package regex". if it is not either a new
@@ -355,7 +358,11 @@ function cron_or_api_build(api::GitHub.GitHubAPI,
             @info(string("Pull request: $(pr_number). ",
                          "Type: $(pr_type). ",
                          "Decision: merge now."))
-            my_retry(() -> merge!(api, registry, pr, passed_pr_head_sha; auth = auth))
+            if read_only
+                @info "`read_only` mode on; skipping merge"
+            else
+                my_retry(() -> merge!(api, registry, pr, passed_pr_head_sha; auth = auth))
+            end
         else
             @info(string("Pull request: $(pr_number). ",
                          "Type: $(pr_type). ",
@@ -378,7 +385,11 @@ function cron_or_api_build(api::GitHub.GitHubAPI,
             @info(string("Pull request: $(pr_number). ",
                          "Type: $(pr_type). ",
                          "Decision: merge now."))
-            my_retry(() -> merge!(api, registry, pr, passed_pr_head_sha; auth = auth))
+            if read_only
+                @info "`read_only` mode on; skipping merge"
+            else
+                my_retry(() -> merge!(api, registry, pr, passed_pr_head_sha; auth = auth))
+            end
         else
             @info(string("Pull request: $(pr_number). ",
                          "Type: $(pr_type). ",

--- a/src/AutoMerge/new-package.jl
+++ b/src/AutoMerge/new-package.jl
@@ -1,6 +1,10 @@
 # TODO: This function should probably be moved to some other file,
 #       unless new_package.jl and new_version.jl are merged into one.
 function update_status(data::GitHubAutoMergeData; kwargs...)
+    if data.read_only
+        @info "`read_only` mode; skipping updating the status" 
+        return nothing
+    end
     my_retry(() -> GitHub.create_status(data.api,
                                         data.registry,
                                         data.current_pr_head_commit_sha;

--- a/src/AutoMerge/public.jl
+++ b/src/AutoMerge/public.jl
@@ -29,7 +29,8 @@ function run(env = ENV,
              # which will be checked for UUID collisions in order to
              # mitigate the dependency confusion vulnerability. See
              # the `dependency_confusion.jl` file for details.
-             public_registries::Vector{<:AbstractString} = String[])::Nothing
+             public_registries::Vector{<:AbstractString} = String[],
+             read_only::Bool=false)::Nothing
     all_statuses = deepcopy(additional_statuses)
     all_check_runs = deepcopy(additional_check_runs)
     push!(all_statuses, "automerge/decision")
@@ -77,7 +78,8 @@ function run(env = ENV,
                            whoami = whoami,
                            registry_deps = registry_deps,
                            check_license = check_license,
-                           public_registries = public_registries)
+                           public_registries = public_registries,
+                           read_only = read_only)
     else
         always_assert(run_merge_build)
         cron_or_api_build(api,
@@ -93,7 +95,8 @@ function run(env = ENV,
                           new_jll_version_waiting_period = new_jll_version_waiting_period,
                           whoami = whoami,
                           all_statuses = all_statuses,
-                          all_check_runs = all_check_runs)
+                          all_check_runs = all_check_runs,
+                          read_only = read_only)
     end
     return nothing
 end

--- a/src/AutoMerge/pull-requests.jl
+++ b/src/AutoMerge/pull-requests.jl
@@ -76,7 +76,8 @@ function pull_request_build(api::GitHub.GitHubAPI,
                             suggest_onepointzero::Bool,
                             registry_deps::Vector{<:AbstractString} = String[],
                             check_license::Bool,
-                            public_registries::Vector{<:AbstractString} = String[])::Nothing
+                            public_registries::Vector{<:AbstractString} = String[],
+                            read_only::Bool)::Nothing
     pr = my_retry(() -> GitHub.pull_request(api, registry, pr_number; auth=auth))
     _github_api_pr_head_commit_sha = pull_request_head_sha(pr)
     if current_pr_head_commit_sha != _github_api_pr_head_commit_sha
@@ -97,7 +98,8 @@ function pull_request_build(api::GitHub.GitHubAPI,
                                 whoami=whoami,
                                 registry_deps=registry_deps,
                                 check_license=check_license,
-                                public_registries=public_registries)
+                                public_registries=public_registries,
+                                read_only=read_only)
     return result
 end
 

--- a/src/AutoMerge/pull-requests.jl
+++ b/src/AutoMerge/pull-requests.jl
@@ -116,7 +116,8 @@ function pull_request_build(api::GitHub.GitHubAPI,
                             whoami::String,
                             registry_deps::Vector{<:AbstractString} = String[],
                             check_license::Bool,
-                            public_registries::Vector{<:AbstractString} = String[])::Nothing
+                            public_registries::Vector{<:AbstractString} = String[],
+                            read_only::Bool)::Nothing
     # 1. Check if the PR is open, if not quit.
     # 2. Determine if it is a new package or new version of an
     #    existing package, if neither quit.
@@ -173,7 +174,8 @@ function pull_request_build(api::GitHub.GitHubAPI,
                                suggest_onepointzero = suggest_onepointzero,
                                whoami = whoami,
                                registry_deps = registry_deps,
-                               public_registries = public_registries)
+                               public_registries = public_registries,
+                               read_only = read_only)
     pull_request_build(data, registration_type; check_license=check_license)
     rm(registry_master; force = true, recursive = true)
     return nothing

--- a/src/AutoMerge/types.jl
+++ b/src/AutoMerge/types.jl
@@ -91,6 +91,9 @@ struct GitHubAutoMergeData
     # dependency confusion vulnerability. See the
     # `dependency_confusion.jl` file for details.
     public_registries::Vector{String}
+
+    # whether only read-only actions should be taken
+    read_only::Bool
 end
 
 # Constructor that requires all fields (except `pkg_code_path`) as named arguments.


### PR DESCRIPTION
closes https://github.com/JuliaRegistries/RegistryCI.jl/issues/382

I thought this would be way harder! But also I could've missed something.

I wonder if we can test this by adding a github workflow with read-only permissions like we talked about in https://github.com/JuliaRegistries/General/issues/35514, and then run the regular integration tests on that except with `read_only` set to true. What do you think?