### PR TITLE
Add some checks to make sure that the regex docs never get out of sync

### DIFF
--- a/docs/src/regexes.md
+++ b/docs/src/regexes.md
@@ -67,7 +67,7 @@ for row in rows
     regex_occurs_in_example = occursin(row.regex, row.example)
     if !regex_occurs_in_example
         @error("Regex does not occur in example", row.regex, row.example)
-        throw(ErrorException("Regex $(row.regex) does not occur in example $(row.example)"))
+        throw(ErrorException("Regex `$(row.regex)` does not occur in example \"$(row.example)\""))
     end
 end
 

--- a/docs/src/regexes.md
+++ b/docs/src/regexes.md
@@ -11,21 +11,75 @@ regular expressions:
 import RegistryCI
 import Markdown
 
-const AutoMerge = RegistryCI.AutoMerge
+Base.@kwdef struct TableRow
+    regex::Regex
+    regex_str::String
+    pr_field::String
+    pr_type::String
+    example::String
+end
 
 escape_pipes(str::String) = replace(str, "|" => "\\|")
 
-const new_package_title_regex = AutoMerge.new_package_title_regex |> repr |> escape_pipes
-const new_version_title_regex = AutoMerge.new_version_title_regex |> repr |> escape_pipes
-const commit_regex            = AutoMerge.commit_regex            |> repr |> escape_pipes
+function table_row(; regex::Regex,
+                     pr_field::String,
+                     pr_type::String,
+                     example::String)
+    regex_str = regex |> Base.repr |> escape_pipes
+    result = TableRow(;
+            regex,
+            regex_str,
+            pr_field,
+            pr_type,
+            example,
+        )
+    return result
+end
+
+const row_1 = table_row(;
+    regex = RegistryCI.AutoMerge.new_package_title_regex,
+    pr_field = "PR title",
+    pr_type = "New packages",
+    example = "New package: HelloWorld v1.2.3",
+)
+
+const row_2 = table_row(;
+    regex = RegistryCI.AutoMerge.new_version_title_regex,
+    pr_field = "PR title",
+    pr_type = "New versions",
+    example = "New version: HelloWorld v1.2.3",
+)
+
+const row_3 = table_row(;
+    regex = RegistryCI.AutoMerge.commit_regex,
+    pr_field = "PR body",
+    pr_type = "All",
+    example = "* Commit: mycommithash123",
+)
+
+const rows = [
+    row_1,
+    row_2,
+    row_3,
+]
+
+for row in rows
+    regex_occurs_in_example = occursin(row.regex, row.example)
+    if !regex_occurs_in_example
+        @error("Regex does not occur in example", row.regex, row.example)
+        throw(ErrorException("Regex $(row.regex) does not occur in example $(row.example)"))
+    end
+end
 
 const markdown_lines = String[
-    "| Regex                        | Field    | PR Type      | Example                          |",
-    "| ---------------------------- | -------- | ------------ | -------------------------------- |",
-    "| `$(new_package_title_regex)` | PR title | New packages | `New package: HelloWorld v1.2.3` |",
-    "| `$(new_version_title_regex)` | PR title | New versions | `New version: HelloWorld v1.2.3` |",
-    "| `$(commit_regex)`            | PR body  | All          | `* Commit: mycommithash123`      |",
+    "| Regex | Field | PR Type | Example |",
+    "| ----- | ----- | ------- | ------- |",
 ]
+
+for row in rows
+    line = "| `$(row.regex_str)` | $(row.pr_field) | $(row.pr_type) | `$(row.example)` |"
+    push!(markdown_lines, line)
+end
 
 const markdown_string = join(markdown_lines, "\n")
 const markdown_parsed = Markdown.parse(markdown_string)

--- a/docs/src/regexes.md
+++ b/docs/src/regexes.md
@@ -47,7 +47,7 @@ const row_2 = table_row(;
     regex = RegistryCI.AutoMerge.new_version_title_regex,
     pr_field = "PR title",
     pr_type = "New versions",
-    example = "New version: HelloWorld----- v1.2.3",
+    example = "New version: HelloWorld v1.2.3",
 )
 
 const row_3 = table_row(;

--- a/docs/src/regexes.md
+++ b/docs/src/regexes.md
@@ -40,7 +40,7 @@ const row_1 = table_row(;
     regex = RegistryCI.AutoMerge.new_package_title_regex,
     pr_field = "PR title",
     pr_type = "New packages",
-    example = "New package: HelloWorld v1.2.3",
+    example = "New packageFOOBAR: HelloWorld v1.2.3",
 )
 
 const row_2 = table_row(;

--- a/docs/src/regexes.md
+++ b/docs/src/regexes.md
@@ -47,7 +47,7 @@ const row_2 = table_row(;
     regex = RegistryCI.AutoMerge.new_version_title_regex,
     pr_field = "PR title",
     pr_type = "New versions",
-    example = "New version: HelloWorld v1.2.3",
+    example = "New version: HelloWorld----- v1.2.3",
 )
 
 const row_3 = table_row(;

--- a/docs/src/regexes.md
+++ b/docs/src/regexes.md
@@ -40,7 +40,7 @@ const row_1 = table_row(;
     regex = RegistryCI.AutoMerge.new_package_title_regex,
     pr_field = "PR title",
     pr_type = "New packages",
-    example = "New packageFOOBAR: HelloWorld v1.2.3",
+    example = "New package: HelloWorld v1.2.3",
 )
 
 const row_2 = table_row(;


### PR DESCRIPTION
With this PR, we:
1. Implement the DRY (don't repeat yourself) principle. For example, the regexes are only defined in one place.
2. Make sure that the regex documentation never gets out of sync with the source code.