### PR TITLE
README: remove the Bors badge, and put all other badges into the table

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,11 @@
 # RegistryCI.jl
 
-[![Documentation (stable)][docs-stable-img]][docs-stable-url]
-[![Documentation (dev)][docs-dev-img]][docs-dev-url]
-
-[![Code Coverage][codecov-img]][codecov-url]
-[![Bors][bors-img]][bors-url]
-
-| Test Set          | Status                                                                                  | 
-| ----------------- | --------------------------------------------------------------------------------------- |
-| Unit Tests        | [![Continuous Integration (Unit Tests)][ci-unit-img]][ci-unit-url]                      |
-| Integration Tests | [![Continuous Integration (Integration Tests)][ci-integration-img]][ci-integration-url] |
+| Category          | Status                                                                                                             |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------ |
+| Unit Tests        | [![Continuous Integration (Unit Tests)][ci-unit-img]][ci-unit-url]                                                 |
+| Integration Tests | [![Continuous Integration (Integration Tests)][ci-integration-img]][ci-integration-url]                            |
+| Documentation     | [![Documentation (stable)][docs-stable-img]][docs-stable-url] [![Documentation (dev)][docs-dev-img]][docs-dev-url] |
+| Code Coverage     | [![Code Coverage][codecov-img]][codecov-url]                                                                       |
 
 [docs-stable-img]: https://img.shields.io/badge/docs-stable-blue.svg "Documentation (stable)"
 [docs-stable-url]: https://JuliaRegistries.github.io/RegistryCI.jl/stable


### PR DESCRIPTION
Closes #403 

The Bors badge is static (i.e. the content never changes), so I went ahead and removed it.

I put everything else into the table. The docs badges are not very big, so I put both of them into the same cell.