### PR TITLE
Auto-generate the documentation page with the list of AutoMerge guidelines

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryCI"
 uuid = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
 authors = ["Dilum Aluthge <dilum@aluthge.com>", "Fredrik Ekre <ekrefredrik@gmail.com>", "contributors"]
-version = "7.0.2"
+version = "7.1.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -26,5 +26,5 @@ makedocs(;
 
 deploydocs(;
     repo="github.com/JuliaRegistries/RegistryCI.jl",
-    push_preview=true, # TODO: turn this back to false
+    push_preview=false,
 )

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -26,4 +26,5 @@ makedocs(;
 
 deploydocs(;
     repo="github.com/JuliaRegistries/RegistryCI.jl",
+    push_preview=true, # TODO: turn this back to false
 )

--- a/docs/src/guidelines.md
+++ b/docs/src/guidelines.md
@@ -17,7 +17,7 @@ function guidelines_to_markdown_output(guidelines_function::Function)
         this_pr_can_use_special_jll_exceptions = false,
     )
     filter!(x -> x[1] != :update_status, guidelines)
-    filter!(x -> x[1].include_in_docs, guidelines)
+    filter!(x -> !(x[1].docs isa Nothing), guidelines)
     docs = [rstrip(x[1].docs) for x in guidelines]
     output_string = join(string.(collect(1:length(docs)), Ref(". "), docs), "\n")
     output_markdown = Markdown.parse(output_string)
@@ -43,8 +43,8 @@ function guidelines_to_markdown_output(guidelines_function::Function)
         this_pr_can_use_special_jll_exceptions = false,
     )
     filter!(x -> x[1] != :update_status, guidelines)
-    filter!(x -> x[1].include_in_docs, guidelines)
-    docs = [x[1].docs for x in guidelines]
+    filter!(x -> !(x[1].docs isa Nothing), guidelines)
+    docs = [rstrip(x[1].docs) for x in guidelines]
     output_string = join(string.(collect(1:length(docs)), Ref(". "), docs), "\n")
     output_markdown = Markdown.parse(output_string)
     return output_markdown

--- a/docs/src/guidelines.md
+++ b/docs/src/guidelines.md
@@ -4,5 +4,115 @@ CurrentModule = RegistryCI
 
 # Automatic merging guidelines
 
-For the list of automatic merging (AutoMerge) guidelines, please see the
-[General registry README](https://github.com/JuliaRegistries/General/blob/master/README.md#automatic-merging-of-pull-requests).
+## New packages
+
+```@eval
+import RegistryCI
+import Markdown
+
+function guidelines_to_markdown_output(guidelines_function::Function)
+    guidelines = guidelines_function(;
+        check_license = true,
+        this_is_jll_package = false,
+        this_pr_can_use_special_jll_exceptions = false,
+    )
+    filter!(x -> x[1] != :update_status, guidelines)
+    filter!(x -> x[1].include_in_docs, guidelines)
+    docs = [rstrip(x[1].docs) for x in guidelines]
+    output_string = join(string.(collect(1:length(docs)), Ref(". "), docs), "\n")
+    output_markdown = Markdown.parse(output_string)
+    return output_markdown
+end
+
+const guidelines_function = RegistryCI.AutoMerge.get_automerge_guidelines_new_packages
+const output_markdown = guidelines_to_markdown_output(guidelines_function)
+
+return output_markdown
+```
+
+## New versions of existing packages
+
+```@eval
+import RegistryCI
+import Markdown
+
+function guidelines_to_markdown_output(guidelines_function::Function)
+    guidelines = guidelines_function(;
+        check_license = true,
+        this_is_jll_package = false,
+        this_pr_can_use_special_jll_exceptions = false,
+    )
+    filter!(x -> x[1] != :update_status, guidelines)
+    filter!(x -> x[1].include_in_docs, guidelines)
+    docs = [x[1].docs for x in guidelines]
+    output_string = join(string.(collect(1:length(docs)), Ref(". "), docs), "\n")
+    output_markdown = Markdown.parse(output_string)
+    return output_markdown
+end
+
+const guidelines_function = RegistryCI.AutoMerge.get_automerge_guidelines_new_versions
+const output_markdown = guidelines_to_markdown_output(guidelines_function)
+
+return output_markdown
+```
+
+## Additional information
+
+### Upper-bounded `[compat]` entries
+
+For example, the following `[compat]` entries meet the criteria for automatic merging:
+```toml
+[compat]
+PackageA = "1"          # [1.0.0, 2.0.0), has upper bound (good)
+PackageB = "0.1, 0.2"   # [0.1.0, 0.3.0), has upper bound (good)
+```
+The following `[compat]` entries do NOT meet the criteria for automatic merging:
+```toml
+[compat]
+PackageC = ">=3"        # [3.0.0, ∞), no upper bound (bad)
+PackageD = ">=0.4, <1"  # [0, ∞), no lower bound, no upper bound (very bad)
+```
+Please note: each `[compat]` entry must include only a finite number of breaking releases. Therefore, the following `[compat]` entries do NOT meet the criteria for automatic merging:
+```toml
+[compat]
+PackageE = "0"          # includes infinitely many breaking 0.x releases of PackageE (bad)
+PackageF = "0.2 - 0"    # includes infinitely many breaking 0.x releases of PackageF (bad)
+PackageG = "0.2 - 1"    # includes infinitely many breaking 0.x releases of PackageG (bad)
+```
+See [Pkg's documentation](https://julialang.github.io/Pkg.jl/v1/compatibility/) for specification of `[compat]` entries in your
+`Project.toml` file.
+
+(**Note:** Standard libraries are excluded for this criterion since they are bundled
+with Julia, and, hence, implicitly included in the `[compat]` entry for Julia.
+For the time being, JLL dependencies are also excluded for this criterion because they
+often have non-standard version numbering schemes; however, this may change in the future.)
+
+You may find [CompatHelper.jl](https://github.com/bcbi/CompatHelper.jl) and [PackageCompatUI.jl](https://github.com/GunnarFarneback/PackageCompatUI.jl) helpful for maintaining up-to-date `[compat]` entries.
+
+### Name similarity distance check
+
+These checks and tolerances are subject to change in order to improve the
+process.
+
+To test yourself that a tentative package name, say `MyPackage` meets these
+checks, you can use the following code (after adding the RegistryCI package
+to your Julia environment):
+
+```julia
+using RegistryCI
+using RegistryCI.AutoMerge
+all_pkg_names = AutoMerge.get_all_non_jll_package_names(path_to_registry)
+AutoMerge.meets_distance_check("MyPackage", all_pkg_names)
+```
+
+where `path_to_registry` is a path to the folder containing the registry of
+interest. For the General Julia registry, usually `path_to_registry =
+joinpath(DEPOT_PATH[1], "registries", "General")` if you haven't changed
+your `DEPOT_PATH`. This will return a boolean, indicating whether or not
+your tentative package name passed the check, as well as a string,
+indicating what the problem is in the event the check did not pass.
+
+Note that these automerge guidelines are deliberately conservative: it is
+very possible for a perfectly good name to not pass the automatic checks and
+require manual merging. They simply exist to provide a fast path so that
+manual review is not required for every new package.

--- a/src/AutoMerge/AutoMerge.jl
+++ b/src/AutoMerge/AutoMerge.jl
@@ -17,26 +17,25 @@ import RegistryTools
 import ..RegistryCI
 import Tar
 
-include("assert.jl")
-
 include("types.jl")
-
 include("ciservice.jl")
-include("public.jl")
 
 include("api_rate_limiting.jl")
+include("assert.jl")
 include("automerge_comment.jl")
 include("changed_files.jl")
 include("cron.jl")
+include("dependency_confusion.jl")
 include("github.jl")
 include("guidelines.jl")
 include("jll.jl")
 include("new-package.jl")
 include("new-version.jl")
 include("not-automerge-applicable.jl")
+include("public.jl")
 include("pull-requests.jl")
 include("semver.jl")
+include("update_status.jl")
 include("util.jl")
-include("dependency_confusion.jl")
 
 end # module

--- a/src/AutoMerge/assert.jl
+++ b/src/AutoMerge/assert.jl
@@ -1,6 +1,3 @@
-struct AlwaysAssertionError <: Exception
-    msg::String
-end
 AlwaysAssertionError() = AlwaysAssertionError("")
 
 # The documentation for the `Base.@assert` macro says: "Warning: An assert might be

--- a/src/AutoMerge/changed_files.jl
+++ b/src/AutoMerge/changed_files.jl
@@ -16,14 +16,17 @@ function allowed_changed_files(::NewVersion, pkg::String)
     return result
 end
 
-const guideline_pr_only_changes_allowed_files =
-    Guideline("Only modifies the files that it's allowed to modify",
-              data -> pr_only_changes_allowed_files(data.api,
-                                                    data.registration_type,
-                                                    data.registry,
-                                                    data.pr,
-                                                    data.pkg;
-                                                    auth = data.auth))
+const guideline_pr_only_changes_allowed_files = Guideline(;
+    info = "Only modifies the files that it's allowed to modify",
+    include_in_docs = false,
+    check = data -> pr_only_changes_allowed_files(data.api,
+        data.registration_type,
+        data.registry,
+        data.pr,
+        data.pkg;
+        auth = data.auth,
+    ),
+)
 
 function pr_only_changes_allowed_files(api::GitHub.GitHubAPI,
                                        t::Union{NewPackage, NewVersion},

--- a/src/AutoMerge/changed_files.jl
+++ b/src/AutoMerge/changed_files.jl
@@ -17,8 +17,8 @@ function allowed_changed_files(::NewVersion, pkg::String)
 end
 
 const guideline_pr_only_changes_allowed_files = Guideline(;
-    info = "Only modifies the files that it's allowed to modify",
-    include_in_docs = false,
+    info = "Only modifies the files that it's allowed to modify.",
+    docs = nothing,
     check = data -> pr_only_changes_allowed_files(data.api,
         data.registration_type,
         data.registry,

--- a/src/AutoMerge/dependency_confusion.jl
+++ b/src/AutoMerge/dependency_confusion.jl
@@ -3,7 +3,7 @@
 
 const guideline_dependency_confusion = Guideline(;
     info = "No UUID conflict with other registries.",
-    include_in_docs = false,
+    docs = nothing,
     check = data -> has_no_dependency_confusion(
         data.pkg,
         data.registry_head,

--- a/src/AutoMerge/dependency_confusion.jl
+++ b/src/AutoMerge/dependency_confusion.jl
@@ -1,11 +1,15 @@
 # TODO: Add a more thorough explanation of the dependency confusion
 # vulnerability and how this guideline mitigates it.
 
-const guideline_dependency_confusion =
-    Guideline("No UUID conflict with other registries.",
-              data -> has_no_dependency_confusion(data.pkg,
-                                                  data.registry_head,
-                                                  data.public_registries))
+const guideline_dependency_confusion = Guideline(;
+    info = "No UUID conflict with other registries.",
+    include_in_docs = false,
+    check = data -> has_no_dependency_confusion(
+        data.pkg,
+        data.registry_head,
+        data.public_registries,
+    ),
+)
 
 # TODO: Needs a strategy to handle connection failures for the public
 # registries. Preferably they should also be cloned only once and then

--- a/src/AutoMerge/guidelines.jl
+++ b/src/AutoMerge/guidelines.jl
@@ -2,7 +2,7 @@ import HTTP
 
 const guideline_registry_consistency_tests_pass = Guideline(;
     info = "Registy consistency tests",
-    include_in_docs = false,
+    docs = nothing,
     check = data -> meets_registry_consistency_tests_pass(
         data.registry_head,
         data.registry_deps,
@@ -24,7 +24,7 @@ const guideline_compat_for_julia = Guideline(;
     info = "Compat with upper bound for julia",
     docs = string(
         "There is an upper-bounded `[compat]` entry for `julia` that ",
-        "only includes a finite number of breaking releases of Julia",
+        "only includes a finite number of breaking releases of Julia.",
     ),
     check = data -> meets_compat_for_julia(
         data.registry_head,
@@ -70,7 +70,7 @@ const guideline_compat_for_all_deps = Guideline(;
     docs = string(
         "Dependencies: All dependencies should have `[compat]` entries that ",
         "are upper-bounded and only include a finite number of breaking releases. ",
-        "For more information, please see the \"Name similarity distance check\" subsection under the \"Additional information\" section below.",
+        "For more information, please see the \"Upper bounded `[compat]` entries\" subsection under \"Additional information\" below.",
     ),
     check = data -> meets_compat_for_all_deps(
         data.registry_head,
@@ -204,8 +204,7 @@ function meets_name_length(pkg)
 end
 
 const guideline_name_ascii = Guideline(;
-    info = "Name is composed of ASCII characters only",
-    docs = "Name is composed of ASCII characters only",
+    info = "Name is composed of ASCII characters only.",
     check = data -> meets_name_ascii(data.pkg),
 )
 
@@ -218,7 +217,7 @@ function meets_name_ascii(pkg)
 end
 
 const guideline_julia_name_check = Guideline(;
-    info = "Name does not include \"julia\" or start with \"Ju\"",
+    info = "Name does not include \"julia\" or start with \"Ju\".",
     check = data -> meets_julia_name_check(data.pkg),
 )
 
@@ -238,7 +237,7 @@ sqrt_normalized_vd(name1, name2) = VisualStringDistances.visual_distance(name1, 
 const guideline_distance_check = Guideline(;
     info = "Name is not too similar to existing package names",
     docs = """
-  To prevent confusion between similarly named packages, the names of new packages must also satisfy the following three checks: (for more information, please see the \"Name similarity distance check\" subsection under the \"Additional information\" section below)
+  To prevent confusion between similarly named packages, the names of new packages must also satisfy the following three checks: (for more information, please see the \"Name similarity distance check\" subsection under \"Additional information\" below)
       - the [Damerau–Levenshtein
         distance](https://en.wikipedia.org/wiki/Damerau%E2%80%93Levenshtein_distance)
         between the package name and the name of any existing package must be at
@@ -339,7 +338,7 @@ const guideline_normal_capitalization = Guideline(;
     docs = string(
         "The package name should start with an uppercase letter, ",
         "contain only ASCII alphanumeric characters, ",
-        "and contain at least one lowercase letter",
+        "and contain at least one lowercase letter.",
     ),
     check = data -> meets_normal_capitalization(data.pkg),
 )
@@ -354,7 +353,7 @@ function meets_normal_capitalization(pkg)
 end
 
 const guideline_repo_url_requirement = Guideline(;
-    info = "Repo URL ends with /PackageName.jl.git",
+    info = "Repo URL ends with `/PackageName.jl.git`.",
     check = data -> meets_repo_url_requirement(
         data.pkg;
         registry_head = data.registry_head,
@@ -452,7 +451,7 @@ function meets_sequential_version_number(pkg::String,
 end
 
 const guideline_standard_initial_version_number = Guideline(;
-    info = "Standard initial version number. Must be one of: 0.0.1, 0.1.0, 1.0.0, or X.0.0",
+    info = "Standard initial version number. Must be one of: `0.0.1`, `0.1.0`, `1.0.0`, or `X.0.0`.",
     check = data -> meets_standard_initial_version_number(data.version),
 )
 
@@ -477,8 +476,7 @@ function _is_x_0_0(version::VersionNumber)
 end
 
 const guideline_code_can_be_downloaded = Guideline(;
-    info = "Code can be downloaded",
-    docs = "Code can be downloaded",
+    info = "Code can be downloaded.",
     check = data -> meets_code_can_be_downloaded(data.registry_head, data.pkg, data.version, data.pr; pkg_code_path = data.pkg_code_path),
 )
 
@@ -526,7 +524,7 @@ is_valid_url(str::AbstractString) = !isempty(HTTP.URI(str).scheme) && isvalid(HT
 
 const guideline_version_can_be_pkg_added = Guideline(;
     info = "Version can be `Pkg.add`ed",
-    docs = "Package installation: The package should be installable (`Pkg.add(\"PackageName\")`)",
+    docs = "Package installation: The package should be installable (`Pkg.add(\"PackageName\")`).",
     check = data -> meets_version_can_be_pkg_added(
         data.registry_head,
         data.pkg,
@@ -582,7 +580,7 @@ const guideline_version_has_osi_license = Guideline(;
         "License: The package should have an ",
         "[OSI-approved software license](https://opensource.org/licenses/alphabetical) ",
         "located in the top-level directory of the package code, ",
-        "e.g. in a file named `LICENSE` or `LICENSE.md`",
+        "e.g. in a file named `LICENSE` or `LICENSE.md`.",
     ),
     check = data -> meets_version_has_osi_license(
         data.pkg;
@@ -629,7 +627,7 @@ end
 
 const guideline_version_can_be_imported = Guideline(;
     info = "Version can be `import`ed",
-    docs = "Package loading: The package should be loadable (`import PackageName`)",
+    docs = "Package loading: The package should be loadable (`import PackageName`).",
     check = data -> meets_version_can_be_imported(
         data.registry_head,
         data.pkg,

--- a/src/AutoMerge/jll.jl
+++ b/src/AutoMerge/jll.jl
@@ -18,11 +18,19 @@ function _get_all_dependencies_nonrecursive(working_directory::AbstractString,
     return all_dependencies
 end
 
-const guideline_allowed_jll_nonrecursive_dependencies =
-    Guideline("If this is a JLL package, only deps are Pkg, Libdl, and other JLL packages",
-              data -> meets_allowed_jll_nonrecursive_dependencies(data.registry_head,
-                                                                  data.pkg,
-                                                                  data.version))
+const guideline_allowed_jll_nonrecursive_dependencies = Guideline(;
+    info = "If this is a JLL package, only deps are Pkg, Libdl, and other JLL packages",
+    docs = """
+    If this is a JLL package, only deps are Pkg, Libdl, and other JLL packages
+    """,
+    include_in_docs = false,
+    check = data -> meets_allowed_jll_nonrecursive_dependencies(
+        data.registry_head,
+        data.pkg,
+        data.version,
+    ),
+)
+
 
 function meets_allowed_jll_nonrecursive_dependencies(working_directory::AbstractString,
                                                      pkg,

--- a/src/AutoMerge/jll.jl
+++ b/src/AutoMerge/jll.jl
@@ -20,10 +20,7 @@ end
 
 const guideline_allowed_jll_nonrecursive_dependencies = Guideline(;
     info = "If this is a JLL package, only deps are Pkg, Libdl, and other JLL packages",
-    docs = """
-    If this is a JLL package, only deps are Pkg, Libdl, and other JLL packages
-    """,
-    include_in_docs = false,
+    docs = nothing,
     check = data -> meets_allowed_jll_nonrecursive_dependencies(
         data.registry_head,
         data.pkg,

--- a/src/AutoMerge/new-package.jl
+++ b/src/AutoMerge/new-package.jl
@@ -1,75 +1,4 @@
-# TODO: This function should probably be moved to some other file,
-#       unless new_package.jl and new_version.jl are merged into one.
-function update_status(data::GitHubAutoMergeData; kwargs...)
-    if data.read_only
-        @info "`read_only` mode; skipping updating the status" 
-        return nothing
-    end
-    my_retry(() -> GitHub.create_status(data.api,
-                                        data.registry,
-                                        data.current_pr_head_commit_sha;
-                                        auth = data.auth,
-                                        params = Dict(kwargs...)))
-end
-
 function pull_request_build(data::GitHubAutoMergeData, ::NewPackage; check_license)::Nothing
-    # Rules:
-    # 1. Registry consistency tests pass
-    # 2.  Only changes a subset of the following files:
-    #         - `Registry.toml`,
-    #         - `E/Example/Compat.toml`
-    #         - `E/Example/Deps.toml`
-    #         - `E/Example/Package.toml`
-    #         - `E/Example/Versions.toml`
-    # 3.  TODO: implement this check. When implemented, this check will make sure that the changes to `Registry.toml` only modify the specified package.
-    # 4.  Normal capitalization
-    #         - name should match r"^[A-Z]\w*[a-z]\w*[0-9]?$"
-    #         - i.e. starts with a capital letter, ASCII alphanumerics only, contains at least 1 lowercase letter
-    # 5.  Not too short
-    #         - at least five letters
-    #         - you can register names shorter than this, but doing so requires someone to approve
-    # 6.  Meets julia name check
-    #         - does not include the string "julia" with any case
-    #         - does not start with "Ju"
-    # 7.  DISABLED. Standard initial version number - one of 0.0.1, 0.1.0, 1.0.0, X.0.0
-    #         - does not apply to JLL packages
-    # 8.  Repo URL ends with /$name.jl.git where name is the package name. We only apply this check if the package is not a subdirectory package.
-    # 9.  Compat for Julia
-    #         - there should be a [compat] entry for Julia
-    #         - the Julia [compat] should have an upper bound
-    #         - the Julia [compat] upper bound must have major version 1
-    # 10.  Compat for all dependencies
-    #         - there should be a [compat] entry for Julia
-    #         - all [deps] should also have [compat] entries
-    #         - all [compat] entries should have upper bounds
-    #         - dependencies that are standard libraries do not need [compat] entries
-    #         - dependencies that are JLL packages do not need [compat] entries
-    # 11. (only applies to JLL packages) The only dependencies of the package are:
-    #         - Pkg
-    #         - Libdl
-    #         - other JLL packages
-    # 12. Package's name has only ASCII characters
-    # 13. Version can be installed
-    #         - given the proposed changes to the registry, can we resolve and install the new version of the package?
-    #         - i.e. can we run `Pkg.add("Foo")`
-    # 14. Package code can be downloaded. Can we `git clone` the repo and get the files corresponding to the tree hash in the PR?
-    #       - and does that tree hash match what we get by looking at the subdir + commit the registration was triggered from?
-    # 15. Package repository contains only OSI-approved license(s) in the license file at toplevel in the version being registered
-    # 16. Version can be loaded
-    #         - once it's been installed (and built?), can we load the code?
-    #         - i.e. can we run `import Foo`
-    # 17. Dependency confusion check
-    #         - Package UUID doesn't conflict with an UUID in the provided
-    #           list of package registries. The exception is if also the
-    #           package name *and* package URL matches those in the other
-    #           registry, in which case this is a valid co-registration.
-    # 18. Package's name is sufficiently far from existing package names in the registry
-    #         - We always run this check last.
-    #         - We exclude JLL packages from the "existing names"
-    #         - We use three checks:
-    #             i. that the lowercased name is at least 1 away in Damerau Levenshtein distance from any other lowercased name
-    #             ii. that the name is at least 2 away in Damerau Levenshtein distance from any other name
-    #             iii. that the name is sufficiently far in a visual distance from any other name
     this_is_jll_package = is_jll_name(data.pkg)
     @info("This is a new package pull request",
           pkg = data.pkg,
@@ -84,47 +13,11 @@ function pull_request_build(data::GitHubAutoMergeData, ::NewPackage; check_licen
     this_pr_can_use_special_jll_exceptions =
         this_is_jll_package && data.authorization == :jll
 
-    # Each element is a tuple of a guideline and whether it's
-    # applicable. Instead of a guideline there can be the symbol
-    # `:update_status` in which case the PR status will be updated
-    # with the results so far before continuing to the following
-    # guidelines.
-    guidelines =
-        [
-            (guideline_registry_consistency_tests_pass, true),  # 1
-            (guideline_pr_only_changes_allowed_files, true),    # 2
-            # (guideline_only_changes_specified_package, true), # 3 (unimplemented)
-            (guideline_normal_capitalization,                   # 4
-                !this_pr_can_use_special_jll_exceptions),
-            (guideline_name_length,                             # 5
-                !this_pr_can_use_special_jll_exceptions),
-            (guideline_julia_name_check, true),                 # 6
-            # (guideline_standard_initial_version_number,       # 7 (deactivated)
-            #     !this_pr_can_use_special_jll_exceptions),
-            (guideline_repo_url_requirement, true),             # 8
-            (guideline_compat_for_julia, true),                 # 9
-            (guideline_compat_for_all_deps, true),              # 10
-            (guideline_allowed_jll_nonrecursive_dependencies,   # 11
-                this_is_jll_package),
-            (guideline_name_ascii, true),                       # 12
-            (:update_status, true),
-            (guideline_version_can_be_pkg_added, true),         # 13
-            (guideline_code_can_be_downloaded, true),           # 14
-            # `guideline_version_has_osi_license` must be run
-            # after `guideline_code_can_be_downloaded` so
-            # that it can use the downloaded code!
-            (guideline_version_has_osi_license, check_license), # 15
-            (guideline_version_can_be_imported, true),          # 16
-            (:update_status, true),
-            (guideline_dependency_confusion, true),             # 17
-            # We always run the `guideline_distance_check`
-            # check last, because if the check fails, it
-            # prints the list of similar package names in
-            # the automerge comment. To make the comment easy
-            # to read, we want this list to be at the end.
-            (guideline_distance_check, true),                   # 18
-         ]
-
+    guidelines = get_automerge_guidelines_new_packages(;
+        check_license = check_license,
+        this_is_jll_package = this_is_jll_package,
+        this_pr_can_use_special_jll_exceptions = this_pr_can_use_special_jll_exceptions,
+    )
     checked_guidelines = Guideline[]
 
     for (guideline, applicable) in guidelines

--- a/src/AutoMerge/new-version.jl
+++ b/src/AutoMerge/new-version.jl
@@ -1,38 +1,4 @@
 function pull_request_build(data::GitHubAutoMergeData, ::NewVersion; check_license)::Nothing
-    # Rules:
-    # 1. Registry consistency tests pass
-    # 2. Only changes a subset of the following files:
-    #     - `E/Example/Compat.toml`
-    #     - `E/Example/Deps.toml`
-    #     - `E/Example/Versions.toml`
-    # 3. Sequential version number
-    #     - if the last version was 1.2.3 then the next can be 1.2.4, 1.3.0 or 2.0.0
-    #     - does not apply to JLL packages
-    # 4.  Compat for Julia
-    #         - there should be a [compat] entry for Julia
-    #         - the Julia [compat] should have an upper bound
-    #         - the Julia [compat] upper bound must have major version 1
-    # 5. Compat for all dependencies
-    #     - there should be a [compat] entry for Julia
-    #     - all [deps] should also have [compat] entries
-    #     - all [compat] entries should have upper bounds
-    #     - dependencies that are standard libraries do not need [compat] entries
-    #     - dependencies that are JLL packages do not need [compat] entries
-    # 6. If it is a patch release, then it does not narrow the Julia compat range
-    # 7. (only applies to JLL packages) The only dependencies of the package are:
-    #     - Pkg
-    #     - Libdl
-    #     - other JLL packages
-    # 8. Version can be installed
-    #     - given the proposed changes to the registry, can we resolve and install the new version of the package?
-    #     - i.e. can we run `Pkg.add("Foo")`
-    # 9. Package code can be downloaded. Can we `git clone` the repo and get the files corresponding to the tree hash in the PR?
-    #       - and does that tree hash match what we get by looking at the subdir + commit the registration was triggered from?
-    # 10. Package repository contains only OSI-approved license(s) in the license file at toplevel in the version being registered
-    # 11. Version can be loaded
-    #     - once it's been installed (and built?), can we load the code?
-    #     - i.e. can we run `import Foo`
-
     this_is_jll_package = is_jll_name(data.pkg)
     @info("This is a new package pull request",
           pkg = data.pkg,
@@ -47,32 +13,11 @@ function pull_request_build(data::GitHubAutoMergeData, ::NewVersion; check_licen
     this_pr_can_use_special_jll_exceptions =
         this_is_jll_package && data.authorization == :jll
 
-    # Each element is a tuple of a guideline and whether it's
-    # applicable. Instead of a guideline there can be the symbol
-    # `:update_status` in which case the PR status will be updated
-    # with the results so far before continuing to the following
-    # guidelines.
-    guidelines =
-        [
-            (guideline_registry_consistency_tests_pass, true),     # 1
-            (guideline_pr_only_changes_allowed_files, true),       # 2
-            (guideline_sequential_version_number,                  # 3
-                !this_pr_can_use_special_jll_exceptions),
-            (guideline_compat_for_julia, true),                    # 4
-            (guideline_compat_for_all_deps, true),                 # 5
-            (guideline_patch_release_does_not_narrow_julia_compat, # 6
-                !this_pr_can_use_special_jll_exceptions),
-            (guideline_allowed_jll_nonrecursive_dependencies,      # 7
-                this_is_jll_package),
-            (:update_status, true),
-            (guideline_version_can_be_pkg_added, true),            # 8
-            (guideline_code_can_be_downloaded, true),              # 9
-            # `guideline_version_has_osi_license` must be run after
-            # `guideline_code_can_be_downloaded` so that it can use the downloaded code!
-            (guideline_version_has_osi_license, check_license),    # 10
-            (guideline_version_can_be_imported, true),             # 11
-        ]
-
+    guidelines = get_automerge_guidelines_new_versions(;
+        check_license = check_license,
+        this_is_jll_package = this_is_jll_package,
+        this_pr_can_use_special_jll_exceptions = this_pr_can_use_special_jll_exceptions,
+    )
     checked_guidelines = Guideline[]
 
     for (guideline, applicable) in guidelines

--- a/src/AutoMerge/types.jl
+++ b/src/AutoMerge/types.jl
@@ -1,3 +1,7 @@
+struct AlwaysAssertionError <: Exception
+    msg::String
+end
+
 struct NewPackage end
 struct NewVersion end
 
@@ -106,26 +110,26 @@ function GitHubAutoMergeData(; kwargs...)
     return GitHubAutoMergeData(getindex.(Ref(kwargs), fields)...)
 end
 
-mutable struct Guideline
+Base.@kwdef mutable struct Guideline
     # Short description of the guideline. Only used for logging.
     info::String
+
+    # Documentation for the guideline
+    docs::String = info
+
+    include_in_docs::Bool = true
+
     # Function that is run in order to determine whether a guideline
     # is met. Input is an instance of `GitHubAutoMergeData` and output
     # is passed status plus a user facing message explaining the
     # guideline result.
     check::Function
-    # Saved result of the `check` function.
-    passed::Bool
-    # Saved output message from the `check` function.
-    message::String
-end
 
-function Guideline(info::String, check::Function)
-    # This initial status and message are overwritten when the check
-    # has been run.
-    passed = false
-    message = "Internal error. A check that was supposed to run never did: $info"
-    return Guideline(info, check, passed, message)
+    # Saved result of the `check` function.
+    passed::Bool = false
+
+    # Saved output message from the `check` function.
+    message::String = "Internal error. A check that was supposed to run never did: $(info)"
 end
 
 passed(guideline::Guideline) = guideline.passed

--- a/src/AutoMerge/types.jl
+++ b/src/AutoMerge/types.jl
@@ -115,9 +115,7 @@ Base.@kwdef mutable struct Guideline
     info::String
 
     # Documentation for the guideline
-    docs::String = info
-
-    include_in_docs::Bool = true
+    docs::Union{String,Nothing} = info
 
     # Function that is run in order to determine whether a guideline
     # is met. Input is an instance of `GitHubAutoMergeData` and output

--- a/src/AutoMerge/update_status.jl
+++ b/src/AutoMerge/update_status.jl
@@ -1,0 +1,11 @@
+function update_status(data::GitHubAutoMergeData; kwargs...)
+    if data.read_only
+        @info "`read_only` mode; skipping updating the status"
+        return nothing
+    end
+    my_retry(() -> GitHub.create_status(data.api,
+                                        data.registry,
+                                        data.current_pr_head_commit_sha;
+                                        auth = data.auth,
+                                        params = Dict(kwargs...)))
+end


### PR DESCRIPTION
Currently, we duplicate a lot of this information. For example, the guidelines themselves are defined in the source code of the `RegistryCI.jl` package (specifically in the `RegistryCI.AutoMerge` submodule), but the documentation of the guidelines is in the [General registry README](https://github.com/JuliaRegistries/General/blob/master/README.md).

With this PR, I attempt to implement the [don't repeat yourself (DRY)](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) principle by centralizing the definition of the guidelines and their documentation into a single place, specifically the AutoMerge source code, which is now the single source of truth.

Then, we use the AutoMerge source code to auto-generate a documentation page that has the list of AutoMerge guidelines.

Once this PR is merged and a new version of RegistryCI has been tagged, we can remove the list of AutoMerge guidelines from the [General registry README](https://github.com/JuliaRegistries/General/blob/master/README.md) and replace it with a link to the appropriate RegistryCI.jl documentation page.