### PR TITLE
A few tweaks to the docs for AutoMerge guidelines

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryCI"
 uuid = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
 authors = ["Dilum Aluthge <dilum@aluthge.com>", "Fredrik Ekre <ekrefredrik@gmail.com>", "contributors"]
-version = "7.1.4"
+version = "7.1.5"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/docs/src/guidelines.md
+++ b/docs/src/guidelines.md
@@ -4,6 +4,12 @@ CurrentModule = RegistryCI
 
 # Automatic merging guidelines
 
+These are the guidelines that a pull request must pass in order to be automatically merged.
+
+All of those guidelines are enabled on the General registry.
+
+For private registries, some of these guidelines can be disabled.
+
 ## New packages
 
 ```@eval

--- a/docs/src/guidelines.md
+++ b/docs/src/guidelines.md
@@ -8,7 +8,7 @@ These are the guidelines that a pull request must pass in order to be automatica
 
 All of those guidelines are enabled on the General registry.
 
-For private registries, some of these guidelines can be disabled.
+For other registries, some of these guidelines can be disabled.
 
 ## New packages
 

--- a/src/AutoMerge/guidelines.jl
+++ b/src/AutoMerge/guidelines.jl
@@ -591,7 +591,9 @@ const guideline_version_has_osi_license = Guideline(;
         "License: The package should have an ",
         "[OSI-approved software license](https://opensource.org/licenses/alphabetical) ",
         "located in the top-level directory of the package code, ",
-        "e.g. in a file named `LICENSE` or `LICENSE.md`.",
+        "e.g. in a file named `LICENSE` or `LICENSE.md`. ",
+        "This check is required for the General registry. ",
+        "For private registries, registry maintainers have the option to disable this check.",
     ),
     check = data -> meets_version_has_osi_license(
         data.pkg;

--- a/src/AutoMerge/guidelines.jl
+++ b/src/AutoMerge/guidelines.jl
@@ -593,7 +593,7 @@ const guideline_version_has_osi_license = Guideline(;
         "located in the top-level directory of the package code, ",
         "e.g. in a file named `LICENSE` or `LICENSE.md`. ",
         "This check is required for the General registry. ",
-        "For private registries, registry maintainers have the option to disable this check.",
+        "For other registries, registry maintainers have the option to disable this check.",
     ),
     check = data -> meets_version_has_osi_license(
         data.pkg;


### PR DESCRIPTION
I've bumped the version number because the `stable` docs link is not updated unless we register and tag a new release.