### PR TITLE
relax `_include_this_registry` check

### DIFF
--- a/src/registry_testing.jl
+++ b/src/registry_testing.jl
@@ -30,13 +30,12 @@ function _include_this_registry(
     end
     for fieldvalue in all_fieldvalues
         for registry_deps_name in registry_deps_names
-            if strip(fieldvalue) == strip(registry_deps_name)
-                return true
-            end
-            if strip(fieldvalue) == strip("$(registry_deps_name).git")
-                return true
-            end
-            if strip("$(fieldvalue).git") == strip(registry_deps_name)
+            fieldvalue = strip(fieldvalue)
+            registry_deps_name = strip(registry_deps_name)
+            ref = Set((lowercase(basename(fieldvalue)), fieldvalue, "$(fieldvalue).git"))
+            dep = Set((lowercase(basename(registry_deps_name)), registry_deps_name, "$(registry_deps_name).git"))
+            @debug "Registry match check" registry_spec=ref extra_deps=dep
+            if !isempty(intersect(ref, dep))
                 return true
             end
         end


### PR DESCRIPTION
Sometimes one might prefer to use a fork URL for various reasons(e.g., private network, slow connection to GitHub). The current `_include_this_registry` check fails silently by returning false. This causes some hard to figure error:

```julia
url = "https://github.com/johnnychen94/General.git"
RegistryCI.test(registry_deps=[url])

┌ Error: It is not the case that all dependencies exist in the General registry
│   setdiff(depuuids, alluuids) =
│    Set{Base.UUID} with 1 element:
│      UUID("6fe1bfb0-de20-5000-8ca7-80f57d26f881")
└ @ RegistryCI ~/.julia/packages/RegistryCI/Nj1Mv/src/registry_testing.jl:187
BlockMatching: Test Failed at /Users/jc/.julia/packages/RegistryCI/Nj1Mv/src/registry_testing.jl:189
  Expression: depuuids ⊆ alluuids
   Evaluated: Set(Base.UUID[UUID("6fe1bfb0-de20-5000-8ca7-80f57d26f881")]) ⊆ Set(Base.UUID[UUID("3f19e933-33d8-53b3-aaab-bd5110c3b7a0"), UUID("8bf52ea8-c179-5cab-976a-9e18b702a9bc"), UUID("9fa8497b-333b-5362-9e8d-4d0656e87820"), UUID("6462fe0b-24de-5631-8697-dd941f90decc"), UUID("cf7118a7-6976-5b1a-9a39-7adc72f591a4"), UUID("d6f4376e-aef5-505a-96c1-9c027394607a"), UUID("fa267f1f-6049-4f14-aa54-33bafae1ed76"), UUID("05823500-19ac-5b8b-9628-191a04bc5112"), UUID("c8ffd9c3-330d-5841-b78e-0817d7145fa1"), UUID("9a3f8284-a2c9-5f02-9a11-845980a1fd5c")  …  UUID("8bb1440f-4735-579b-a4ab-409b98df4dab"), UUID("2f01184e-e22b-5df5-ae63-d93ebab69eaf"), UUID("a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"), UUID("4af54fe1-eca0-43a8-85a7-787d91b784e3"), UUID("14a3606d-f60d-562e-9121-12d972cd8159"), UUID("e66e0078-7015-5450-92f7-15fbd957f2ae"), UUID("2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"), UUID("56f22d72-fd6d-98f1-02f0-08ddc0907c33"), UUID("efcefdf7-47ab-520b-bdef-62a2eaa19f15"), UUID("de0858da-6303-5e67-8744-51eddeeeb8d7")])
```

This change introduces a `lowercase(basename(x))` alternative and uses the set intersection operation to simplify the logic. 

A debug log for easier review:

```julia
┌ Info: Registry match check
│   registry_spec =
│    Set{AbstractString} with 3 elements:
│      "General.git"
│      "General"
│      "general"
│   extra_deps =
│    Set{AbstractString} with 3 elements:
│      "https://gitlab.lflab.cn/julialang/JuliaRegistries/General.git.git"
│      "general.git"
└      "https://gitlab.lflab.cn/julialang/JuliaRegistries/General.git"
┌ Info: Registry match check
│   registry_spec =
│    Set{AbstractString} with 3 elements:
│      "https://github.com/JuliaRegistries/General.git.git"
│      "https://github.com/JuliaRegistries/General.git"
│      "general.git"
│   extra_deps =
│    Set{AbstractString} with 3 elements:
│      "https://gitlab.lflab.cn/julialang/JuliaRegistries/General.git.git"
│      "general.git"
└      "https://gitlab.lflab.cn/julialang/JuliaRegistries/General.git"
```