### PR TITLE
Upper-bounded -> Upper bounded

### DIFF
--- a/docs/src/guidelines.md
+++ b/docs/src/guidelines.md
@@ -68,7 +68,7 @@ return output_markdown
 
 ## Additional information
 
-### Upper-bounded `[compat]` entries
+### Upper bounded `[compat]` entries
 
 For example, the following `[compat]` entries meet the criteria for automatic merging:
 ```toml


### PR DESCRIPTION
So it matches the text
> For more information, please see the "Upper bounded [compat] entries" subsection under "Additional information" below.
https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/