### PR TITLE
Revise the commit regex.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryCI"
 uuid = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
 authors = ["Dilum Aluthge <dilum@aluthge.com>", "Fredrik Ekre <ekrefredrik@gmail.com>", "contributors"]
-version = "7.6.0"
+version = "7.7.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/docs/src/regexes.md
+++ b/docs/src/regexes.md
@@ -54,7 +54,7 @@ const row_3 = table_row(;
     regex = RegistryCI.AutoMerge.commit_regex,
     pr_field = "PR body",
     pr_type = "All",
-    example = "* Commit: mycommithash123",
+    example = "* Commit: 012345678901234567890123456789abcdef0000",
 )
 
 const rows = [

--- a/src/AutoMerge/pull_requests.jl
+++ b/src/AutoMerge/pull_requests.jl
@@ -2,7 +2,7 @@ const new_package_title_regex = r"^New package: (\w*?) v(\S*?)$"
 
 const new_version_title_regex = r"^New version: (\w*?) v(\S*?)$"
 
-const commit_regex = r"(?:^|\n|\r\n)(?:\-|\*) Commit: (\w*?)(?:$|\n|\r\n)"
+const commit_regex = r"Commit: ([0-9a-f]+)"
 
 function is_new_package(pull_request::GitHub.PullRequest)
     return occursin(new_package_title_regex, title(pull_request))
@@ -57,7 +57,9 @@ end
 function commit_from_pull_request_body(pull_request::GitHub.PullRequest)
     pr_body = body(pull_request)
     m = match(commit_regex, pr_body)
-    return convert(String, m.captures[1])::String
+    commit = convert(String, m.captures[1])::String
+    always_assert(length(commit) == 40)
+    return commit
 end
 
 function parse_pull_request_title(::NewPackage, pull_request::GitHub.PullRequest)

--- a/test/automerge-unit.jl
+++ b/test/automerge-unit.jl
@@ -295,25 +295,23 @@ end
                 end
             end
             @testset "commit_regex" begin
-                @test occursin(
-                    AutoMerge.commit_regex, "- Foo\n- Commit: mycommithash123\n- Bar"
-                )
-                @test occursin(AutoMerge.commit_regex, "- Commit: mycommithash123\n- Bar")
-                @test occursin(AutoMerge.commit_regex, "- Foo\n- Commit: mycommithash123")
-                @test occursin(AutoMerge.commit_regex, "- Commit: mycommithash123")
-                @test occursin(
-                    AutoMerge.commit_regex, "* Foo\n* Commit: mycommithash123\n* Bar"
-                )
-                @test occursin(AutoMerge.commit_regex, "* Commit: mycommithash123\n* Bar")
-                @test occursin(AutoMerge.commit_regex, "* Foo\n* Commit: mycommithash123")
-                @test occursin(AutoMerge.commit_regex, "* Commit: mycommithash123")
+                commit_hash = "012345678901234567890123456789abcdef0000"
+                @test occursin(AutoMerge.commit_regex, "- Foo\n- Commit: $(commit_hash)\n- Bar")
+                @test occursin(AutoMerge.commit_regex, "- Commit: $(commit_hash)\n- Bar")
+                @test occursin(AutoMerge.commit_regex, "- Foo\n- Commit: $(commit_hash)")
+                @test occursin(AutoMerge.commit_regex, "- Commit: $(commit_hash)")
+                @test occursin(AutoMerge.commit_regex, "Commit: $(commit_hash)")
+                @test occursin(AutoMerge.commit_regex, "* Foo\n* Commit: $(commit_hash)\n* Bar")
+                @test occursin(AutoMerge.commit_regex, "* Commit: $(commit_hash)\n* Bar")
+                @test occursin(AutoMerge.commit_regex, "* Foo\n* Commit: $(commit_hash)")
+                @test occursin(AutoMerge.commit_regex, "* Commit: $(commit_hash)")
                 @test !occursin(AutoMerge.commit_regex, "- Commit: mycommit hash 123")
                 let
                     m = match(
-                        AutoMerge.commit_regex, "- Foo\n- Commit: mycommithash123\n- Bar"
+                        AutoMerge.commit_regex, "- Foo\n- Commit: $(commit_hash)\n- Bar"
                     )
                     @test length(m.captures) == 1
-                    @test m.captures[1] == "mycommithash123"
+                    @test m.captures[1] == "$(commit_hash)"
                 end
             end
         end


### PR DESCRIPTION
This revises the commit regex to match
```
r"Commit: ([0-9a-f]+)"
```
but no longer requires that it is a markdown item on a line of its own.

The rationale is https://github.com/GunnarFarneback/LocalRegistry.jl/pull/49, which makes use of "git push options" to create a pull request (only effective on GitLab). This provides a very low complexity pull request creation mechanism but has the limitation that it cannot pass newlines.

In terms of robustness and input sanitation this change makes no difference to Registrator generated pull requests.In fact it's rather stricter since the code in total only allows the commit hash to be exactly 40 hexadecimal digits.