### PR TITLE
Allow TOML as dependency of JLL packages

### DIFF
--- a/src/AutoMerge/jll.jl
+++ b/src/AutoMerge/jll.jl
@@ -36,9 +36,10 @@ function meets_allowed_jll_nonrecursive_dependencies(
     # 3. Artifacts
     # 4. JLLWrappers
     # 5. LazyArtifacts
-    # 6. other JLL packages
+    # 6. TOML
+    # 7. other JLL packages
     all_dependencies = _get_all_dependencies_nonrecursive(working_directory, pkg, version)
-    allowed_dependencies = ("Pkg", "Libdl", "Artifacts", "JLLWrappers", "LazyArtifacts")
+    allowed_dependencies = ("Pkg", "Libdl", "Artifacts", "JLLWrappers", "LazyArtifacts", "TOML")
     for dep in all_dependencies
         if dep ∉ allowed_dependencies && !is_jll_name(dep)
             return false,

--- a/src/AutoMerge/util.jl
+++ b/src/AutoMerge/util.jl
@@ -287,7 +287,7 @@ function get_all_non_jll_package_names(registry_dir::AbstractString)
         x in values(TOML.parsefile(joinpath(registry_dir, "Registry.toml"))["packages"])
     ]
     sort!(packages)
-    append!(packages, values(RegistryTools.stdlibs()))
+    append!(packages, (RegistryTools.get_stdlib_name(x) for x in values(RegistryTools.stdlibs())))
     filter!(x -> !endswith(x, "_jll"), packages)
     unique!(packages)
     return packages


### PR DESCRIPTION
Since https://github.com/JuliaPackaging/BinaryBuilder.jl/pull/1128 we also use TOML for JLLs in some cases.