### PR TITLE
Allow JLL packages to depend on TOML.

### DIFF
--- a/src/AutoMerge/jll.jl
+++ b/src/AutoMerge/jll.jl
@@ -37,8 +37,9 @@ function meets_allowed_jll_nonrecursive_dependencies(
     # 4. JLLWrappers
     # 5. LazyArtifacts
     # 6. other JLL packages
+    # 7. TOML
     all_dependencies = _get_all_dependencies_nonrecursive(working_directory, pkg, version)
-    allowed_dependencies = ("Pkg", "Libdl", "Artifacts", "JLLWrappers", "LazyArtifacts")
+    allowed_dependencies = ("Pkg", "Libdl", "Artifacts", "JLLWrappers", "LazyArtifacts", "TOML")
     for dep in all_dependencies
         if dep ∉ allowed_dependencies && !is_jll_name(dep)
             return false,


### PR DESCRIPTION
After https://github.com/JuliaPackaging/BinaryBuilder.jl/pull/1191, JLLs using platform augmentation will depend on TOML. Example: https://github.com/JuliaRegistries/General/pull/57214