### PR TITLE
Registry consistency tests: the compress roundtrip check should compare `VersionRange`s (not `String`s)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryCI"
 uuid = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
 authors = ["Dilum Aluthge <dilum@aluthge.com>", "Fredrik Ekre <ekrefredrik@gmail.com>", "contributors"]
-version = "7.4.0"
+version = "7.5.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/registry_testing.jl
+++ b/src/registry_testing.jl
@@ -224,7 +224,7 @@ function test(path=pwd(); registry_deps::Vector{<:AbstractString}=String[])
                     compressed = RegistryTools.Compress.compress(
                         compatfile, RegistryTools.Compress.load(compatfile)
                     )
-                    mapdict = (f, dict) -> Dict(f(k, v) for (k, v) in pairs(dict))
+                    mapdict = (f, dict) -> Dict(f(k, v) for (k, v) in dict)
                     f_inner = (k, v) -> (k, Pkg.Types.VersionRange.(v))
                     f_outer = (k, dict) -> (k, mapdict(f_inner, dict))
                     Test.@test mapdict(f_outer, compressed) == mapdict(f_outer, compat)

--- a/src/registry_testing.jl
+++ b/src/registry_testing.jl
@@ -224,10 +224,10 @@ function test(path=pwd(); registry_deps::Vector{<:AbstractString}=String[])
                     compressed = RegistryTools.Compress.compress(
                         compatfile, RegistryTools.Compress.load(compatfile)
                     )
-                    mapdict = (f, dict) -> Dict(f(k, v) for (k, v) in dict)
-                    f_inner = (k, v) -> (k, Pkg.Types.VersionRange.(v))
-                    f_outer = (k, dict) -> (k, mapdict(f_inner, dict))
-                    Test.@test mapdict(f_outer, compressed) == mapdict(f_outer, compat)
+                    mapvalues = (f, dict) -> Dict(k => f(v) for (k, v) in dict)
+                    f_inner = v -> Pkg.Types.VersionRange.(v)
+                    f_outer = dict -> mapvalues(f_inner, dict)
+                    Test.@test mapvalues(f_outer, compressed) == mapvalues(f_outer, compat)
                 end
             end
             # Make sure all paths are unique


### PR DESCRIPTION
Fixes #457

Will likely fail until https://github.com/JuliaRegistries/General/pull/65997 is merged.