### PR TITLE
checking name similarity requires an extracted registry

### DIFF
--- a/docs/src/guidelines.md
+++ b/docs/src/guidelines.md
@@ -118,7 +118,7 @@ AutoMerge.meets_distance_check("MyPackage", all_pkg_names)
 where `path_to_registry` is a path to the folder containing the registry of
 interest. For the General Julia registry, usually `path_to_registry =
 joinpath(DEPOT_PATH[1], "registries", "General")` if you haven't changed
-your `DEPOT_PATH`. This will return a boolean, indicating whether or not
+your `DEPOT_PATH` and have an extracted version of the Pkg server registry (see JuliaRegistries/RegistryCI.jl#442). This will return a boolean, indicating whether or not
 your tentative package name passed the check, as well as a string,
 indicating what the problem is in the event the check did not pass.
 


### PR DESCRIPTION
Added a brief note explaining that `get_all_non_jll_package_names` requires a non-default extracted General registry, as explained in #442 .