### PR TITLE
Enforce files in `src` have distinct names after lowercasing and are allowed on all OS's

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryCI"
 uuid = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
 authors = ["Dilum Aluthge <dilum@aluthge.com>", "Fredrik Ekre <ekrefredrik@gmail.com>", "contributors"]
-version = "7.9.0"
+version = "8.0.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/AutoMerge/guidelines.jl
+++ b/src/AutoMerge/guidelines.jl
@@ -570,7 +570,7 @@ const DISALLOWED_NAMES = ["CON", "PRN", "AUX", "NUL",
 
 function meets_file_dir_name_check(name)
     # https://stackoverflow.com/a/31976060
-    idx = findfirst(n -> contains(name, n), DISALLOWED_CHARS)
+    idx = findfirst(n -> occursin(n, name), DISALLOWED_CHARS)
     if idx !== nothing
         return false, "contains character $(DISALLOWED_CHARS[idx]) which may not be valid as a file or directory name on some platforms"
     end

--- a/test/automerge-unit.jl
+++ b/test/automerge-unit.jl
@@ -252,37 +252,61 @@ end
         @test AutoMerge._find_lowercase_duplicates(["ab", "bc"]) === nothing
         @test AutoMerge._find_lowercase_duplicates(("ab", "bb", "aB", "AB")) == ("ab", "aB")
     end
-    @testset "meets_src_files_distinct" begin
-        @test !AutoMerge.meets_src_files_distinct("DOES NOT EXIST")[1]
+    @testset "meets_file_dir_name_check" begin
+        @test AutoMerge.meets_file_dir_name_check("hi")[1]
+        @test AutoMerge.meets_file_dir_name_check("hi bye")[1]
+        @test AutoMerge.meets_file_dir_name_check("hi.txt")[1]
+        @test AutoMerge.meets_file_dir_name_check("hi.con")[1]
+        @test !AutoMerge.meets_file_dir_name_check("con")[1]
+        @test !AutoMerge.meets_file_dir_name_check("lpt5")[1]
+        @test !AutoMerge.meets_file_dir_name_check("hi.")[1]
+        @test !AutoMerge.meets_file_dir_name_check("hi.txt.")[1]
+        @test !AutoMerge.meets_file_dir_name_check("hi ")[1]
+        @test !AutoMerge.meets_file_dir_name_check("hi:")[1]
+        @test !AutoMerge.meets_file_dir_name_check("hi:bye")[1]
+        @test !AutoMerge.meets_file_dir_name_check("hi?bye")[1]
+        @test !AutoMerge.meets_file_dir_name_check("hi>bye")[1]
+    end
+    @testset "meets_src_names_ok: duplicates" begin
+        @test !AutoMerge.meets_src_names_ok("DOES NOT EXIST")[1]
         tmp = mktempdir()
-        @test !AutoMerge.meets_src_files_distinct(tmp)[1]
+        @test !AutoMerge.meets_src_names_ok(tmp)[1]
         mkdir(joinpath(tmp, "src"))
-        @test AutoMerge.meets_src_files_distinct(tmp)[1]
+        @test AutoMerge.meets_src_names_ok(tmp)[1]
         touch(joinpath(tmp, "src", "a"))
-        @test AutoMerge.meets_src_files_distinct(tmp)[1]
+        @test AutoMerge.meets_src_names_ok(tmp)[1]
 
         if !isdir(joinpath(tmp, "SRC"))
             mkdir(joinpath(tmp, "src", "A"))
 
             # dir vs file fails
-            @test !AutoMerge.meets_src_files_distinct(tmp)[1]
+            @test !AutoMerge.meets_src_names_ok(tmp)[1]
             rm(joinpath(tmp, "src", "a"))
             mkdir(joinpath(tmp, "src", "A"))
 
-            @test AutoMerge.meets_src_files_distinct(tmp)[1]
+            @test AutoMerge.meets_src_names_ok(tmp)[1]
 
             touch(joinpath(tmp, "src", "A", "b"))
-            @test AutoMerge.meets_src_files_distinct(tmp)[1]
+            @test AutoMerge.meets_src_names_ok(tmp)[1]
             touch(joinpath(tmp, "src", "b"))
             # repetition at different levels is OK
-            @test AutoMerge.meets_src_files_distinct(tmp)[1]
+            @test AutoMerge.meets_src_names_ok(tmp)[1]
 
             touch(joinpath(tmp, "src", "A", "B"))
             # repetition at the same level is not OK
-            @test !AutoMerge.meets_src_files_distinct(tmp)[1]
+            @test !AutoMerge.meets_src_names_ok(tmp)[1]
         else
             @warn "Case insensitive filesystem detected, so skipping some `meets_src_files_distinct` checks."
         end
+    end
+    @testset "meets_src_names_ok: names" begin
+        tmp = mktempdir()
+        mkdir(joinpath(tmp, "src"))
+        @test AutoMerge.meets_src_names_ok(tmp)[1]
+        mkdir(joinpath(tmp, "src", "B"))
+        @test AutoMerge.meets_src_names_ok(tmp)[1]
+        touch(joinpath(tmp, "src", "B", "con"))
+        @test !AutoMerge.meets_src_names_ok(tmp)[1]
     end
     @testset "pull-requests.jl" begin
         @testset "regexes" begin

--- a/test/automerge-unit.jl
+++ b/test/automerge-unit.jl
@@ -282,7 +282,6 @@ end
             # dir vs file fails
             @test !AutoMerge.meets_src_names_ok(tmp)[1]
             rm(joinpath(tmp, "src", "a"))
-            mkdir(joinpath(tmp, "src", "A"))
 
             @test AutoMerge.meets_src_names_ok(tmp)[1]
 


### PR DESCRIPTION
closes https://github.com/JuliaRegistries/RegistryCI.jl/issues/441