### PR TITLE
Allow the `Deps.toml`, `WeakDeps.toml`, and `Compat.toml`, and `WeakCompat.toml` files to not exist

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryCI"
 uuid = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
 authors = ["Dilum Aluthge <dilum@aluthge.com>", "Fredrik Ekre <ekrefredrik@gmail.com>", "contributors"]
-version = "8.0.1"
+version = "8.1.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/AutoMerge/AutoMerge.jl
+++ b/src/AutoMerge/AutoMerge.jl
@@ -35,6 +35,7 @@ include("package_path_in_registry.jl")
 include("public.jl")
 include("pull_requests.jl")
 include("semver.jl")
+include("toml.jl")
 include("update_status.jl")
 include("util.jl")
 

--- a/src/AutoMerge/guidelines.jl
+++ b/src/AutoMerge/guidelines.jl
@@ -32,7 +32,7 @@ function meets_compat_for_julia(working_directory::AbstractString, pkg, version)
     package_relpath = get_package_relpath_in_registry(;
         package_name=pkg, registry_path=working_directory
     )
-    compat = Pkg.TOML.parsefile(joinpath(working_directory, package_relpath, "Compat.toml"))
+    compat = maybe_parse_toml(joinpath(working_directory, package_relpath), "Compat.toml")
     # Go through all the compat entries looking for the julia compat
     # of the new version. When found, test
     # 1. that it is a bounded range,
@@ -80,8 +80,8 @@ function meets_compat_for_all_deps(working_directory::AbstractString, pkg, versi
     package_relpath = get_package_relpath_in_registry(;
         package_name=pkg, registry_path=working_directory
     )
-    deps = Pkg.TOML.parsefile(joinpath(working_directory, package_relpath, "Deps.toml"))
-    compat = Pkg.TOML.parsefile(joinpath(working_directory, package_relpath, "Compat.toml"))
+    deps = maybe_parse_toml(joinpath(working_directory, package_relpath), "Deps.toml")
+    compat = maybe_parse_toml(joinpath(working_directory, package_relpath), "Compat.toml")
     # First, we construct a Dict in which the keys are the package's
     # dependencies, and the value is always false.
     dep_has_compat_with_upper_bound = Dict{String,Bool}()

--- a/src/AutoMerge/guidelines.jl
+++ b/src/AutoMerge/guidelines.jl
@@ -33,7 +33,6 @@ function meets_compat_for_julia(working_directory::AbstractString, pkg, version)
         package_name=pkg, registry_path=working_directory
     )
     compat_file = joinpath(working_directory, package_relpath, "Compat.toml")
-    assert_allowed_to_not_exist(compat_file)
     compat = maybe_parse_toml(compat_file)
     # Go through all the compat entries looking for the julia compat
     # of the new version. When found, test
@@ -84,8 +83,6 @@ function meets_compat_for_all_deps(working_directory::AbstractString, pkg, versi
     )
     compat_file = joinpath(working_directory, package_relpath, "Compat.toml")
     deps_file = joinpath(working_directory, package_relpath, "Deps.toml")
-    assert_allowed_to_not_exist(compat_file)
-    assert_allowed_to_not_exist(deps_toml)
     compat = maybe_parse_toml(compat_file)
     deps = maybe_parse_toml(deps_file)
     # First, we construct a Dict in which the keys are the package's

--- a/src/AutoMerge/guidelines.jl
+++ b/src/AutoMerge/guidelines.jl
@@ -32,7 +32,9 @@ function meets_compat_for_julia(working_directory::AbstractString, pkg, version)
     package_relpath = get_package_relpath_in_registry(;
         package_name=pkg, registry_path=working_directory
     )
-    compat = maybe_parse_toml(joinpath(working_directory, package_relpath), "Compat.toml")
+    compat_file = joinpath(working_directory, package_relpath, "Compat.toml")
+    assert_allowed_to_not_exist(compat_file)
+    compat = maybe_parse_toml(compat_file)
     # Go through all the compat entries looking for the julia compat
     # of the new version. When found, test
     # 1. that it is a bounded range,
@@ -80,8 +82,12 @@ function meets_compat_for_all_deps(working_directory::AbstractString, pkg, versi
     package_relpath = get_package_relpath_in_registry(;
         package_name=pkg, registry_path=working_directory
     )
-    deps = maybe_parse_toml(joinpath(working_directory, package_relpath), "Deps.toml")
-    compat = maybe_parse_toml(joinpath(working_directory, package_relpath), "Compat.toml")
+    compat_file = joinpath(working_directory, package_relpath, "Compat.toml")
+    deps_file = joinpath(working_directory, package_relpath, "Deps.toml")
+    assert_allowed_to_not_exist(compat_file)
+    assert_allowed_to_not_exist(deps_toml)
+    compat = maybe_parse_toml(compat_file)
+    deps = maybe_parse_toml(deps_file)
     # First, we construct a Dict in which the keys are the package's
     # dependencies, and the value is always false.
     dep_has_compat_with_upper_bound = Dict{String,Bool}()

--- a/src/AutoMerge/jll.jl
+++ b/src/AutoMerge/jll.jl
@@ -7,7 +7,7 @@ function _get_all_dependencies_nonrecursive(working_directory::AbstractString, p
     package_relpath = get_package_relpath_in_registry(;
         package_name=pkg, registry_path=working_directory
     )
-    deps = Pkg.TOML.parsefile(joinpath(working_directory, package_relpath, "Deps.toml"))
+    deps = maybe_parse_toml(joinpath(working_directory, package_relpath), "Deps.toml")
     for version_range in keys(deps)
         if version in Pkg.Types.VersionRange(version_range)
             for name in keys(deps[version_range])

--- a/src/AutoMerge/jll.jl
+++ b/src/AutoMerge/jll.jl
@@ -8,7 +8,6 @@ function _get_all_dependencies_nonrecursive(working_directory::AbstractString, p
         package_name=pkg, registry_path=working_directory
     )
     deps_file = joinpath(working_directory, package_relpath, "Deps.toml")
-    assert_allowed_to_not_exist(deps_file)
     deps = maybe_parse_toml(deps_file)
     for version_range in keys(deps)
         if version in Pkg.Types.VersionRange(version_range)

--- a/src/AutoMerge/jll.jl
+++ b/src/AutoMerge/jll.jl
@@ -7,7 +7,9 @@ function _get_all_dependencies_nonrecursive(working_directory::AbstractString, p
     package_relpath = get_package_relpath_in_registry(;
         package_name=pkg, registry_path=working_directory
     )
-    deps = maybe_parse_toml(joinpath(working_directory, package_relpath), "Deps.toml")
+    deps_file = joinpath(working_directory, package_relpath, "Deps.toml")
+    assert_allowed_to_not_exist(deps_file)
+    deps = maybe_parse_toml(deps_file)
     for version_range in keys(deps)
         if version in Pkg.Types.VersionRange(version_range)
             for name in keys(deps[version_range])

--- a/src/AutoMerge/semver.jl
+++ b/src/AutoMerge/semver.jl
@@ -92,7 +92,6 @@ function julia_compat(pkg::String, version::VersionNumber, registry_path::String
     )
     all_compat_entries_for_julia = Pkg.Types.VersionRange[]
     compat_file = joinpath(working_directory, package_relpath, "Compat.toml")
-    assert_allowed_to_not_exist(compat_file)
     compat = maybe_parse_toml(compat_file)
     for version_range in keys(compat)
         if version in Pkg.Types.VersionRange(version_range)

--- a/src/AutoMerge/semver.jl
+++ b/src/AutoMerge/semver.jl
@@ -91,7 +91,7 @@ function julia_compat(pkg::String, version::VersionNumber, registry_path::String
         package_name=pkg, registry_path=registry_path
     )
     all_compat_entries_for_julia = Pkg.Types.VersionRange[]
-    compat = Pkg.TOML.parsefile(joinpath(registry_path, package_relpath, "Compat.toml"))
+    compat = maybe_parse_toml(joinpath(registry_path, package_relpath), "Compat.toml")
     for version_range in keys(compat)
         if version in Pkg.Types.VersionRange(version_range)
             for compat_entry in compat[version_range]

--- a/src/AutoMerge/semver.jl
+++ b/src/AutoMerge/semver.jl
@@ -91,7 +91,9 @@ function julia_compat(pkg::String, version::VersionNumber, registry_path::String
         package_name=pkg, registry_path=registry_path
     )
     all_compat_entries_for_julia = Pkg.Types.VersionRange[]
-    compat = maybe_parse_toml(joinpath(registry_path, package_relpath), "Compat.toml")
+    compat_file = joinpath(working_directory, package_relpath, "Compat.toml")
+    assert_allowed_to_not_exist(compat_file)
+    compat = maybe_parse_toml(compat_file)
     for version_range in keys(compat)
         if version in Pkg.Types.VersionRange(version_range)
             for compat_entry in compat[version_range]

--- a/src/AutoMerge/toml.jl
+++ b/src/AutoMerge/toml.jl
@@ -1,5 +1,5 @@
 function maybe_parse_toml(full_path::AbstractString)
-    file = basename(pathfull_path)
+    file = basename(full_path)
     allowed_filenames = (
         "Compat.toml",
         "WeakCompat.toml",
@@ -10,9 +10,5 @@ function maybe_parse_toml(full_path::AbstractString)
         msg = "Filename is not in the allowed list: $(file)"
         throw(ErrorException(msg))
     end
-    if !ispath(full_path)
-        @warn "TOML file does not exist; returning an empty dict" directory file full_path
-        return Dict()
-    end
-    return Pkg.TOML.parsefile(full_path)
+    return ispath(full_path) ? Pkg.TOML.parsefile(full_path) : Dict{String, Any}()
 end

--- a/src/AutoMerge/toml.jl
+++ b/src/AutoMerge/toml.jl
@@ -13,6 +13,4 @@ function assert_allowed_to_not_exist(full_path::AbstractString)
     return nothing
 end
 
-function maybe_parse_toml(f::AbstractString)
-    return ispath(f) ? Pkg.TOML.parsefile(f) : Dict{String, Any}()
-end
+maybe_parse_toml(f::AbstractString) = ispath(f) ? Pkg.TOML.parsefile(f) : Dict{String, Any}()

--- a/src/AutoMerge/toml.jl
+++ b/src/AutoMerge/toml.jl
@@ -1,16 +1,1 @@
-function assert_allowed_to_not_exist(full_path::AbstractString)
-    file = basename(full_path)
-    allowed_filenames = (
-        "Compat.toml",
-        "WeakCompat.toml",
-        "Deps.toml",
-        "WeakDeps.toml",
-    )
-    if !(file in allowed_filenames)
-        msg = "Filename is not in the allowed list: $(file)"
-        throw(ErrorException(msg))
-    end
-    return nothing
-end
-
 maybe_parse_toml(f::AbstractString) = ispath(f) ? Pkg.TOML.parsefile(f) : Dict{String, Any}()

--- a/src/AutoMerge/toml.jl
+++ b/src/AutoMerge/toml.jl
@@ -1,0 +1,18 @@
+function maybe_parse_toml(directory::AbstractString, file::AbstractString)
+    allowed_filenames = (
+        "Compat.toml",
+        "WeakCompat.toml",
+        "Deps.toml",
+        "WeakDeps.toml",
+    )
+    if !(file in allowed_filenames)
+        msg = "Filename is not in the allowed list: $(file)"
+        throw(ErrorException(msg))
+    end
+    full_path = joinpath(directory, file)
+    if !ispath(full_path)
+        @warn "TOML file does not exist; returning an empty dict" directory file full_path
+        return Dict()
+    end
+    return Pkg.TOML.parsefile(full_path)
+end

--- a/src/AutoMerge/toml.jl
+++ b/src/AutoMerge/toml.jl
@@ -13,6 +13,6 @@ function assert_allowed_to_not_exist(full_path::AbstractString)
     return nothing
 end
 
-function maybe_parse_toml(full_path::AbstractString)
-    return ispath(full_path) ? Pkg.TOML.parsefile(full_path) : Dict{String, Any}()
+function maybe_parse_toml(f::AbstractString)
+    return ispath(f) ? Pkg.TOML.parsefile(f) : Dict{String, Any}()
 end

--- a/src/AutoMerge/toml.jl
+++ b/src/AutoMerge/toml.jl
@@ -1,4 +1,5 @@
-function maybe_parse_toml(directory::AbstractString, file::AbstractString)
+function maybe_parse_toml(full_path::AbstractString)
+    file = basename(pathfull_path)
     allowed_filenames = (
         "Compat.toml",
         "WeakCompat.toml",
@@ -9,7 +10,6 @@ function maybe_parse_toml(directory::AbstractString, file::AbstractString)
         msg = "Filename is not in the allowed list: $(file)"
         throw(ErrorException(msg))
     end
-    full_path = joinpath(directory, file)
     if !ispath(full_path)
         @warn "TOML file does not exist; returning an empty dict" directory file full_path
         return Dict()

--- a/src/AutoMerge/toml.jl
+++ b/src/AutoMerge/toml.jl
@@ -1,4 +1,4 @@
-function maybe_parse_toml(full_path::AbstractString)
+function assert_allowed_to_not_exist(full_path::AbstractString)
     file = basename(full_path)
     allowed_filenames = (
         "Compat.toml",
@@ -10,5 +10,9 @@ function maybe_parse_toml(full_path::AbstractString)
         msg = "Filename is not in the allowed list: $(file)"
         throw(ErrorException(msg))
     end
+    return nothing
+end
+
+function maybe_parse_toml(full_path::AbstractString)
     return ispath(full_path) ? Pkg.TOML.parsefile(full_path) : Dict{String, Any}()
 end

--- a/src/registry_testing.jl
+++ b/src/registry_testing.jl
@@ -194,6 +194,8 @@ function test(path=pwd(); registry_deps::Vector{<:AbstractString}=String[])
                         depsfile, RegistryTools.Compress.load(depsfile)
                     )
                     Test.@test compressed == deps
+                else
+                    @debug "Deps.toml file does not exist" depsfile
                 end
 
                 # Compat.toml testing
@@ -228,6 +230,8 @@ function test(path=pwd(); registry_deps::Vector{<:AbstractString}=String[])
                     f_inner = v -> Pkg.Types.VersionRange.(v)
                     f_outer = dict -> mapvalues(f_inner, dict)
                     Test.@test mapvalues(f_outer, compressed) == mapvalues(f_outer, compat)
+                else
+                    @debug "Compat.toml file does not exist" compatfile
                 end
             end
             # Make sure all paths are unique


### PR DESCRIPTION
Fixes https://github.com/JuliaRegistries/RegistryTools.jl/issues/81
Fixes #494