### PR TITLE
Alphanumeric name check: Don't use `\w`, because we don't want to include underscores

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryCI"
 uuid = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
 authors = ["Dilum Aluthge <dilum@aluthge.com>", "Fredrik Ekre <ekrefredrik@gmail.com>", "contributors"]
-version = "8.4.0"
+version = "8.4.1"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/AutoMerge/guidelines.jl
+++ b/src/AutoMerge/guidelines.jl
@@ -384,7 +384,10 @@ const guideline_normal_capitalization = Guideline(;
 )
 
 function meets_normal_capitalization(pkg)
-    meets_this_guideline = occursin(r"^[A-Z]\w*[a-z]\w*[0-9]?$", pkg)
+    # We intentionally do not use `\w` in this regex.
+    # `\w` includes underscores, but we don't want to include underscores.
+    # So, instead of `\w`, we use `[A-Za-z0-9]`.
+    meets_this_guideline = occursin(r"^[A-Z][A-Za-z0-9]*[a-z][A-Za-z0-9]*[0-9]?$", pkg)
     if meets_this_guideline
         return true, ""
     else


### PR DESCRIPTION
This is a bug-fix. This guideline was always intended to exclude non-alphanumeric characters; we just weren't doing that correctly.