### PR TITLE
Gracefully handle pull requests without bodies

### DIFF
--- a/src/TagBot/TagBot.jl
+++ b/src/TagBot/TagBot.jl
@@ -45,6 +45,9 @@ function main()
 end
 
 function repo_and_version_of_pull_request_body(body)
+    # Return immediately if the pull request's description is empty. In this
+    # case no further information can be obtained about a registration
+    isnothing(body) && return (nothing, nothing)
     if occursin("JLL package", body)
         @info "Skipping JLL package registration"
         return nothing, nothing

--- a/test/tagbot-unit.jl
+++ b/test/tagbot-unit.jl
@@ -36,6 +36,8 @@ end
     @test TB.repo_and_version_of_pull_request_body(ssh) == ("Foo/Bar", "v1.2.3")
     gitlab = body("https://gitlab.com/Foo/Bar")
     @test TB.repo_and_version_of_pull_request_body(gitlab) == (nothing, "v1.2.3")
+    no_body = nothing
+    @test TB.repo_and_version_of_pull_request_body(no_body) == (nothing, nothing)
 end
 
 @testset "tagbot_file" begin


### PR DESCRIPTION
Calling `repo_and_version_of_pull_request_body` with an empty body causes errors due to `occursin` not handling `Nothing` values.

```julia
ERROR: MethodError: no method matching occursin(::String, ::Nothing)
Closest candidates are:
  occursin(::Union{AbstractChar, AbstractString}, ::AbstractString) at strings/search.jl:628
  occursin(::Any) at strings/search.jl:642
Stacktrace:
 [1] repo_and_version_of_pull_request_body(body::Nothing)
   @ RegistryCI.TagBot ~/.julia/packages/RegistryCI/3KBMb/src/TagBot/TagBot.jl:48
```

This could be handled using a separate dispatch, but this approach seems more in line with the rest of the codebase. Just let me know if you'd prefer the dispatch implementation instead and I'll get this updated.

Fixes #503.