### PR TITLE
When yanking a version, only `yanked = true` is correct; `yank = true` (and other variants) are incorrect, so we should detect them

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryCI"
 uuid = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
 authors = ["Dilum Aluthge <dilum@aluthge.com>", "Fredrik Ekre <ekrefredrik@gmail.com>", "contributors"]
-version = "9.0.0"
+version = "9.1.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/registry_testing.jl
+++ b/src/registry_testing.jl
@@ -172,6 +172,11 @@ function test(path=pwd(); registry_deps::Vector{<:AbstractString}=String[])
                 for (v, data) in vers
                     Test.@test VersionNumber(v) isa VersionNumber
                     Test.@test haskey(data, "git-tree-sha1")
+
+                    # https://github.com/JuliaRegistries/RegistryCI.jl/issues/523
+                    # "yanked" is correct.
+                    # "yank" (and all other variants) are incorrect.
+                    Test.@test keys(data) ⊆ ["git-tree-sha1", "yanked"]
                 end
 
                 # Deps.toml testing


### PR DESCRIPTION
Fixes #523