### PR TITLE
Improve `_invalid_sequential_version` msg.

### DIFF
--- a/src/AutoMerge/guidelines.jl
+++ b/src/AutoMerge/guidelines.jl
@@ -424,8 +424,7 @@ function meets_repo_url_requirement(pkg::String; registry_head::String)
 end
 
 function _invalid_sequential_version(reason::AbstractString)
-    return false, "Does not meet sequential version number guideline: $reason\n
-    If this was intentional, please leave a comment saying so. Otherwise please correct the version number in your package and re-trigger registration.", :invalid
+    return false, "Does not meet sequential version number guideline: $(reason). If this was intentional, please leave a comment saying so. Otherwise please correct the version number in your package and re-trigger registration.", :invalid
 end
 
 function _valid_change(old_version::VersionNumber, new_version::VersionNumber)

--- a/src/AutoMerge/guidelines.jl
+++ b/src/AutoMerge/guidelines.jl
@@ -425,7 +425,7 @@ end
 
 function _invalid_sequential_version(reason::AbstractString)
     return false, "Does not meet sequential version number guideline: $reason\n \
-    A double check is required to verify this was done on purpose.", :invalid
+    If this was intentional, please leave a comment saying so. Otherwise please correct the version number in your package and re-trigger registration.", :invalid
 end
 
 function _valid_change(old_version::VersionNumber, new_version::VersionNumber)

--- a/src/AutoMerge/guidelines.jl
+++ b/src/AutoMerge/guidelines.jl
@@ -424,7 +424,8 @@ function meets_repo_url_requirement(pkg::String; registry_head::String)
 end
 
 function _invalid_sequential_version(reason::AbstractString)
-    return false, "Does not meet sequential version number guideline: $reason", :invalid
+    return false, "Does not meet sequential version number guideline: $reason\n \
+    A double check is recommended to verify this was done on purpose.", :invalid
 end
 
 function _valid_change(old_version::VersionNumber, new_version::VersionNumber)

--- a/src/AutoMerge/guidelines.jl
+++ b/src/AutoMerge/guidelines.jl
@@ -425,7 +425,7 @@ end
 
 function _invalid_sequential_version(reason::AbstractString)
     return false, "Does not meet sequential version number guideline: $reason\n \
-    A double check is recommended to verify this was done on purpose.", :invalid
+    A double check is required to verify this was done on purpose.", :invalid
 end
 
 function _valid_change(old_version::VersionNumber, new_version::VersionNumber)

--- a/src/AutoMerge/guidelines.jl
+++ b/src/AutoMerge/guidelines.jl
@@ -424,7 +424,7 @@ function meets_repo_url_requirement(pkg::String; registry_head::String)
 end
 
 function _invalid_sequential_version(reason::AbstractString)
-    return false, "Does not meet sequential version number guideline: $reason\n \
+    return false, "Does not meet sequential version number guideline: $reason\n
     If this was intentional, please leave a comment saying so. Otherwise please correct the version number in your package and re-trigger registration.", :invalid
 end
 


### PR DESCRIPTION
This PR is created due to [this discussion](https://julialang.slack.com/archives/C6M4DQA5P/p1700666990252839). When a version skipping happens, the RegistryCI shows the following message:

> ... . The following guidelines were not met:
> 
> Does not meet sequential version number guideline: version 1.3.2 skips over 1.3.1
> Note that the guidelines are only required for the pull request to be merged automatically. However, **it is strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.

In my opinion, this message gives the impression that version skipping is strictly prohibited. It seems to say that you should not do this, but if you did, you need to provide a convincing explanation for why you skipped some versions. Otherwise, the PR will not be merged. However, I can infer that the reason for this check is to prevent any mistakes rather than to ban version skipping. As Mr. Giordano [stated](https://julialang.slack.com/archives/C6M4DQA5P/p1700673594182829?thread_ts=1700666990.252839&cid=C6M4DQA5P):

>  lots of time [version skipping] is a mistake
> a large fraction of [General registry] PRs closed without merge (not for new packages of course) is because of skipped versions which were a mistake.

However, the message I mentioned earlier could imply that developers who deliberately skipped some versions are doing something wrong or problematic, while the main purpose of this check is to prevent mistakes. Therefore, I opened this PR to improve the message. I appreciate your feedback and any suggestions you might have.