### PR TITLE
CI: Migrate from Bors to GitHub Merge Queue

### DIFF
--- a/.github/workflows/ci_integration.yml
+++ b/.github/workflows/ci_integration.yml
@@ -31,7 +31,7 @@ jobs:
     # because we want to avoid hitting rate limits.
     # So, if this is a PR build, mark the integration tests as "skipped".
     if: github.event_name != 'pull_request'
-    name: Integration/Julia ${{ matrix.version }}/${{ matrix.os }}/${{ matrix.arch }}
+    name: Integration
     runs-on: ${{ matrix.os }}
     strategy:
       max-parallel: 1

--- a/.github/workflows/ci_integration.yml
+++ b/.github/workflows/ci_integration.yml
@@ -11,8 +11,6 @@ on:
   push:
     branches:
       - master
-      # - staging # Bors
-      # - trying # Bors
 
 # Make sure that the `GITHUB_TOKEN` only has read-only permissions
 # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions

--- a/.github/workflows/ci_integration.yml
+++ b/.github/workflows/ci_integration.yml
@@ -30,7 +30,7 @@ jobs:
     # We don't actually want to run integration tests on pull requests,
     # because we want to avoid hitting rate limits.
     # So, if this is a PR build, mark the integration tests as "skipped".
-    if: github.event_name != 'pull_request'
+    # if: github.event_name != 'pull_request'
     name: Integration
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci_integration.yml
+++ b/.github/workflows/ci_integration.yml
@@ -7,6 +7,7 @@ name: CI (integration tests)
 
 on:
   merge_group: # GitHub Merge Queue
+  pull_request: # but we will skip the integration tests on PR builds, to avoid hitting rate limits
   push:
     branches:
       - master
@@ -26,7 +27,10 @@ env:
 
 jobs:
   integration:
-    if: github.event_name == 'push'
+    # We don't actually want to run integration tests on pull requests,
+    # because we want to avoid hitting rate limits.
+    # So, if this is a PR build, mark the integration tests as "skipped".
+    if: github.event_name != 'pull_request'
     name: Integration/Julia ${{ matrix.version }}/${{ matrix.os }}/${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/ci_integration.yml
+++ b/.github/workflows/ci_integration.yml
@@ -30,7 +30,7 @@ jobs:
     # We don't actually want to run integration tests on pull requests,
     # because we want to avoid hitting rate limits.
     # So, if this is a PR build, mark the integration tests as "skipped".
-    # if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request'
     name: Integration
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci_integration.yml
+++ b/.github/workflows/ci_integration.yml
@@ -6,11 +6,12 @@ name: CI (integration tests)
 # GitHub's abuse rate limits.
 
 on:
+  merge_group: # GitHub Merge Queue
   push:
     branches:
       - master
-      - staging
-      - trying
+      # - staging # Bors
+      # - trying # Bors
 
 # Make sure that the `GITHUB_TOKEN` only has read-only permissions
 # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions

--- a/.github/workflows/ci_integration.yml
+++ b/.github/workflows/ci_integration.yml
@@ -32,23 +32,13 @@ jobs:
     # So, if this is a PR build, mark the integration tests as "skipped".
     if: github.event_name != 'pull_request'
     name: Integration
-    runs-on: ${{ matrix.os }}
-    strategy:
-      max-parallel: 1
-      fail-fast: true
-      matrix:
-        arch:
-          - x64
-        os:
-          - ubuntu-latest
-        version:
-          - '1'
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
         with:
-          version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
+          version: '1'
+          arch: x64
       - uses: actions/cache@v1
         env:
           cache-name: cache-artifacts

--- a/.github/workflows/ci_unit.yml
+++ b/.github/workflows/ci_unit.yml
@@ -5,8 +5,6 @@ on:
   push:
     branches:
       - master
-      # - staging # Bors
-      # - trying # Bors
     tags: '*'
 env:
   JULIA_PKG_UNPACK_REGISTRY: 'true'

--- a/.github/workflows/ci_unit.yml
+++ b/.github/workflows/ci_unit.yml
@@ -1,13 +1,12 @@
 name: CI (unit tests)
 on:
+  merge_group: # GitHub Merge Queue
   pull_request:
-    branches:
-      - master
   push:
     branches:
       - master
-      - staging
-      - trying
+      # - staging # Bors
+      # - trying # Bors
     tags: '*'
 env:
   JULIA_PKG_UNPACK_REGISTRY: 'true'


### PR DESCRIPTION
Because the public instance of Bors has been shut down.