### PR TITLE
AutoMerge: Respect the `Override AutoMerge: name similarity is okay` label

### DIFF
--- a/docs/src/guidelines.md
+++ b/docs/src/guidelines.md
@@ -22,6 +22,7 @@ function guidelines_to_markdown_output(guidelines_function::Function)
         check_license = true,
         this_is_jll_package = false,
         this_pr_can_use_special_jll_exceptions = false,
+        use_distance_check = false,
     )
     filter!(x -> x[1] != :update_status, guidelines)
     filter!(x -> !(x[1].docs isa Nothing), guidelines)
@@ -50,6 +51,7 @@ function guidelines_to_markdown_output(guidelines_function::Function)
         check_license = true,
         this_is_jll_package = false,
         this_pr_can_use_special_jll_exceptions = false,
+        use_distance_check = false,
     )
     filter!(x -> x[1] != :update_status, guidelines)
     filter!(x -> !(x[1].docs isa Nothing), guidelines)

--- a/example_github_workflow_files/automerge.yml
+++ b/example_github_workflow_files/automerge.yml
@@ -10,6 +10,11 @@ on:
 
 jobs:
   AutoMerge:
+    # Run if the we are not triggered by a label OR we are triggered by a label, and that
+    # label is one that affects the execution of the workflow
+    # Note: since the label contains a colon, we need to use a workaround like https://github.com/actions/runner/issues/1019#issuecomment-810482716
+    # for the syntax to parse correctly.
+    if: "${{  github.event.action != 'labeled' || (github.event.action == 'labeled' && github.event.label.name == 'Override AutoMerge: name similarity is okay') }}"
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/example_github_workflow_files/automerge.yml
+++ b/example_github_workflow_files/automerge.yml
@@ -4,6 +4,8 @@ on:
   schedule:
     - cron: '05,17,29,41,53 * * * *'
   pull_request:
+    # Here we run when labels are applied, so that the "Override AutoMerge: name similarity is okay label is respected.
+    types: [labeled, synchronize]
   workflow_dispatch:
 
 jobs:

--- a/example_github_workflow_files/automerge.yml
+++ b/example_github_workflow_files/automerge.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron: '05,17,29,41,53 * * * *'
   pull_request:
+    # opened = run when the PR is first opened
     # labeled = run when labels are applied, so that the "Override AutoMerge: name similarity is okay label is respected.
     # synchronize = run when a commit is pushed to the PR
     types: [opened, labeled, synchronize]

--- a/example_github_workflow_files/automerge.yml
+++ b/example_github_workflow_files/automerge.yml
@@ -4,8 +4,9 @@ on:
   schedule:
     - cron: '05,17,29,41,53 * * * *'
   pull_request:
-    # Here we run when labels are applied, so that the "Override AutoMerge: name similarity is okay label is respected.
-    types: [labeled, synchronize]
+    # labeled = run when labels are applied, so that the "Override AutoMerge: name similarity is okay label is respected.
+    # synchronize = run when a commit is pushed to the PR
+    types: [opened, labeled, synchronize]
   workflow_dispatch:
 
 jobs:
@@ -14,7 +15,7 @@ jobs:
     # label is one that affects the execution of the workflow
     # Note: since the label contains a colon, we need to use a workaround like https://github.com/actions/runner/issues/1019#issuecomment-810482716
     # for the syntax to parse correctly.
-    if: "${{  github.event.action != 'labeled' || (github.event.action == 'labeled' && github.event.label.name == 'Override AutoMerge: name similarity is okay') }}"
+    if: "${{ github.event.action != 'labeled' || (github.event.action == 'labeled' && github.event.label.name == 'Override AutoMerge: name similarity is okay') }}"
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/src/AutoMerge/guidelines.jl
+++ b/src/AutoMerge/guidelines.jl
@@ -265,6 +265,8 @@ To prevent confusion between similarly named packages, the names of new packages
       [VisualStringDistances.jl](https://github.com/ericphanson/VisualStringDistances.jl)
       between the package name and any existing package must exceeds a certain
       a hand-chosen threshold (currently 2.5).
+
+These checks can be overridden by applying a label `Override AutoMerge: name similarity is okay` to the PR. This will turn off the check as long as the label is applied to the PR.
   """,
     check=data -> meets_distance_check(data.pkg, data.registry_master),
 )

--- a/src/AutoMerge/pull_requests.jl
+++ b/src/AutoMerge/pull_requests.jl
@@ -195,6 +195,7 @@ function pull_request_build(data::GitHubAutoMergeData; check_license)::Nothing
         check_license=check_license,
         this_is_jll_package=this_is_jll_package,
         this_pr_can_use_special_jll_exceptions=this_pr_can_use_special_jll_exceptions,
+        use_distance_check=perform_distance_check(data.pr.labels)
     )
     checked_guidelines = Guideline[]
 

--- a/test/automerge-unit.jl
+++ b/test/automerge-unit.jl
@@ -123,6 +123,12 @@ end
             "ReallyLooooongNameCD", ["ReallyLooooongNameAB"]
         )[1]
     end
+    @testset "perform_distance_check" begin
+        @test AutoMerge.perform_distance_check(nothing)
+        @test AutoMerge.perform_distance_check([GitHub.Label(; name="hi")])
+        @test !AutoMerge.perform_distance_check([GitHub.Label(; name="Override AutoMerge: name similarity is okay")])
+        @test !AutoMerge.perform_distance_check([GitHub.Label(; name="hi"), GitHub.Label(; name="Override AutoMerge: name similarity is okay")])
+    end
     @testset "`get_all_non_jll_package_names`" begin
         registry_path = joinpath(DEPOT_PATH[1], "registries", "General")
         packages = AutoMerge.get_all_non_jll_package_names(registry_path)
@@ -617,7 +623,7 @@ end
             @test result[1]
             result = has_osi_license_in_depot("VisualStringDistances")
             @test result[1]
-    
+
             # Now, what happens if there's also a non-OSI license in another file?
             pkg_path = pkgdir_from_depot(tmp_depot, "UnbalancedOptimalTransport")
             open(joinpath(pkg_path, "LICENSE2"); write=true) do io
@@ -627,12 +633,12 @@ end
             end
             result = has_osi_license_in_depot("UnbalancedOptimalTransport")
             @test result[1]
-    
+
             # What if we also remove the original license, leaving only the CC0 license?
             rm(joinpath(pkg_path, "LICENSE"))
             result = has_osi_license_in_depot("UnbalancedOptimalTransport")
             @test !result[1]
-    
+
             # What about no license at all?
             pkg_path = pkgdir_from_depot(tmp_depot, "VisualStringDistances")
             rm(joinpath(pkg_path, "LICENSE"))


### PR DESCRIPTION
...by turning off the distance check whenever the label is applied. The github action should be updated to activate when labels are added, for best effect, as shown in the example yaml.