### PR TITLE
AutoMerge: temporarily disable the "Require `[compat]` for stdlib dependencies" feature"

### DIFF
--- a/src/AutoMerge/guidelines.jl
+++ b/src/AutoMerge/guidelines.jl
@@ -1,7 +1,10 @@
 using HTTP: HTTP
 
-# TODO: change this to `true` once Julia 1.6 is no longer
-# the LTS.
+# TODO: change this value to `true` once we are ready to re-enable the
+# "Require `[compat]` for stdlib dependencies" feature.
+#
+# For example, we might consider changing this value to `true`
+# once Julia 1.6 is no longer the LTS.
 const _AUTOMERGE_REQUIRE_STDLIB_COMPAT = false
 
 const guideline_registry_consistency_tests_pass = Guideline(;

--- a/src/AutoMerge/guidelines.jl
+++ b/src/AutoMerge/guidelines.jl
@@ -1,5 +1,9 @@
 using HTTP: HTTP
 
+# TODO: change this to `true` once Julia 1.6 is no longer
+# the LTS.
+const _AUTOMERGE_REQUIRE_STDLIB_COMPAT = false
+
 const guideline_registry_consistency_tests_pass = Guideline(;
     info="Registy consistency tests",
     docs=nothing,
@@ -91,8 +95,15 @@ function meets_compat_for_all_deps(working_directory::AbstractString, pkg, versi
     for version_range in keys(deps)
         if version in Pkg.Types.VersionRange(version_range)
             for name in keys(deps[version_range])
-                if !is_jll_name(name)
-                    @debug("Found a new (non-JLL) dependency: $(name)")
+                if _AUTOMERGE_REQUIRE_STDLIB_COMPAT
+                    debug_msg = "Found a new (non-JLL) dependency: $(name)"
+                    apply_compat_requirement = !is_jll_name(name)
+                else
+                    debug_msg = "Found a new (non-stdlib non-JLL) dependency: $(name)"
+                    apply_compat_requirement = !is_jll_name(name) && !is_julia_stdlib(name)
+                end
+                if apply_compat_requirement
+                    @debug debug_msg
                     dep_has_compat_with_upper_bound[name] = false
                 end
             end

--- a/src/AutoMerge/util.jl
+++ b/src/AutoMerge/util.jl
@@ -239,6 +239,20 @@ function comment_text_merge_now()
     return result
 end
 
+is_julia_stdlib(name) = name in julia_stdlib_list()
+
+function julia_stdlib_list()
+    stdlib_list = readdir(Pkg.Types.stdlib_dir())
+    # Before Julia v1.6 Artifacts.jl isn't a standard library, but
+    # we want to include it because JLL packages depend on the empty
+    # placeholder https://github.com/JuliaPackaging/Artifacts.jl
+    # in older versions for compatibility.
+    if VERSION < v"1.6.0"
+        push!(stdlib_list, "Artifacts")
+    end
+    return stdlib_list
+end
+
 function now_utc()
     utc = TimeZones.tz"UTC"
     return Dates.now(utc)


### PR DESCRIPTION
Follow-up to #516 

Once we are ready to re-enable the "Require `[compat]` for stdlib dependencies" feature", we just need to change the following value from `false` to `true`:

https://github.com/JuliaRegistries/RegistryCI.jl/blob/d4f84b521bab13f57b355a979120455e34db0954/src/AutoMerge/guidelines.jl#L5-L5