### PR TITLE
Bump version for release

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -4,6 +4,22 @@ on:
     types:
       - created
   workflow_dispatch:
+    inputs:
+      lookback:
+        default: 3
+permissions:
+  actions: read
+  checks: read
+  contents: write
+  deployments: read
+  issues: read
+  discussions: read
+  packages: read
+  pages: read
+  pull-requests: read
+  repository-projects: read
+  security-events: read
+  statuses: read
 jobs:
   TagBot:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryCI"
 uuid = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
 authors = ["Dilum Aluthge <dilum@aluthge.com>", "Fredrik Ekre <ekrefredrik@gmail.com>", "contributors"]
-version = "9.1.0"
+version = "10.0.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"


### PR DESCRIPTION
Also updates tagbot, so we have the best chances of actually getting a tag.

When we register this, we can include these release notes:

```
* Turn off stdlib compat requirement ([#540](https://github.com/JuliaRegistries/RegistryCI.jl/pull/540))
* Adds label-reading support for author-approval workflow ([#539](https://github.com/JuliaRegistries/RegistryCI.jl/pull/539)) and overriding the name similarity check ([#536](https://github.com/JuliaRegistries/RegistryCI.jl/pull/536))
```

We should only tag after landing #539 and #541