### PR TITLE
Fix sequential version message

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryCI"
 uuid = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
 authors = ["Dilum Aluthge <dilum@aluthge.com>", "Fredrik Ekre <ekrefredrik@gmail.com>", "contributors"]
-version = "10.0.0"
+version = "10.0.1"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/AutoMerge/guidelines.jl
+++ b/src/AutoMerge/guidelines.jl
@@ -458,7 +458,7 @@ function meets_repo_url_requirement(pkg::String; registry_head::String)
 end
 
 function _invalid_sequential_version(reason::AbstractString)
-    return false, "Does not meet sequential version number guideline: $(reason). If this was intentional, please leave a comment saying so. Otherwise please correct the version number in your package and re-trigger registration.", :invalid
+    return false, "Does not meet sequential version number guideline: $(reason). $PACKAGE_AUTHOR_APPROVAL_INSTRUCTIONS", :invalid
 end
 
 function _valid_change(old_version::VersionNumber, new_version::VersionNumber)
@@ -489,7 +489,6 @@ const guideline_sequential_version_number = Guideline(;
         "valid new versions are `1.0.1`, `1.1.1`, `1.2.0` and `2.0.0`. ",
         "Invalid new versions include `1.0.2` (skips `1.0.1`), ",
         "`1.3.0` (skips `1.2.0`), `3.0.0` (skips `2.0.0`) etc.",
-        PACKAGE_AUTHOR_APPROVAL_INSTRUCTIONS,
     ),
     check=data -> meets_sequential_version_number(
         data.pkg,


### PR DESCRIPTION
in #539 I placed the message in the wrong spot, as revealed by https://github.com/JuliaRegistries/General/pull/99875#issuecomment-1917615690, which still says

> Does not meet sequential version number guideline: version 3.1.3 skips over 3.1.2. If this was intentional, please leave a comment saying so. Otherwise please correct the version number in your package and re-trigger registration.


instead of the intended new message directing the author to approve if desired.

I've bumped the version here so we can release the bugfix right away.