### PR TITLE
fix tiny typo in sequential merge instructions

### DIFF
--- a/src/AutoMerge/guidelines.jl
+++ b/src/AutoMerge/guidelines.jl
@@ -476,7 +476,7 @@ function _valid_change(old_version::VersionNumber, new_version::VersionNumber)
 end
 
 const PACKAGE_AUTHOR_APPROVAL_INSTRUCTIONS = string(
-    "**If this was not a mistake and you wish to merge this PR anyway,",
+    "**If this was not a mistake and you wish to merge this PR anyway, ",
     "write a comment that says `[merge approved]`.**")
 
 const guideline_sequential_version_number = Guideline(;


### PR DESCRIPTION
noticed in https://github.com/JuliaRegistries/General/pull/99903