### PR TITLE
make authorization a guideline rather than early exit

### DIFF
--- a/src/AutoMerge/guidelines.jl
+++ b/src/AutoMerge/guidelines.jl
@@ -7,6 +7,19 @@ using HTTP: HTTP
 # once Julia 1.6 is no longer the LTS.
 const _AUTOMERGE_REQUIRE_STDLIB_COMPAT = false
 
+const guideline_pr_is_authorized = Guideline(;
+    info="PR creator is authorized for automerging",
+    check=data -> meets_pr_is_authorized(data.authorized),
+)
+
+function meets_pr_is_authorized(authorization)
+    if authorization == :not_authorized
+        return false, "PR creator is not authorized for merging. [Registrator.jl](https://github.com/JuliaRegistries/Registrator.jl) can be used for creating authorized registration PRs. Alternatively, this PR can be manually merged (especially if all the other guidelines are satisfied)."
+    else
+        return true, ""
+    end
+end
+
 const guideline_registry_consistency_tests_pass = Guideline(;
     info="Registy consistency tests",
     docs=nothing,
@@ -1042,6 +1055,7 @@ function get_automerge_guidelines(
         (guideline_version_can_be_imported, true),
         (:update_status, true),
         (guideline_dependency_confusion, true),
+        (guideline_pr_is_authorized, true),
         # this is the non-optional part of name checking
         (guideline_name_match_check, true),
         # We always run the `guideline_distance_check`
@@ -1084,6 +1098,7 @@ function get_automerge_guidelines(
         (guideline_version_has_osi_license, check_license),
         (guideline_src_names_OK, true),
         (guideline_version_can_be_imported, true),
+        (guideline_pr_is_authorized, true)
     ]
     return guidelines
 end

--- a/src/AutoMerge/pull_requests.jl
+++ b/src/AutoMerge/pull_requests.jl
@@ -127,6 +127,9 @@ function pull_request_build(
         return nothing
     end
 
+    # Here we check whether or not the PR author is authorized
+    # for merging. If not, we will fail a guideline, but
+    # we will still run all the guidelines.
     pkg, version = parse_pull_request_title(registration_type, pr)
     pr_author_login = author_login(pr)
     authorization = check_authorization(
@@ -136,10 +139,6 @@ function pull_request_build(
         authorized_authors_special_jll_exceptions,
         error_exit_if_automerge_not_applicable,
     )
-
-    if authorization == :not_authorized
-        return nothing
-    end
 
     registry_master = clone_repo(registry)
     if !master_branch_is_default_branch

--- a/src/AutoMerge/types.jl
+++ b/src/AutoMerge/types.jl
@@ -63,6 +63,7 @@ struct GitHubAutoMergeData
     auth::GitHub.Authorization
 
     # Type of authorization for automerge. This can be either:
+    # :not_authorized - PR is not authorized for merging
     # :jll - special jll exceptions are allowed,
     # :normal - normal automerge rules.
     authorization::Symbol
@@ -112,7 +113,7 @@ function GitHubAutoMergeData(; kwargs...)
     kwargs = (; pkg_code_path=pkg_code_path, kwargs...)
     fields = fieldnames(GitHubAutoMergeData)
     always_assert(Set(keys(kwargs)) == Set(fields))
-    always_assert(kwargs[:authorization] ∈ (:normal, :jll))
+    always_assert(kwargs[:authorization] ∈ (:not_authorized, :normal, :jll))
     return GitHubAutoMergeData(getindex.(Ref(kwargs), fields)...)
 end
 

--- a/test/automerge-unit.jl
+++ b/test/automerge-unit.jl
@@ -76,6 +76,11 @@ end
 end
 
 @testset "Guidelines for new packages" begin
+    @testset "meets_pr_is_authorized" begin
+        @test !AutoMerge.meets_pr_is_authorized(:not_authorized)[1]
+        @test AutoMerge.meets_pr_is_authorized(:jll)[1]
+        @test AutoMerge.meets_pr_is_authorized(:normal)[1]
+    end
     @testset "Normal capitalization" begin
         @test AutoMerge.meets_normal_capitalization("Zygote")[1]  # Regular name
         @test AutoMerge.meets_normal_capitalization("Zygote")[1]


### PR DESCRIPTION
As discussed on Slack, this is a step towards running AutoMerge on non-Registrator PRs. We also need to tweak the `if` on General to run AutoMerge on forks.

Note that we don't provision the merging token unless the PR is not from a fork, so we do have some additional security from that.

The guideline shoudl help give a clear error to explain why merging is not happening.

I put the guideline near the end so we still run all the other checks (it is after the last `:update_status`).