### PR TITLE
Don't automerge packages whose names end with jl

### DIFF
--- a/src/AutoMerge/guidelines.jl
+++ b/src/AutoMerge/guidelines.jl
@@ -244,7 +244,7 @@ function meets_name_ascii(pkg)
 end
 
 const guideline_julia_name_check = Guideline(;
-    info="Name does not include \"julia\" or start with \"Ju\".",
+    info="Name does not include \"julia\", start with \"Ju\", or end with \"jl\".",
     check=data -> meets_julia_name_check(data.pkg),
 )
 
@@ -254,6 +254,8 @@ function meets_julia_name_check(pkg)
         "Lowercase package name $(lowercase(pkg)) contains the string \"julia\"."
     elseif startswith(pkg, "Ju")
         return false, "Package name starts with \"Ju\"."
+    elseif endswith(lowercase(pkg), "jl")
+        return false, "Lowercase package name $(lowercase(pkg)) ends with \"jl\"."
     else
         return true, ""
     end

--- a/test/automerge-unit.jl
+++ b/test/automerge-unit.jl
@@ -94,12 +94,14 @@ end
         @test !AutoMerge.meets_name_length("Flux")[1]
         @test !AutoMerge.meets_name_length("Flux")[1]
     end
-    @testset "Name does not include \"julia\" or start with \"Ju\"" begin
+    @testset "Name does not include \"julia\", start with \"Ju\", or end with \"jl\"" begin
         @test AutoMerge.meets_julia_name_check("Zygote")[1]
         @test AutoMerge.meets_julia_name_check("RegistryCI")[1]
         @test !AutoMerge.meets_julia_name_check("JuRegistryCI")[1]
         @test !AutoMerge.meets_julia_name_check("ZygoteJulia")[1]
         @test !AutoMerge.meets_julia_name_check("Zygotejulia")[1]
+        @test !AutoMerge.meets_julia_name_check("Sortingjl")[1]
+        @test !AutoMerge.meets_julia_name_check("BananasJL")[1]
         @test !AutoMerge.meets_julia_name_check("AbcJuLiA")[1]
     end
     @testset "Package name is ASCII" begin


### PR DESCRIPTION
Inspired by https://github.com/JuliaRegistries/General/pull/100209. Whether or not folks decide to allow the name PsychoJL.jl, all such names should require manual approval.