### PR TITLE
Bump version for release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryCI"
 uuid = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
 authors = ["Dilum Aluthge <dilum@aluthge.com>", "Fredrik Ekre <ekrefredrik@gmail.com>", "contributors"]
-version = "10.1.0"
+version = "10.2.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"


### PR DESCRIPTION
I want to release these changes once they are in:

- https://github.com/JuliaRegistries/RegistryCI.jl/pull/552
- https://github.com/JuliaRegistries/RegistryCI.jl/pull/550
- https://github.com/JuliaRegistries/RegistryCI.jl/pull/548

They are all non-breaking; two improve the comment, and one causes us to leave the comment with an explicit failure rather than exiting without making a comment at all.