### PR TITLE
Correctly handle an edge case in the sequential version check

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryCI"
 uuid = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
 authors = ["Dilum Aluthge <dilum@aluthge.com>", "Fredrik Ekre <ekrefredrik@gmail.com>", "contributors"]
-version = "10.3.0"
+version = "10.3.1"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/AutoMerge/guidelines.jl
+++ b/src/AutoMerge/guidelines.jl
@@ -501,6 +501,16 @@ end
 
 function _valid_change(old_version::VersionNumber, new_version::VersionNumber)
     diff = difference(old_version, new_version)
+    if !(diff isa VersionNumber)
+        if diff isa ErrorCannotComputeVersionDifference
+            old_msg = diff.msg
+        else
+            T = typeof(diff)
+            old_msg = "Unknown diff type: $(T)"
+        end
+        new_msg = "Error occured while trying to compute version bump. Message: $(old_msg)"
+        return _invalid_sequential_version(new_msg)
+    end
     @debug("Difference between versions: ", old_version, new_version, diff)
     if diff == v"0.0.1"
         return true, "", :patch

--- a/src/AutoMerge/semver.jl
+++ b/src/AutoMerge/semver.jl
@@ -14,9 +14,9 @@ function difference(x::VersionNumber, y::VersionNumber)
     elseif y.patch > x.patch
         return VersionNumber(y.major - x.major, y.minor - x.minor, y.patch - x.patch)
     else
-        throw(
-            ArgumentError("first argument must be strictly less than the second argument")
-        )
+        msg = "first argument $(x) must be strictly less than the second argument $(y)"
+        @warn msg x y
+        return ErrorCannotComputeVersionDifference(msg)
     end
 end
 

--- a/src/AutoMerge/types.jl
+++ b/src/AutoMerge/types.jl
@@ -36,6 +36,7 @@ struct AutoMergeWrongBuildType <: AutoMergeException
 end
 
 struct ErrorCannotComputeVersionDifference
+    msg::String
 end
 
 struct GitHubAutoMergeData

--- a/src/AutoMerge/types.jl
+++ b/src/AutoMerge/types.jl
@@ -35,6 +35,9 @@ struct AutoMergeWrongBuildType <: AutoMergeException
     msg::String
 end
 
+struct ErrorCannotComputeVersionDifference
+end
+
 struct GitHubAutoMergeData
     # Handle to the GitHub API. Used to query the PR and update
     # comments and status.

--- a/test/automerge-unit.jl
+++ b/test/automerge-unit.jl
@@ -527,8 +527,8 @@ end
         @test AutoMerge.nextmajor(v"1.2") == v"2"
         @test AutoMerge.nextmajor(v"1.2.3") == v"2"
         @test AutoMerge.difference(v"1", v"2") == v"1"
-        @test_throws ArgumentError AutoMerge.difference(v"1", v"1")
-        @test_throws ArgumentError AutoMerge.difference(v"2", v"1")
+        @test AutoMerge.difference(v"1", v"1") isa AutoMerge.ErrorCannotComputeVersionDifference
+        @test AutoMerge.difference(v"2", v"1") isa AutoMerge.ErrorCannotComputeVersionDifference
         @test !AutoMerge._has_upper_bound(Pkg.Types.VersionRange("0"))
         @test AutoMerge._has_upper_bound(Pkg.Types.VersionRange("1"))
         @test !AutoMerge._has_upper_bound(Pkg.Types.VersionRange("*"))


### PR DESCRIPTION
Fixes #562 

The basic idea of this PR is to take something out of the "exception" domain and move it into the "guideline failure" domain. This allows us to surface the underlying error back up to the user (in the form of the AutoMerge comment).