### PR TITLE
Tweak AutoMerge comment formatting and wording

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryCI"
 uuid = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
 authors = ["Dilum Aluthge <dilum@aluthge.com>", "Fredrik Ekre <ekrefredrik@gmail.com>", "contributors"]
-version = "10.3.1"
+version = "10.4.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/AutoMerge/cron.jl
+++ b/src/AutoMerge/cron.jl
@@ -399,7 +399,6 @@ function cron_or_api_build(
     if pr_type == :NewPackage # it is a new package
         always_assert(status_pr_type == :NewPackage)
         if merge_new_packages
-            my_comment = comment_text_merge_now()
             @info(
                 string(
                     "Pull request: $(pr_number). ",
@@ -434,7 +433,6 @@ function cron_or_api_build(
         always_assert(pr_type == :NewVersion)
         always_assert(status_pr_type == :NewVersion)
         if merge_new_versions
-            my_comment = comment_text_merge_now()
             @info(
                 string(
                     "Pull request: $(pr_number). ",

--- a/src/AutoMerge/util.jl
+++ b/src/AutoMerge/util.jl
@@ -105,14 +105,14 @@ function _comment_bot_intro()
 end
 
 function _new_package_section(n)
-    return string("## $n. New package registration", "\n\n",
+    return string("### $n. New package registration", "\n\n",
     "Since you are registering a new package, please make sure that you have read the ",
     "[package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).\n\n")
 end
 
 function _what_next_if_fail(n; point_to_slack=false)
     msg = """
-    ## $n. *Needs action*: here's what to do next
+    ### $n. *Needs action*: here's what to do next
 
     1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so. You can also leave a comment on this PR (and include `[noblock]`)"""
     if point_to_slack
@@ -131,16 +131,16 @@ function _what_next_if_fail(n; point_to_slack=false)
 end
 
 function _automerge_guidelines_failed_section_title(n)
-    return "## $n. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌\n\n"
+    return "### $n. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌\n\n"
 end
 
 function _automerge_guidelines_passed_section_title(n)
-    "## $n. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅\n\n"
+    "### $n. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅\n\n"
 end
 
 function _comment_noblock(n)
     result = string(
-        "## $n. To pause or stop registration\n\n",
+        "### $n. To pause or stop registration\n\n",
         "If you want to prevent this pull request from ",
         "being auto-merged, simply leave a comment. ",
         "If you want to post a comment without blocking ",
@@ -276,7 +276,7 @@ end
 function _onepointzero_suggestion(n, suggest_onepointzero::Bool, version::VersionNumber)
     if suggest_onepointzero && version < v"1.0.0"
         result = string(
-            "## $n. Declare v1.0?\n\n",
+            "### $n. Declare v1.0?\n\n",
             "On a separate note, I see that you are registering ",
             "a release with a version number of the form ",
             "`v0.X.Y`.\n\n",

--- a/src/AutoMerge/util.jl
+++ b/src/AutoMerge/util.jl
@@ -96,8 +96,8 @@ end
 # We hope they will at least read the section titles, and if they aren't
 # familiar, hopefully they will also read the sections themselves.
 
-function _comment_bot_intro(n)
-    return string("## $n. Introduction\n\n", "Hello, I am an automated registration bot.",
+function _comment_bot_intro()
+    return string("Hello, I am an automated registration bot.",
     " I help manage the registration process by checking your registration against a set of ","[AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). ",
     "Meeting these guidelines is only required for the pull request to be **merged automatically**. ",
     "However, it is **strongly recommended** to follow them, since otherwise ",
@@ -158,13 +158,13 @@ function comment_text_pass(
     # Need to know this ahead of time to get the section numbers right
     suggest_onepointzero &= version < v"1.0.0"
     result = string(
-        _comment_bot_intro(1),
-        _automerge_guidelines_passed_section_title(2),
+        _comment_bot_intro(),
+        _automerge_guidelines_passed_section_title(1),
         "Your new version registration met all of the ",
         "guidelines for auto-merging and is scheduled to ",
         "be merged in the next round.\n\n",
-        _onepointzero_suggestion(3, suggest_onepointzero, version),
-        _comment_noblock(suggest_onepointzero ? 4 : 3),
+        _onepointzero_suggestion(2, suggest_onepointzero, version),
+        _comment_noblock(suggest_onepointzero ? 3 : 2),
         "<!-- [noblock] -->",
     )
     return result
@@ -176,25 +176,25 @@ function comment_text_pass(
     suggest_onepointzero &= version < v"1.0.0"
     if is_jll
         result = string(
-            _comment_bot_intro(1),
-            _automerge_guidelines_passed_section_title(2),
+            _comment_bot_intro(),
+            _automerge_guidelines_passed_section_title(1),
             "Your new `_jll` package registration met all of the ",
             "guidelines for auto-merging and is scheduled to ",
             "be merged in the next round.\n\n",
-            _onepointzero_suggestion(3, suggest_onepointzero, version),
-            _comment_noblock(suggest_onepointzero ? 4 : 3),
+            _onepointzero_suggestion(2, suggest_onepointzero, version),
+            _comment_noblock(suggest_onepointzero ? 3 : 2),
             "<!-- [noblock] -->",
         )
     else
         result = string(
-            _comment_bot_intro(1),
-            _new_package_section(2),
-            _automerge_guidelines_passed_section_title(3),
+            _comment_bot_intro(),
+            _new_package_section(1),
+            _automerge_guidelines_passed_section_title(2),
             "Your new package registration met all of the ",
             "guidelines for auto-merging and is scheduled to ",
             "be merged when the mandatory waiting period ($new_package_waiting_period) has elapsed.\n\n",
-            _onepointzero_suggestion(4, suggest_onepointzero, version),
-            _comment_noblock(suggest_onepointzero ? 5 : 4),
+            _onepointzero_suggestion(3, suggest_onepointzero, version),
+            _comment_noblock(suggest_onepointzero ? 4 : 3),
             "<!-- [noblock] -->",
         )
     end
@@ -211,13 +211,13 @@ function comment_text_fail(
     suggest_onepointzero &= version < v"1.0.0"
     reasons_formatted = string(join(string.("- ", reasons), "\n"), "\n\n")
     result = string(
-        _comment_bot_intro(1),
-        _new_package_section(2),
-        _automerge_guidelines_failed_section_title(3),
+        _comment_bot_intro(),
+        _new_package_section(1),
+        _automerge_guidelines_failed_section_title(2),
         reasons_formatted,
-        _what_next_if_fail(4; point_to_slack=point_to_slack),
-        _onepointzero_suggestion(5, suggest_onepointzero, version),
-        _comment_noblock(suggest_onepointzero ? 6 : 5),
+        _what_next_if_fail(3; point_to_slack=point_to_slack),
+        _onepointzero_suggestion(4, suggest_onepointzero, version),
+        _comment_noblock(suggest_onepointzero ? 5 : 4),
         "<!-- [noblock] -->",
     )
     return result
@@ -233,12 +233,12 @@ function comment_text_fail(
     suggest_onepointzero &= version < v"1.0.0"
     reasons_formatted = string(join(string.("- ", reasons), "\n"), "\n\n")
     result = string(
-        _comment_bot_intro(1),
-        _automerge_guidelines_failed_section_title(2),
+        _comment_bot_intro(),
+        _automerge_guidelines_failed_section_title(1),
         reasons_formatted,
-        _what_next_if_fail(3; point_to_slack=point_to_slack),
-        _onepointzero_suggestion(4, suggest_onepointzero, version),
-        _comment_noblock(suggest_onepointzero ? 5 : 4),
+        _what_next_if_fail(2; point_to_slack=point_to_slack),
+        _onepointzero_suggestion(3, suggest_onepointzero, version),
+        _comment_noblock(suggest_onepointzero ? 4 : 3),
         "<!-- [noblock] -->",
     )
     return result

--- a/src/AutoMerge/util.jl
+++ b/src/AutoMerge/util.jl
@@ -244,16 +244,6 @@ function comment_text_fail(
     return result
 end
 
-function comment_text_merge_now()
-    result = string(
-        "The mandatory waiting period has elapsed.\n\n",
-        "Your pull request is ready to merge.\n\n",
-        "I will now merge this pull request.",
-        "\n<!-- [noblock] -->",
-    )
-    return result
-end
-
 is_julia_stdlib(name) = name in julia_stdlib_list()
 
 function julia_stdlib_list()

--- a/src/AutoMerge/util.jl
+++ b/src/AutoMerge/util.jl
@@ -98,15 +98,14 @@ end
 
 function _comment_bot_intro()
     return string("Hello, I am an automated registration bot.",
-    " I help manage the registration process by checking your registration against a set of ","[AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). ",
-    "Meeting these guidelines is only required for the pull request to be **merged automatically**. ",
-    "However, it is **strongly recommended** to follow them, since otherwise ",
+    " I help manage the registration process by checking your registration against a set of ","[AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).\n\n",
+    "If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise ",
     "the pull request needs to be manually reviewed and merged by a human.\n\n")
 end
 
 function _new_package_section(n)
     return string("### $n. New package registration", "\n\n",
-    "Since you are registering a new package, please make sure that you have read the ",
+    "Please make sure that you have read the ",
     "[package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).\n\n")
 end
 
@@ -114,17 +113,14 @@ function _what_next_if_fail(n; point_to_slack=false)
     msg = """
     ### $n. *Needs action*: here's what to do next
 
-    1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so. You can also leave a comment on this PR (and include `[noblock]`)"""
-    if point_to_slack
-        msg = string(msg, " or send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) to ask for help. Include a link to this pull request if you do so!")
-    end
+    1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so."""
     msg = string(msg, "\n",
-        "2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless of course the AutoMerge issue is that you skipped a version number, in which case you should change the version number).",
+        "2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless the AutoMerge issue is that you skipped a version number).",
         "\n\n",
-        "If you do not want to fix the AutoMerge issues, please post a comment explaining why you would like this pull request to be manually merged.")
+        "If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged.")
 
     if point_to_slack
-        msg = string(msg, " Then, send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) to ask for help.")
+        msg = string(msg, " Then, send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) for better visibility.")
     end
     msg = string(msg, "\n\n")
     return msg
@@ -146,8 +142,8 @@ function _comment_noblock(n)
         "If you want to post a comment without blocking ",
         "auto-merging, you must include the text ",
         "`[noblock]` in your comment. ",
-        "You can edit blocking comments, adding `[noblock]` ",
-        "to them in order to unblock auto-merging.\n\n",
+        "\n\n_Tip: You can edit blocking comments to add `[noblock]` ",
+        "in order to unblock auto-merging._\n\n",
     )
     return result
 end

--- a/src/AutoMerge/util.jl
+++ b/src/AutoMerge/util.jl
@@ -104,14 +104,14 @@ function _comment_bot_intro()
 end
 
 function _new_package_section(n)
-    return string("### $n. New package registration", "\n\n",
+    return string("## $n. New package registration", "\n\n",
     "Please make sure that you have read the ",
     "[package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).\n\n")
 end
 
 function _what_next_if_fail(n; point_to_slack=false)
     msg = """
-    ### $n. *Needs action*: here's what to do next
+    ## $n. *Needs action*: here's what to do next
 
     1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so."""
     msg = string(msg, "\n",
@@ -127,16 +127,16 @@ function _what_next_if_fail(n; point_to_slack=false)
 end
 
 function _automerge_guidelines_failed_section_title(n)
-    return "### $n. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌\n\n"
+    return "## $n. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌\n\n"
 end
 
 function _automerge_guidelines_passed_section_title(n)
-    "### $n. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅\n\n"
+    "## $n. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅\n\n"
 end
 
 function _comment_noblock(n)
     result = string(
-        "### $n. To pause or stop registration\n\n",
+        "## $n. To pause or stop registration\n\n",
         "If you want to prevent this pull request from ",
         "being auto-merged, simply leave a comment. ",
         "If you want to post a comment without blocking ",
@@ -262,7 +262,7 @@ end
 function _onepointzero_suggestion(n, suggest_onepointzero::Bool, version::VersionNumber)
     if suggest_onepointzero && version < v"1.0.0"
         result = string(
-            "### $n. Declare v1.0?\n\n",
+            "## $n. Declare v1.0?\n\n",
             "On a separate note, I see that you are registering ",
             "a release with a version number of the form ",
             "`v0.X.Y`.\n\n",

--- a/src/AutoMerge/util.jl
+++ b/src/AutoMerge/util.jl
@@ -98,7 +98,7 @@ end
 
 function _comment_bot_intro()
     return string("Hello, I am an automated registration bot.",
-    " I help manage the registration process by checking your registration against a set of ","[AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).\n\n",
+    " I help manage the registration process by checking your registration against a set of ","[AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). ",
     "If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise ",
     "the pull request needs to be manually reviewed and merged by a human.\n\n")
 end

--- a/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_0.1.0_point_to_slack_false.md
+++ b/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_0.1.0_point_to_slack_false.md
@@ -1,21 +1,21 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. New package registration
+### 1. New package registration
 
 Since you are registering a new package, please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+### 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-## 3. *Needs action*: here's what to do next
+### 3. *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so. You can also leave a comment on this PR (and include `[noblock]`)
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless of course the AutoMerge issue is that you skipped a version number, in which case you should change the version number).
 
 If you do not want to fix the AutoMerge issues, please post a comment explaining why you would like this pull request to be manually merged.
 
-## 4. To pause or stop registration
+### 4. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_0.1.0_point_to_slack_false.md
+++ b/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_0.1.0_point_to_slack_false.md
@@ -1,8 +1,10 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
+
+If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. New package registration
 
-Since you are registering a new package, please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
+Please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
 ### 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
@@ -10,13 +12,15 @@ Since you are registering a new package, please make sure that you have read the
 
 ### 3. *Needs action*: here's what to do next
 
-1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so. You can also leave a comment on this PR (and include `[noblock]`)
-2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless of course the AutoMerge issue is that you skipped a version number, in which case you should change the version number).
+1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so.
+2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless the AutoMerge issue is that you skipped a version number).
 
-If you do not want to fix the AutoMerge issues, please post a comment explaining why you would like this pull request to be manually merged.
+If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged.
 
 ### 4. To pause or stop registration
 
-If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
+If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
+
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
 
 <!-- [noblock] -->

--- a/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_0.1.0_point_to_slack_false.md
+++ b/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_0.1.0_point_to_slack_false.md
@@ -1,23 +1,21 @@
-## 1. Introduction
-
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 2. New package registration
+## 1. New package registration
 
 Since you are registering a new package, please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-## 3. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-## 4. *Needs action*: here's what to do next
+## 3. *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so. You can also leave a comment on this PR (and include `[noblock]`)
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless of course the AutoMerge issue is that you skipped a version number, in which case you should change the version number).
 
 If you do not want to fix the AutoMerge issues, please post a comment explaining why you would like this pull request to be manually merged.
 
-## 5. To pause or stop registration
+## 4. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_0.1.0_point_to_slack_false.md
+++ b/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_0.1.0_point_to_slack_false.md
@@ -1,21 +1,21 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-### 1. New package registration
+## 1. New package registration
 
 Please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-### 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-### 3. *Needs action*: here's what to do next
+## 3. *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so.
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless the AutoMerge issue is that you skipped a version number).
 
 If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged.
 
-### 4. To pause or stop registration
+## 4. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_0.1.0_point_to_slack_false.md
+++ b/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_0.1.0_point_to_slack_false.md
@@ -1,6 +1,4 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
-
-If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. New package registration
 

--- a/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_0.1.0_point_to_slack_true.md
+++ b/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_0.1.0_point_to_slack_true.md
@@ -1,23 +1,21 @@
-## 1. Introduction
-
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 2. New package registration
+## 1. New package registration
 
 Since you are registering a new package, please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-## 3. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-## 4. *Needs action*: here's what to do next
+## 3. *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so. You can also leave a comment on this PR (and include `[noblock]`) or send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) to ask for help. Include a link to this pull request if you do so!
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless of course the AutoMerge issue is that you skipped a version number, in which case you should change the version number).
 
 If you do not want to fix the AutoMerge issues, please post a comment explaining why you would like this pull request to be manually merged. Then, send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) to ask for help.
 
-## 5. To pause or stop registration
+## 4. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_0.1.0_point_to_slack_true.md
+++ b/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_0.1.0_point_to_slack_true.md
@@ -1,8 +1,10 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
+
+If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. New package registration
 
-Since you are registering a new package, please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
+Please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
 ### 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
@@ -10,13 +12,15 @@ Since you are registering a new package, please make sure that you have read the
 
 ### 3. *Needs action*: here's what to do next
 
-1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so. You can also leave a comment on this PR (and include `[noblock]`) or send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) to ask for help. Include a link to this pull request if you do so!
-2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless of course the AutoMerge issue is that you skipped a version number, in which case you should change the version number).
+1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so.
+2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless the AutoMerge issue is that you skipped a version number).
 
-If you do not want to fix the AutoMerge issues, please post a comment explaining why you would like this pull request to be manually merged. Then, send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) to ask for help.
+If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged. Then, send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) for better visibility.
 
 ### 4. To pause or stop registration
 
-If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
+If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
+
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
 
 <!-- [noblock] -->

--- a/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_0.1.0_point_to_slack_true.md
+++ b/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_0.1.0_point_to_slack_true.md
@@ -1,21 +1,21 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-### 1. New package registration
+## 1. New package registration
 
 Please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-### 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-### 3. *Needs action*: here's what to do next
+## 3. *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so.
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless the AutoMerge issue is that you skipped a version number).
 
 If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged. Then, send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) for better visibility.
 
-### 4. To pause or stop registration
+## 4. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_0.1.0_point_to_slack_true.md
+++ b/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_0.1.0_point_to_slack_true.md
@@ -1,21 +1,21 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. New package registration
+### 1. New package registration
 
 Since you are registering a new package, please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+### 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-## 3. *Needs action*: here's what to do next
+### 3. *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so. You can also leave a comment on this PR (and include `[noblock]`) or send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) to ask for help. Include a link to this pull request if you do so!
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless of course the AutoMerge issue is that you skipped a version number, in which case you should change the version number).
 
 If you do not want to fix the AutoMerge issues, please post a comment explaining why you would like this pull request to be manually merged. Then, send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) to ask for help.
 
-## 4. To pause or stop registration
+### 4. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_0.1.0_point_to_slack_true.md
+++ b/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_0.1.0_point_to_slack_true.md
@@ -1,6 +1,4 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
-
-If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. New package registration
 

--- a/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_1.0.0_point_to_slack_false.md
+++ b/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_1.0.0_point_to_slack_false.md
@@ -1,21 +1,21 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. New package registration
+### 1. New package registration
 
 Since you are registering a new package, please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+### 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-## 3. *Needs action*: here's what to do next
+### 3. *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so. You can also leave a comment on this PR (and include `[noblock]`)
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless of course the AutoMerge issue is that you skipped a version number, in which case you should change the version number).
 
 If you do not want to fix the AutoMerge issues, please post a comment explaining why you would like this pull request to be manually merged.
 
-## 4. To pause or stop registration
+### 4. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_1.0.0_point_to_slack_false.md
+++ b/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_1.0.0_point_to_slack_false.md
@@ -1,8 +1,10 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
+
+If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. New package registration
 
-Since you are registering a new package, please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
+Please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
 ### 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
@@ -10,13 +12,15 @@ Since you are registering a new package, please make sure that you have read the
 
 ### 3. *Needs action*: here's what to do next
 
-1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so. You can also leave a comment on this PR (and include `[noblock]`)
-2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless of course the AutoMerge issue is that you skipped a version number, in which case you should change the version number).
+1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so.
+2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless the AutoMerge issue is that you skipped a version number).
 
-If you do not want to fix the AutoMerge issues, please post a comment explaining why you would like this pull request to be manually merged.
+If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged.
 
 ### 4. To pause or stop registration
 
-If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
+If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
+
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
 
 <!-- [noblock] -->

--- a/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_1.0.0_point_to_slack_false.md
+++ b/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_1.0.0_point_to_slack_false.md
@@ -1,23 +1,21 @@
-## 1. Introduction
-
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 2. New package registration
+## 1. New package registration
 
 Since you are registering a new package, please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-## 3. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-## 4. *Needs action*: here's what to do next
+## 3. *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so. You can also leave a comment on this PR (and include `[noblock]`)
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless of course the AutoMerge issue is that you skipped a version number, in which case you should change the version number).
 
 If you do not want to fix the AutoMerge issues, please post a comment explaining why you would like this pull request to be manually merged.
 
-## 5. To pause or stop registration
+## 4. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_1.0.0_point_to_slack_false.md
+++ b/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_1.0.0_point_to_slack_false.md
@@ -1,21 +1,21 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-### 1. New package registration
+## 1. New package registration
 
 Please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-### 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-### 3. *Needs action*: here's what to do next
+## 3. *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so.
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless the AutoMerge issue is that you skipped a version number).
 
 If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged.
 
-### 4. To pause or stop registration
+## 4. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_1.0.0_point_to_slack_false.md
+++ b/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_1.0.0_point_to_slack_false.md
@@ -1,6 +1,4 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
-
-If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. New package registration
 

--- a/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_1.0.0_point_to_slack_true.md
+++ b/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_1.0.0_point_to_slack_true.md
@@ -1,23 +1,21 @@
-## 1. Introduction
-
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 2. New package registration
+## 1. New package registration
 
 Since you are registering a new package, please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-## 3. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-## 4. *Needs action*: here's what to do next
+## 3. *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so. You can also leave a comment on this PR (and include `[noblock]`) or send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) to ask for help. Include a link to this pull request if you do so!
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless of course the AutoMerge issue is that you skipped a version number, in which case you should change the version number).
 
 If you do not want to fix the AutoMerge issues, please post a comment explaining why you would like this pull request to be manually merged. Then, send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) to ask for help.
 
-## 5. To pause or stop registration
+## 4. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_1.0.0_point_to_slack_true.md
+++ b/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_1.0.0_point_to_slack_true.md
@@ -1,8 +1,10 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
+
+If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. New package registration
 
-Since you are registering a new package, please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
+Please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
 ### 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
@@ -10,13 +12,15 @@ Since you are registering a new package, please make sure that you have read the
 
 ### 3. *Needs action*: here's what to do next
 
-1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so. You can also leave a comment on this PR (and include `[noblock]`) or send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) to ask for help. Include a link to this pull request if you do so!
-2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless of course the AutoMerge issue is that you skipped a version number, in which case you should change the version number).
+1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so.
+2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless the AutoMerge issue is that you skipped a version number).
 
-If you do not want to fix the AutoMerge issues, please post a comment explaining why you would like this pull request to be manually merged. Then, send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) to ask for help.
+If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged. Then, send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) for better visibility.
 
 ### 4. To pause or stop registration
 
-If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
+If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
+
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
 
 <!-- [noblock] -->

--- a/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_1.0.0_point_to_slack_true.md
+++ b/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_1.0.0_point_to_slack_true.md
@@ -1,21 +1,21 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-### 1. New package registration
+## 1. New package registration
 
 Please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-### 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-### 3. *Needs action*: here's what to do next
+## 3. *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so.
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless the AutoMerge issue is that you skipped a version number).
 
 If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged. Then, send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) for better visibility.
 
-### 4. To pause or stop registration
+## 4. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_1.0.0_point_to_slack_true.md
+++ b/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_1.0.0_point_to_slack_true.md
@@ -1,21 +1,21 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. New package registration
+### 1. New package registration
 
 Since you are registering a new package, please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+### 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-## 3. *Needs action*: here's what to do next
+### 3. *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so. You can also leave a comment on this PR (and include `[noblock]`) or send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) to ask for help. Include a link to this pull request if you do so!
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless of course the AutoMerge issue is that you skipped a version number, in which case you should change the version number).
 
 If you do not want to fix the AutoMerge issues, please post a comment explaining why you would like this pull request to be manually merged. Then, send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) to ask for help.
 
-## 4. To pause or stop registration
+### 4. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_1.0.0_point_to_slack_true.md
+++ b/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_1.0.0_point_to_slack_true.md
@@ -1,6 +1,4 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
-
-If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. New package registration
 

--- a/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_0.1.0_point_to_slack_false.md
+++ b/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_0.1.0_point_to_slack_false.md
@@ -1,23 +1,21 @@
-## 1. Introduction
-
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 2. New package registration
+## 1. New package registration
 
 Since you are registering a new package, please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-## 3. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-## 4. *Needs action*: here's what to do next
+## 3. *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so. You can also leave a comment on this PR (and include `[noblock]`)
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless of course the AutoMerge issue is that you skipped a version number, in which case you should change the version number).
 
 If you do not want to fix the AutoMerge issues, please post a comment explaining why you would like this pull request to be manually merged.
 
-## 5. Declare v1.0?
+## 4. Declare v1.0?
 
 On a separate note, I see that you are registering a release with a version number of the form `v0.X.Y`.
 
@@ -25,7 +23,7 @@ Does your package have a stable public API? If so, then it's time for you to reg
 
 If your package does not yet have a stable public API, then of course you are not yet ready to release version `v1.0.0`.
 
-## 6. To pause or stop registration
+## 5. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_0.1.0_point_to_slack_false.md
+++ b/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_0.1.0_point_to_slack_false.md
@@ -1,21 +1,21 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-### 1. New package registration
+## 1. New package registration
 
 Please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-### 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-### 3. *Needs action*: here's what to do next
+## 3. *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so.
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless the AutoMerge issue is that you skipped a version number).
 
 If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged.
 
-### 4. Declare v1.0?
+## 4. Declare v1.0?
 
 On a separate note, I see that you are registering a release with a version number of the form `v0.X.Y`.
 
@@ -23,7 +23,7 @@ Does your package have a stable public API? If so, then it's time for you to reg
 
 If your package does not yet have a stable public API, then of course you are not yet ready to release version `v1.0.0`.
 
-### 5. To pause or stop registration
+## 5. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_0.1.0_point_to_slack_false.md
+++ b/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_0.1.0_point_to_slack_false.md
@@ -1,6 +1,4 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
-
-If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. New package registration
 

--- a/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_0.1.0_point_to_slack_false.md
+++ b/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_0.1.0_point_to_slack_false.md
@@ -1,8 +1,10 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
+
+If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. New package registration
 
-Since you are registering a new package, please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
+Please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
 ### 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
@@ -10,10 +12,10 @@ Since you are registering a new package, please make sure that you have read the
 
 ### 3. *Needs action*: here's what to do next
 
-1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so. You can also leave a comment on this PR (and include `[noblock]`)
-2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless of course the AutoMerge issue is that you skipped a version number, in which case you should change the version number).
+1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so.
+2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless the AutoMerge issue is that you skipped a version number).
 
-If you do not want to fix the AutoMerge issues, please post a comment explaining why you would like this pull request to be manually merged.
+If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged.
 
 ### 4. Declare v1.0?
 
@@ -25,6 +27,8 @@ If your package does not yet have a stable public API, then of course you are no
 
 ### 5. To pause or stop registration
 
-If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
+If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
+
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
 
 <!-- [noblock] -->

--- a/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_0.1.0_point_to_slack_false.md
+++ b/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_0.1.0_point_to_slack_false.md
@@ -1,21 +1,21 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. New package registration
+### 1. New package registration
 
 Since you are registering a new package, please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+### 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-## 3. *Needs action*: here's what to do next
+### 3. *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so. You can also leave a comment on this PR (and include `[noblock]`)
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless of course the AutoMerge issue is that you skipped a version number, in which case you should change the version number).
 
 If you do not want to fix the AutoMerge issues, please post a comment explaining why you would like this pull request to be manually merged.
 
-## 4. Declare v1.0?
+### 4. Declare v1.0?
 
 On a separate note, I see that you are registering a release with a version number of the form `v0.X.Y`.
 
@@ -23,7 +23,7 @@ Does your package have a stable public API? If so, then it's time for you to reg
 
 If your package does not yet have a stable public API, then of course you are not yet ready to release version `v1.0.0`.
 
-## 5. To pause or stop registration
+### 5. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_0.1.0_point_to_slack_true.md
+++ b/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_0.1.0_point_to_slack_true.md
@@ -1,8 +1,10 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
+
+If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. New package registration
 
-Since you are registering a new package, please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
+Please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
 ### 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
@@ -10,10 +12,10 @@ Since you are registering a new package, please make sure that you have read the
 
 ### 3. *Needs action*: here's what to do next
 
-1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so. You can also leave a comment on this PR (and include `[noblock]`) or send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) to ask for help. Include a link to this pull request if you do so!
-2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless of course the AutoMerge issue is that you skipped a version number, in which case you should change the version number).
+1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so.
+2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless the AutoMerge issue is that you skipped a version number).
 
-If you do not want to fix the AutoMerge issues, please post a comment explaining why you would like this pull request to be manually merged. Then, send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) to ask for help.
+If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged. Then, send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) for better visibility.
 
 ### 4. Declare v1.0?
 
@@ -25,6 +27,8 @@ If your package does not yet have a stable public API, then of course you are no
 
 ### 5. To pause or stop registration
 
-If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
+If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
+
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
 
 <!-- [noblock] -->

--- a/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_0.1.0_point_to_slack_true.md
+++ b/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_0.1.0_point_to_slack_true.md
@@ -1,21 +1,21 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. New package registration
+### 1. New package registration
 
 Since you are registering a new package, please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+### 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-## 3. *Needs action*: here's what to do next
+### 3. *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so. You can also leave a comment on this PR (and include `[noblock]`) or send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) to ask for help. Include a link to this pull request if you do so!
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless of course the AutoMerge issue is that you skipped a version number, in which case you should change the version number).
 
 If you do not want to fix the AutoMerge issues, please post a comment explaining why you would like this pull request to be manually merged. Then, send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) to ask for help.
 
-## 4. Declare v1.0?
+### 4. Declare v1.0?
 
 On a separate note, I see that you are registering a release with a version number of the form `v0.X.Y`.
 
@@ -23,7 +23,7 @@ Does your package have a stable public API? If so, then it's time for you to reg
 
 If your package does not yet have a stable public API, then of course you are not yet ready to release version `v1.0.0`.
 
-## 5. To pause or stop registration
+### 5. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_0.1.0_point_to_slack_true.md
+++ b/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_0.1.0_point_to_slack_true.md
@@ -1,6 +1,4 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
-
-If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. New package registration
 

--- a/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_0.1.0_point_to_slack_true.md
+++ b/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_0.1.0_point_to_slack_true.md
@@ -1,21 +1,21 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-### 1. New package registration
+## 1. New package registration
 
 Please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-### 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-### 3. *Needs action*: here's what to do next
+## 3. *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so.
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless the AutoMerge issue is that you skipped a version number).
 
 If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged. Then, send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) for better visibility.
 
-### 4. Declare v1.0?
+## 4. Declare v1.0?
 
 On a separate note, I see that you are registering a release with a version number of the form `v0.X.Y`.
 
@@ -23,7 +23,7 @@ Does your package have a stable public API? If so, then it's time for you to reg
 
 If your package does not yet have a stable public API, then of course you are not yet ready to release version `v1.0.0`.
 
-### 5. To pause or stop registration
+## 5. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_0.1.0_point_to_slack_true.md
+++ b/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_0.1.0_point_to_slack_true.md
@@ -1,23 +1,21 @@
-## 1. Introduction
-
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 2. New package registration
+## 1. New package registration
 
 Since you are registering a new package, please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-## 3. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-## 4. *Needs action*: here's what to do next
+## 3. *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so. You can also leave a comment on this PR (and include `[noblock]`) or send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) to ask for help. Include a link to this pull request if you do so!
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless of course the AutoMerge issue is that you skipped a version number, in which case you should change the version number).
 
 If you do not want to fix the AutoMerge issues, please post a comment explaining why you would like this pull request to be manually merged. Then, send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) to ask for help.
 
-## 5. Declare v1.0?
+## 4. Declare v1.0?
 
 On a separate note, I see that you are registering a release with a version number of the form `v0.X.Y`.
 
@@ -25,7 +23,7 @@ Does your package have a stable public API? If so, then it's time for you to reg
 
 If your package does not yet have a stable public API, then of course you are not yet ready to release version `v1.0.0`.
 
-## 6. To pause or stop registration
+## 5. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_1.0.0_point_to_slack_false.md
+++ b/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_1.0.0_point_to_slack_false.md
@@ -1,21 +1,21 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. New package registration
+### 1. New package registration
 
 Since you are registering a new package, please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+### 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-## 3. *Needs action*: here's what to do next
+### 3. *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so. You can also leave a comment on this PR (and include `[noblock]`)
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless of course the AutoMerge issue is that you skipped a version number, in which case you should change the version number).
 
 If you do not want to fix the AutoMerge issues, please post a comment explaining why you would like this pull request to be manually merged.
 
-## 4. To pause or stop registration
+### 4. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_1.0.0_point_to_slack_false.md
+++ b/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_1.0.0_point_to_slack_false.md
@@ -1,8 +1,10 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
+
+If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. New package registration
 
-Since you are registering a new package, please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
+Please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
 ### 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
@@ -10,13 +12,15 @@ Since you are registering a new package, please make sure that you have read the
 
 ### 3. *Needs action*: here's what to do next
 
-1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so. You can also leave a comment on this PR (and include `[noblock]`)
-2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless of course the AutoMerge issue is that you skipped a version number, in which case you should change the version number).
+1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so.
+2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless the AutoMerge issue is that you skipped a version number).
 
-If you do not want to fix the AutoMerge issues, please post a comment explaining why you would like this pull request to be manually merged.
+If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged.
 
 ### 4. To pause or stop registration
 
-If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
+If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
+
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
 
 <!-- [noblock] -->

--- a/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_1.0.0_point_to_slack_false.md
+++ b/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_1.0.0_point_to_slack_false.md
@@ -1,23 +1,21 @@
-## 1. Introduction
-
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 2. New package registration
+## 1. New package registration
 
 Since you are registering a new package, please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-## 3. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-## 4. *Needs action*: here's what to do next
+## 3. *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so. You can also leave a comment on this PR (and include `[noblock]`)
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless of course the AutoMerge issue is that you skipped a version number, in which case you should change the version number).
 
 If you do not want to fix the AutoMerge issues, please post a comment explaining why you would like this pull request to be manually merged.
 
-## 5. To pause or stop registration
+## 4. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_1.0.0_point_to_slack_false.md
+++ b/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_1.0.0_point_to_slack_false.md
@@ -1,21 +1,21 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-### 1. New package registration
+## 1. New package registration
 
 Please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-### 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-### 3. *Needs action*: here's what to do next
+## 3. *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so.
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless the AutoMerge issue is that you skipped a version number).
 
 If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged.
 
-### 4. To pause or stop registration
+## 4. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_1.0.0_point_to_slack_false.md
+++ b/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_1.0.0_point_to_slack_false.md
@@ -1,6 +1,4 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
-
-If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. New package registration
 

--- a/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_1.0.0_point_to_slack_true.md
+++ b/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_1.0.0_point_to_slack_true.md
@@ -1,23 +1,21 @@
-## 1. Introduction
-
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 2. New package registration
+## 1. New package registration
 
 Since you are registering a new package, please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-## 3. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-## 4. *Needs action*: here's what to do next
+## 3. *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so. You can also leave a comment on this PR (and include `[noblock]`) or send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) to ask for help. Include a link to this pull request if you do so!
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless of course the AutoMerge issue is that you skipped a version number, in which case you should change the version number).
 
 If you do not want to fix the AutoMerge issues, please post a comment explaining why you would like this pull request to be manually merged. Then, send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) to ask for help.
 
-## 5. To pause or stop registration
+## 4. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_1.0.0_point_to_slack_true.md
+++ b/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_1.0.0_point_to_slack_true.md
@@ -1,8 +1,10 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
+
+If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. New package registration
 
-Since you are registering a new package, please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
+Please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
 ### 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
@@ -10,13 +12,15 @@ Since you are registering a new package, please make sure that you have read the
 
 ### 3. *Needs action*: here's what to do next
 
-1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so. You can also leave a comment on this PR (and include `[noblock]`) or send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) to ask for help. Include a link to this pull request if you do so!
-2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless of course the AutoMerge issue is that you skipped a version number, in which case you should change the version number).
+1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so.
+2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless the AutoMerge issue is that you skipped a version number).
 
-If you do not want to fix the AutoMerge issues, please post a comment explaining why you would like this pull request to be manually merged. Then, send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) to ask for help.
+If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged. Then, send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) for better visibility.
 
 ### 4. To pause or stop registration
 
-If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
+If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
+
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
 
 <!-- [noblock] -->

--- a/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_1.0.0_point_to_slack_true.md
+++ b/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_1.0.0_point_to_slack_true.md
@@ -1,21 +1,21 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-### 1. New package registration
+## 1. New package registration
 
 Please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-### 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-### 3. *Needs action*: here's what to do next
+## 3. *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so.
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless the AutoMerge issue is that you skipped a version number).
 
 If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged. Then, send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) for better visibility.
 
-### 4. To pause or stop registration
+## 4. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_1.0.0_point_to_slack_true.md
+++ b/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_1.0.0_point_to_slack_true.md
@@ -1,21 +1,21 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. New package registration
+### 1. New package registration
 
 Since you are registering a new package, please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+### 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-## 3. *Needs action*: here's what to do next
+### 3. *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so. You can also leave a comment on this PR (and include `[noblock]`) or send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) to ask for help. Include a link to this pull request if you do so!
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless of course the AutoMerge issue is that you skipped a version number, in which case you should change the version number).
 
 If you do not want to fix the AutoMerge issues, please post a comment explaining why you would like this pull request to be manually merged. Then, send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) to ask for help.
 
-## 4. To pause or stop registration
+### 4. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_1.0.0_point_to_slack_true.md
+++ b/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_1.0.0_point_to_slack_true.md
@@ -1,6 +1,4 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
-
-If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. New package registration
 

--- a/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_0.1.0_point_to_slack_false.md
+++ b/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_0.1.0_point_to_slack_false.md
@@ -1,4 +1,6 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
+
+If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
@@ -6,13 +8,15 @@ Hello, I am an automated registration bot. I help manage the registration proces
 
 ### 2. *Needs action*: here's what to do next
 
-1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so. You can also leave a comment on this PR (and include `[noblock]`)
-2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless of course the AutoMerge issue is that you skipped a version number, in which case you should change the version number).
+1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so.
+2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless the AutoMerge issue is that you skipped a version number).
 
-If you do not want to fix the AutoMerge issues, please post a comment explaining why you would like this pull request to be manually merged.
+If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged.
 
 ### 3. To pause or stop registration
 
-If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
+If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
+
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
 
 <!-- [noblock] -->

--- a/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_0.1.0_point_to_slack_false.md
+++ b/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_0.1.0_point_to_slack_false.md
@@ -1,17 +1,17 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-## 2. *Needs action*: here's what to do next
+### 2. *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so. You can also leave a comment on this PR (and include `[noblock]`)
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless of course the AutoMerge issue is that you skipped a version number, in which case you should change the version number).
 
 If you do not want to fix the AutoMerge issues, please post a comment explaining why you would like this pull request to be manually merged.
 
-## 3. To pause or stop registration
+### 3. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_0.1.0_point_to_slack_false.md
+++ b/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_0.1.0_point_to_slack_false.md
@@ -1,17 +1,17 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-### 2. *Needs action*: here's what to do next
+## 2. *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so.
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless the AutoMerge issue is that you skipped a version number).
 
 If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged.
 
-### 3. To pause or stop registration
+## 3. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_0.1.0_point_to_slack_false.md
+++ b/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_0.1.0_point_to_slack_false.md
@@ -1,19 +1,17 @@
-## 1. Introduction
-
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-## 3. *Needs action*: here's what to do next
+## 2. *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so. You can also leave a comment on this PR (and include `[noblock]`)
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless of course the AutoMerge issue is that you skipped a version number, in which case you should change the version number).
 
 If you do not want to fix the AutoMerge issues, please post a comment explaining why you would like this pull request to be manually merged.
 
-## 4. To pause or stop registration
+## 3. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_0.1.0_point_to_slack_false.md
+++ b/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_0.1.0_point_to_slack_false.md
@@ -1,6 +1,4 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
-
-If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 

--- a/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_0.1.0_point_to_slack_true.md
+++ b/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_0.1.0_point_to_slack_true.md
@@ -1,19 +1,17 @@
-## 1. Introduction
-
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-## 3. *Needs action*: here's what to do next
+## 2. *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so. You can also leave a comment on this PR (and include `[noblock]`) or send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) to ask for help. Include a link to this pull request if you do so!
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless of course the AutoMerge issue is that you skipped a version number, in which case you should change the version number).
 
 If you do not want to fix the AutoMerge issues, please post a comment explaining why you would like this pull request to be manually merged. Then, send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) to ask for help.
 
-## 4. To pause or stop registration
+## 3. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_0.1.0_point_to_slack_true.md
+++ b/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_0.1.0_point_to_slack_true.md
@@ -1,17 +1,17 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-## 2. *Needs action*: here's what to do next
+### 2. *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so. You can also leave a comment on this PR (and include `[noblock]`) or send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) to ask for help. Include a link to this pull request if you do so!
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless of course the AutoMerge issue is that you skipped a version number, in which case you should change the version number).
 
 If you do not want to fix the AutoMerge issues, please post a comment explaining why you would like this pull request to be manually merged. Then, send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) to ask for help.
 
-## 3. To pause or stop registration
+### 3. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_0.1.0_point_to_slack_true.md
+++ b/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_0.1.0_point_to_slack_true.md
@@ -1,17 +1,17 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-### 2. *Needs action*: here's what to do next
+## 2. *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so.
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless the AutoMerge issue is that you skipped a version number).
 
 If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged. Then, send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) for better visibility.
 
-### 3. To pause or stop registration
+## 3. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_0.1.0_point_to_slack_true.md
+++ b/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_0.1.0_point_to_slack_true.md
@@ -1,6 +1,4 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
-
-If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 

--- a/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_0.1.0_point_to_slack_true.md
+++ b/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_0.1.0_point_to_slack_true.md
@@ -1,4 +1,6 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
+
+If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
@@ -6,13 +8,15 @@ Hello, I am an automated registration bot. I help manage the registration proces
 
 ### 2. *Needs action*: here's what to do next
 
-1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so. You can also leave a comment on this PR (and include `[noblock]`) or send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) to ask for help. Include a link to this pull request if you do so!
-2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless of course the AutoMerge issue is that you skipped a version number, in which case you should change the version number).
+1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so.
+2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless the AutoMerge issue is that you skipped a version number).
 
-If you do not want to fix the AutoMerge issues, please post a comment explaining why you would like this pull request to be manually merged. Then, send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) to ask for help.
+If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged. Then, send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) for better visibility.
 
 ### 3. To pause or stop registration
 
-If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
+If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
+
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
 
 <!-- [noblock] -->

--- a/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_1.0.0_point_to_slack_false.md
+++ b/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_1.0.0_point_to_slack_false.md
@@ -1,4 +1,6 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
+
+If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
@@ -6,13 +8,15 @@ Hello, I am an automated registration bot. I help manage the registration proces
 
 ### 2. *Needs action*: here's what to do next
 
-1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so. You can also leave a comment on this PR (and include `[noblock]`)
-2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless of course the AutoMerge issue is that you skipped a version number, in which case you should change the version number).
+1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so.
+2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless the AutoMerge issue is that you skipped a version number).
 
-If you do not want to fix the AutoMerge issues, please post a comment explaining why you would like this pull request to be manually merged.
+If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged.
 
 ### 3. To pause or stop registration
 
-If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
+If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
+
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
 
 <!-- [noblock] -->

--- a/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_1.0.0_point_to_slack_false.md
+++ b/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_1.0.0_point_to_slack_false.md
@@ -1,17 +1,17 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-## 2. *Needs action*: here's what to do next
+### 2. *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so. You can also leave a comment on this PR (and include `[noblock]`)
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless of course the AutoMerge issue is that you skipped a version number, in which case you should change the version number).
 
 If you do not want to fix the AutoMerge issues, please post a comment explaining why you would like this pull request to be manually merged.
 
-## 3. To pause or stop registration
+### 3. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_1.0.0_point_to_slack_false.md
+++ b/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_1.0.0_point_to_slack_false.md
@@ -1,17 +1,17 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-### 2. *Needs action*: here's what to do next
+## 2. *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so.
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless the AutoMerge issue is that you skipped a version number).
 
 If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged.
 
-### 3. To pause or stop registration
+## 3. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_1.0.0_point_to_slack_false.md
+++ b/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_1.0.0_point_to_slack_false.md
@@ -1,19 +1,17 @@
-## 1. Introduction
-
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-## 3. *Needs action*: here's what to do next
+## 2. *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so. You can also leave a comment on this PR (and include `[noblock]`)
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless of course the AutoMerge issue is that you skipped a version number, in which case you should change the version number).
 
 If you do not want to fix the AutoMerge issues, please post a comment explaining why you would like this pull request to be manually merged.
 
-## 4. To pause or stop registration
+## 3. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_1.0.0_point_to_slack_false.md
+++ b/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_1.0.0_point_to_slack_false.md
@@ -1,6 +1,4 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
-
-If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 

--- a/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_1.0.0_point_to_slack_true.md
+++ b/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_1.0.0_point_to_slack_true.md
@@ -1,19 +1,17 @@
-## 1. Introduction
-
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-## 3. *Needs action*: here's what to do next
+## 2. *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so. You can also leave a comment on this PR (and include `[noblock]`) or send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) to ask for help. Include a link to this pull request if you do so!
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless of course the AutoMerge issue is that you skipped a version number, in which case you should change the version number).
 
 If you do not want to fix the AutoMerge issues, please post a comment explaining why you would like this pull request to be manually merged. Then, send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) to ask for help.
 
-## 4. To pause or stop registration
+## 3. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_1.0.0_point_to_slack_true.md
+++ b/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_1.0.0_point_to_slack_true.md
@@ -1,17 +1,17 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-## 2. *Needs action*: here's what to do next
+### 2. *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so. You can also leave a comment on this PR (and include `[noblock]`) or send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) to ask for help. Include a link to this pull request if you do so!
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless of course the AutoMerge issue is that you skipped a version number, in which case you should change the version number).
 
 If you do not want to fix the AutoMerge issues, please post a comment explaining why you would like this pull request to be manually merged. Then, send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) to ask for help.
 
-## 3. To pause or stop registration
+### 3. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_1.0.0_point_to_slack_true.md
+++ b/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_1.0.0_point_to_slack_true.md
@@ -1,17 +1,17 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-### 2. *Needs action*: here's what to do next
+## 2. *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so.
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless the AutoMerge issue is that you skipped a version number).
 
 If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged. Then, send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) for better visibility.
 
-### 3. To pause or stop registration
+## 3. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_1.0.0_point_to_slack_true.md
+++ b/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_1.0.0_point_to_slack_true.md
@@ -1,6 +1,4 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
-
-If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 

--- a/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_1.0.0_point_to_slack_true.md
+++ b/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_1.0.0_point_to_slack_true.md
@@ -1,4 +1,6 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
+
+If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
@@ -6,13 +8,15 @@ Hello, I am an automated registration bot. I help manage the registration proces
 
 ### 2. *Needs action*: here's what to do next
 
-1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so. You can also leave a comment on this PR (and include `[noblock]`) or send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) to ask for help. Include a link to this pull request if you do so!
-2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless of course the AutoMerge issue is that you skipped a version number, in which case you should change the version number).
+1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so.
+2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless the AutoMerge issue is that you skipped a version number).
 
-If you do not want to fix the AutoMerge issues, please post a comment explaining why you would like this pull request to be manually merged. Then, send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) to ask for help.
+If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged. Then, send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) for better visibility.
 
 ### 3. To pause or stop registration
 
-If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
+If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
+
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
 
 <!-- [noblock] -->

--- a/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_0.1.0_point_to_slack_false.md
+++ b/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_0.1.0_point_to_slack_false.md
@@ -1,17 +1,17 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-### 2. *Needs action*: here's what to do next
+## 2. *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so.
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless the AutoMerge issue is that you skipped a version number).
 
 If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged.
 
-### 3. Declare v1.0?
+## 3. Declare v1.0?
 
 On a separate note, I see that you are registering a release with a version number of the form `v0.X.Y`.
 
@@ -19,7 +19,7 @@ Does your package have a stable public API? If so, then it's time for you to reg
 
 If your package does not yet have a stable public API, then of course you are not yet ready to release version `v1.0.0`.
 
-### 4. To pause or stop registration
+## 4. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_0.1.0_point_to_slack_false.md
+++ b/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_0.1.0_point_to_slack_false.md
@@ -1,17 +1,17 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-## 2. *Needs action*: here's what to do next
+### 2. *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so. You can also leave a comment on this PR (and include `[noblock]`)
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless of course the AutoMerge issue is that you skipped a version number, in which case you should change the version number).
 
 If you do not want to fix the AutoMerge issues, please post a comment explaining why you would like this pull request to be manually merged.
 
-## 3. Declare v1.0?
+### 3. Declare v1.0?
 
 On a separate note, I see that you are registering a release with a version number of the form `v0.X.Y`.
 
@@ -19,7 +19,7 @@ Does your package have a stable public API? If so, then it's time for you to reg
 
 If your package does not yet have a stable public API, then of course you are not yet ready to release version `v1.0.0`.
 
-## 4. To pause or stop registration
+### 4. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_0.1.0_point_to_slack_false.md
+++ b/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_0.1.0_point_to_slack_false.md
@@ -1,6 +1,4 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
-
-If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 

--- a/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_0.1.0_point_to_slack_false.md
+++ b/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_0.1.0_point_to_slack_false.md
@@ -1,19 +1,17 @@
-## 1. Introduction
-
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-## 3. *Needs action*: here's what to do next
+## 2. *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so. You can also leave a comment on this PR (and include `[noblock]`)
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless of course the AutoMerge issue is that you skipped a version number, in which case you should change the version number).
 
 If you do not want to fix the AutoMerge issues, please post a comment explaining why you would like this pull request to be manually merged.
 
-## 4. Declare v1.0?
+## 3. Declare v1.0?
 
 On a separate note, I see that you are registering a release with a version number of the form `v0.X.Y`.
 
@@ -21,7 +19,7 @@ Does your package have a stable public API? If so, then it's time for you to reg
 
 If your package does not yet have a stable public API, then of course you are not yet ready to release version `v1.0.0`.
 
-## 5. To pause or stop registration
+## 4. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_0.1.0_point_to_slack_false.md
+++ b/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_0.1.0_point_to_slack_false.md
@@ -1,4 +1,6 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
+
+If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
@@ -6,10 +8,10 @@ Hello, I am an automated registration bot. I help manage the registration proces
 
 ### 2. *Needs action*: here's what to do next
 
-1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so. You can also leave a comment on this PR (and include `[noblock]`)
-2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless of course the AutoMerge issue is that you skipped a version number, in which case you should change the version number).
+1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so.
+2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless the AutoMerge issue is that you skipped a version number).
 
-If you do not want to fix the AutoMerge issues, please post a comment explaining why you would like this pull request to be manually merged.
+If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged.
 
 ### 3. Declare v1.0?
 
@@ -21,6 +23,8 @@ If your package does not yet have a stable public API, then of course you are no
 
 ### 4. To pause or stop registration
 
-If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
+If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
+
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
 
 <!-- [noblock] -->

--- a/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_0.1.0_point_to_slack_true.md
+++ b/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_0.1.0_point_to_slack_true.md
@@ -1,17 +1,17 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-### 2. *Needs action*: here's what to do next
+## 2. *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so.
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless the AutoMerge issue is that you skipped a version number).
 
 If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged. Then, send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) for better visibility.
 
-### 3. Declare v1.0?
+## 3. Declare v1.0?
 
 On a separate note, I see that you are registering a release with a version number of the form `v0.X.Y`.
 
@@ -19,7 +19,7 @@ Does your package have a stable public API? If so, then it's time for you to reg
 
 If your package does not yet have a stable public API, then of course you are not yet ready to release version `v1.0.0`.
 
-### 4. To pause or stop registration
+## 4. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_0.1.0_point_to_slack_true.md
+++ b/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_0.1.0_point_to_slack_true.md
@@ -1,19 +1,17 @@
-## 1. Introduction
-
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-## 3. *Needs action*: here's what to do next
+## 2. *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so. You can also leave a comment on this PR (and include `[noblock]`) or send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) to ask for help. Include a link to this pull request if you do so!
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless of course the AutoMerge issue is that you skipped a version number, in which case you should change the version number).
 
 If you do not want to fix the AutoMerge issues, please post a comment explaining why you would like this pull request to be manually merged. Then, send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) to ask for help.
 
-## 4. Declare v1.0?
+## 3. Declare v1.0?
 
 On a separate note, I see that you are registering a release with a version number of the form `v0.X.Y`.
 
@@ -21,7 +19,7 @@ Does your package have a stable public API? If so, then it's time for you to reg
 
 If your package does not yet have a stable public API, then of course you are not yet ready to release version `v1.0.0`.
 
-## 5. To pause or stop registration
+## 4. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_0.1.0_point_to_slack_true.md
+++ b/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_0.1.0_point_to_slack_true.md
@@ -1,6 +1,4 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
-
-If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 

--- a/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_0.1.0_point_to_slack_true.md
+++ b/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_0.1.0_point_to_slack_true.md
@@ -1,17 +1,17 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-## 2. *Needs action*: here's what to do next
+### 2. *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so. You can also leave a comment on this PR (and include `[noblock]`) or send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) to ask for help. Include a link to this pull request if you do so!
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless of course the AutoMerge issue is that you skipped a version number, in which case you should change the version number).
 
 If you do not want to fix the AutoMerge issues, please post a comment explaining why you would like this pull request to be manually merged. Then, send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) to ask for help.
 
-## 3. Declare v1.0?
+### 3. Declare v1.0?
 
 On a separate note, I see that you are registering a release with a version number of the form `v0.X.Y`.
 
@@ -19,7 +19,7 @@ Does your package have a stable public API? If so, then it's time for you to reg
 
 If your package does not yet have a stable public API, then of course you are not yet ready to release version `v1.0.0`.
 
-## 4. To pause or stop registration
+### 4. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_0.1.0_point_to_slack_true.md
+++ b/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_0.1.0_point_to_slack_true.md
@@ -1,4 +1,6 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
+
+If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
@@ -6,10 +8,10 @@ Hello, I am an automated registration bot. I help manage the registration proces
 
 ### 2. *Needs action*: here's what to do next
 
-1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so. You can also leave a comment on this PR (and include `[noblock]`) or send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) to ask for help. Include a link to this pull request if you do so!
-2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless of course the AutoMerge issue is that you skipped a version number, in which case you should change the version number).
+1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so.
+2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless the AutoMerge issue is that you skipped a version number).
 
-If you do not want to fix the AutoMerge issues, please post a comment explaining why you would like this pull request to be manually merged. Then, send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) to ask for help.
+If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged. Then, send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) for better visibility.
 
 ### 3. Declare v1.0?
 
@@ -21,6 +23,8 @@ If your package does not yet have a stable public API, then of course you are no
 
 ### 4. To pause or stop registration
 
-If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
+If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
+
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
 
 <!-- [noblock] -->

--- a/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_1.0.0_point_to_slack_false.md
+++ b/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_1.0.0_point_to_slack_false.md
@@ -1,4 +1,6 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
+
+If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
@@ -6,13 +8,15 @@ Hello, I am an automated registration bot. I help manage the registration proces
 
 ### 2. *Needs action*: here's what to do next
 
-1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so. You can also leave a comment on this PR (and include `[noblock]`)
-2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless of course the AutoMerge issue is that you skipped a version number, in which case you should change the version number).
+1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so.
+2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless the AutoMerge issue is that you skipped a version number).
 
-If you do not want to fix the AutoMerge issues, please post a comment explaining why you would like this pull request to be manually merged.
+If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged.
 
 ### 3. To pause or stop registration
 
-If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
+If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
+
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
 
 <!-- [noblock] -->

--- a/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_1.0.0_point_to_slack_false.md
+++ b/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_1.0.0_point_to_slack_false.md
@@ -1,17 +1,17 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-## 2. *Needs action*: here's what to do next
+### 2. *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so. You can also leave a comment on this PR (and include `[noblock]`)
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless of course the AutoMerge issue is that you skipped a version number, in which case you should change the version number).
 
 If you do not want to fix the AutoMerge issues, please post a comment explaining why you would like this pull request to be manually merged.
 
-## 3. To pause or stop registration
+### 3. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_1.0.0_point_to_slack_false.md
+++ b/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_1.0.0_point_to_slack_false.md
@@ -1,17 +1,17 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-### 2. *Needs action*: here's what to do next
+## 2. *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so.
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless the AutoMerge issue is that you skipped a version number).
 
 If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged.
 
-### 3. To pause or stop registration
+## 3. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_1.0.0_point_to_slack_false.md
+++ b/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_1.0.0_point_to_slack_false.md
@@ -1,19 +1,17 @@
-## 1. Introduction
-
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-## 3. *Needs action*: here's what to do next
+## 2. *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so. You can also leave a comment on this PR (and include `[noblock]`)
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless of course the AutoMerge issue is that you skipped a version number, in which case you should change the version number).
 
 If you do not want to fix the AutoMerge issues, please post a comment explaining why you would like this pull request to be manually merged.
 
-## 4. To pause or stop registration
+## 3. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_1.0.0_point_to_slack_false.md
+++ b/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_1.0.0_point_to_slack_false.md
@@ -1,6 +1,4 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
-
-If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 

--- a/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_1.0.0_point_to_slack_true.md
+++ b/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_1.0.0_point_to_slack_true.md
@@ -1,19 +1,17 @@
-## 1. Introduction
-
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-## 3. *Needs action*: here's what to do next
+## 2. *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so. You can also leave a comment on this PR (and include `[noblock]`) or send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) to ask for help. Include a link to this pull request if you do so!
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless of course the AutoMerge issue is that you skipped a version number, in which case you should change the version number).
 
 If you do not want to fix the AutoMerge issues, please post a comment explaining why you would like this pull request to be manually merged. Then, send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) to ask for help.
 
-## 4. To pause or stop registration
+## 3. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_1.0.0_point_to_slack_true.md
+++ b/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_1.0.0_point_to_slack_true.md
@@ -1,17 +1,17 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-## 2. *Needs action*: here's what to do next
+### 2. *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so. You can also leave a comment on this PR (and include `[noblock]`) or send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) to ask for help. Include a link to this pull request if you do so!
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless of course the AutoMerge issue is that you skipped a version number, in which case you should change the version number).
 
 If you do not want to fix the AutoMerge issues, please post a comment explaining why you would like this pull request to be manually merged. Then, send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) to ask for help.
 
-## 3. To pause or stop registration
+### 3. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_1.0.0_point_to_slack_true.md
+++ b/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_1.0.0_point_to_slack_true.md
@@ -1,17 +1,17 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-### 2. *Needs action*: here's what to do next
+## 2. *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so.
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless the AutoMerge issue is that you skipped a version number).
 
 If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged. Then, send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) for better visibility.
 
-### 3. To pause or stop registration
+## 3. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_1.0.0_point_to_slack_true.md
+++ b/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_1.0.0_point_to_slack_true.md
@@ -1,6 +1,4 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
-
-If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 

--- a/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_1.0.0_point_to_slack_true.md
+++ b/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_1.0.0_point_to_slack_true.md
@@ -1,4 +1,6 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
+
+If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
@@ -6,13 +8,15 @@ Hello, I am an automated registration bot. I help manage the registration proces
 
 ### 2. *Needs action*: here's what to do next
 
-1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so. You can also leave a comment on this PR (and include `[noblock]`) or send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) to ask for help. Include a link to this pull request if you do so!
-2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless of course the AutoMerge issue is that you skipped a version number, in which case you should change the version number).
+1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so.
+2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless the AutoMerge issue is that you skipped a version number).
 
-If you do not want to fix the AutoMerge issues, please post a comment explaining why you would like this pull request to be manually merged. Then, send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) to ask for help.
+If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged. Then, send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) for better visibility.
 
 ### 3. To pause or stop registration
 
-If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
+If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
+
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
 
 <!-- [noblock] -->

--- a/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_0.1.0_is_jll_false.md
+++ b/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_0.1.0_is_jll_false.md
@@ -1,16 +1,14 @@
-## 1. Introduction
-
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 2. New package registration
+## 1. New package registration
 
 Since you are registering a new package, please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-## 3. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new package registration met all of the guidelines for auto-merging and is scheduled to be merged when the mandatory waiting period (3 days) has elapsed.
 
-## 4. To pause or stop registration
+## 3. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_0.1.0_is_jll_false.md
+++ b/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_0.1.0_is_jll_false.md
@@ -1,14 +1,14 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. New package registration
+### 1. New package registration
 
 Since you are registering a new package, please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+### 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new package registration met all of the guidelines for auto-merging and is scheduled to be merged when the mandatory waiting period (3 days) has elapsed.
 
-## 3. To pause or stop registration
+### 3. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_0.1.0_is_jll_false.md
+++ b/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_0.1.0_is_jll_false.md
@@ -1,14 +1,14 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-### 1. New package registration
+## 1. New package registration
 
 Please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-### 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new package registration met all of the guidelines for auto-merging and is scheduled to be merged when the mandatory waiting period (3 days) has elapsed.
 
-### 3. To pause or stop registration
+## 3. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_0.1.0_is_jll_false.md
+++ b/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_0.1.0_is_jll_false.md
@@ -1,8 +1,10 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
+
+If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. New package registration
 
-Since you are registering a new package, please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
+Please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
 ### 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
@@ -10,6 +12,8 @@ Your new package registration met all of the guidelines for auto-merging and is 
 
 ### 3. To pause or stop registration
 
-If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
+If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
+
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
 
 <!-- [noblock] -->

--- a/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_0.1.0_is_jll_false.md
+++ b/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_0.1.0_is_jll_false.md
@@ -1,6 +1,4 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
-
-If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. New package registration
 

--- a/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_0.1.0_is_jll_true.md
+++ b/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_0.1.0_is_jll_true.md
@@ -1,10 +1,10 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new `_jll` package registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-### 2. To pause or stop registration
+## 2. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_0.1.0_is_jll_true.md
+++ b/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_0.1.0_is_jll_true.md
@@ -1,10 +1,10 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new `_jll` package registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-## 2. To pause or stop registration
+### 2. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_0.1.0_is_jll_true.md
+++ b/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_0.1.0_is_jll_true.md
@@ -1,6 +1,4 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
-
-If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 

--- a/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_0.1.0_is_jll_true.md
+++ b/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_0.1.0_is_jll_true.md
@@ -1,4 +1,6 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
+
+If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
@@ -6,6 +8,8 @@ Your new `_jll` package registration met all of the guidelines for auto-merging 
 
 ### 2. To pause or stop registration
 
-If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
+If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
+
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
 
 <!-- [noblock] -->

--- a/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_0.1.0_is_jll_true.md
+++ b/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_0.1.0_is_jll_true.md
@@ -1,12 +1,10 @@
-## 1. Introduction
-
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new `_jll` package registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-## 3. To pause or stop registration
+## 2. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_1.0.0_is_jll_false.md
+++ b/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_1.0.0_is_jll_false.md
@@ -1,16 +1,14 @@
-## 1. Introduction
-
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 2. New package registration
+## 1. New package registration
 
 Since you are registering a new package, please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-## 3. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new package registration met all of the guidelines for auto-merging and is scheduled to be merged when the mandatory waiting period (3 days) has elapsed.
 
-## 4. To pause or stop registration
+## 3. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_1.0.0_is_jll_false.md
+++ b/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_1.0.0_is_jll_false.md
@@ -1,14 +1,14 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. New package registration
+### 1. New package registration
 
 Since you are registering a new package, please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+### 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new package registration met all of the guidelines for auto-merging and is scheduled to be merged when the mandatory waiting period (3 days) has elapsed.
 
-## 3. To pause or stop registration
+### 3. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_1.0.0_is_jll_false.md
+++ b/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_1.0.0_is_jll_false.md
@@ -1,14 +1,14 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-### 1. New package registration
+## 1. New package registration
 
 Please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-### 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new package registration met all of the guidelines for auto-merging and is scheduled to be merged when the mandatory waiting period (3 days) has elapsed.
 
-### 3. To pause or stop registration
+## 3. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_1.0.0_is_jll_false.md
+++ b/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_1.0.0_is_jll_false.md
@@ -1,8 +1,10 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
+
+If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. New package registration
 
-Since you are registering a new package, please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
+Please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
 ### 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
@@ -10,6 +12,8 @@ Your new package registration met all of the guidelines for auto-merging and is 
 
 ### 3. To pause or stop registration
 
-If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
+If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
+
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
 
 <!-- [noblock] -->

--- a/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_1.0.0_is_jll_false.md
+++ b/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_1.0.0_is_jll_false.md
@@ -1,6 +1,4 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
-
-If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. New package registration
 

--- a/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_1.0.0_is_jll_true.md
+++ b/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_1.0.0_is_jll_true.md
@@ -1,10 +1,10 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new `_jll` package registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-### 2. To pause or stop registration
+## 2. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_1.0.0_is_jll_true.md
+++ b/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_1.0.0_is_jll_true.md
@@ -1,10 +1,10 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new `_jll` package registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-## 2. To pause or stop registration
+### 2. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_1.0.0_is_jll_true.md
+++ b/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_1.0.0_is_jll_true.md
@@ -1,6 +1,4 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
-
-If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 

--- a/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_1.0.0_is_jll_true.md
+++ b/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_1.0.0_is_jll_true.md
@@ -1,4 +1,6 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
+
+If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
@@ -6,6 +8,8 @@ Your new `_jll` package registration met all of the guidelines for auto-merging 
 
 ### 2. To pause or stop registration
 
-If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
+If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
+
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
 
 <!-- [noblock] -->

--- a/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_1.0.0_is_jll_true.md
+++ b/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_1.0.0_is_jll_true.md
@@ -1,12 +1,10 @@
-## 1. Introduction
-
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new `_jll` package registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-## 3. To pause or stop registration
+## 2. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_0.1.0_is_jll_false.md
+++ b/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_0.1.0_is_jll_false.md
@@ -1,8 +1,10 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
+
+If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. New package registration
 
-Since you are registering a new package, please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
+Please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
 ### 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
@@ -18,6 +20,8 @@ If your package does not yet have a stable public API, then of course you are no
 
 ### 4. To pause or stop registration
 
-If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
+If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
+
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
 
 <!-- [noblock] -->

--- a/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_0.1.0_is_jll_false.md
+++ b/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_0.1.0_is_jll_false.md
@@ -1,14 +1,14 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. New package registration
+### 1. New package registration
 
 Since you are registering a new package, please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+### 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new package registration met all of the guidelines for auto-merging and is scheduled to be merged when the mandatory waiting period (3 days) has elapsed.
 
-## 3. Declare v1.0?
+### 3. Declare v1.0?
 
 On a separate note, I see that you are registering a release with a version number of the form `v0.X.Y`.
 
@@ -16,7 +16,7 @@ Does your package have a stable public API? If so, then it's time for you to reg
 
 If your package does not yet have a stable public API, then of course you are not yet ready to release version `v1.0.0`.
 
-## 4. To pause or stop registration
+### 4. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_0.1.0_is_jll_false.md
+++ b/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_0.1.0_is_jll_false.md
@@ -1,16 +1,14 @@
-## 1. Introduction
-
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 2. New package registration
+## 1. New package registration
 
 Since you are registering a new package, please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-## 3. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new package registration met all of the guidelines for auto-merging and is scheduled to be merged when the mandatory waiting period (3 days) has elapsed.
 
-## 4. Declare v1.0?
+## 3. Declare v1.0?
 
 On a separate note, I see that you are registering a release with a version number of the form `v0.X.Y`.
 
@@ -18,7 +16,7 @@ Does your package have a stable public API? If so, then it's time for you to reg
 
 If your package does not yet have a stable public API, then of course you are not yet ready to release version `v1.0.0`.
 
-## 5. To pause or stop registration
+## 4. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_0.1.0_is_jll_false.md
+++ b/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_0.1.0_is_jll_false.md
@@ -1,6 +1,4 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
-
-If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. New package registration
 

--- a/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_0.1.0_is_jll_false.md
+++ b/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_0.1.0_is_jll_false.md
@@ -1,14 +1,14 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-### 1. New package registration
+## 1. New package registration
 
 Please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-### 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new package registration met all of the guidelines for auto-merging and is scheduled to be merged when the mandatory waiting period (3 days) has elapsed.
 
-### 3. Declare v1.0?
+## 3. Declare v1.0?
 
 On a separate note, I see that you are registering a release with a version number of the form `v0.X.Y`.
 
@@ -16,7 +16,7 @@ Does your package have a stable public API? If so, then it's time for you to reg
 
 If your package does not yet have a stable public API, then of course you are not yet ready to release version `v1.0.0`.
 
-### 4. To pause or stop registration
+## 4. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_0.1.0_is_jll_true.md
+++ b/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_0.1.0_is_jll_true.md
@@ -1,12 +1,10 @@
-## 1. Introduction
-
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new `_jll` package registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-## 3. Declare v1.0?
+## 2. Declare v1.0?
 
 On a separate note, I see that you are registering a release with a version number of the form `v0.X.Y`.
 
@@ -14,7 +12,7 @@ Does your package have a stable public API? If so, then it's time for you to reg
 
 If your package does not yet have a stable public API, then of course you are not yet ready to release version `v1.0.0`.
 
-## 4. To pause or stop registration
+## 3. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_0.1.0_is_jll_true.md
+++ b/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_0.1.0_is_jll_true.md
@@ -1,10 +1,10 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new `_jll` package registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-## 2. Declare v1.0?
+### 2. Declare v1.0?
 
 On a separate note, I see that you are registering a release with a version number of the form `v0.X.Y`.
 
@@ -12,7 +12,7 @@ Does your package have a stable public API? If so, then it's time for you to reg
 
 If your package does not yet have a stable public API, then of course you are not yet ready to release version `v1.0.0`.
 
-## 3. To pause or stop registration
+### 3. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_0.1.0_is_jll_true.md
+++ b/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_0.1.0_is_jll_true.md
@@ -1,4 +1,6 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
+
+If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
@@ -14,6 +16,8 @@ If your package does not yet have a stable public API, then of course you are no
 
 ### 3. To pause or stop registration
 
-If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
+If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
+
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
 
 <!-- [noblock] -->

--- a/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_0.1.0_is_jll_true.md
+++ b/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_0.1.0_is_jll_true.md
@@ -1,10 +1,10 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new `_jll` package registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-### 2. Declare v1.0?
+## 2. Declare v1.0?
 
 On a separate note, I see that you are registering a release with a version number of the form `v0.X.Y`.
 
@@ -12,7 +12,7 @@ Does your package have a stable public API? If so, then it's time for you to reg
 
 If your package does not yet have a stable public API, then of course you are not yet ready to release version `v1.0.0`.
 
-### 3. To pause or stop registration
+## 3. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_0.1.0_is_jll_true.md
+++ b/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_0.1.0_is_jll_true.md
@@ -1,6 +1,4 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
-
-If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 

--- a/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_1.0.0_is_jll_false.md
+++ b/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_1.0.0_is_jll_false.md
@@ -1,16 +1,14 @@
-## 1. Introduction
-
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 2. New package registration
+## 1. New package registration
 
 Since you are registering a new package, please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-## 3. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new package registration met all of the guidelines for auto-merging and is scheduled to be merged when the mandatory waiting period (3 days) has elapsed.
 
-## 4. To pause or stop registration
+## 3. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_1.0.0_is_jll_false.md
+++ b/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_1.0.0_is_jll_false.md
@@ -1,14 +1,14 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. New package registration
+### 1. New package registration
 
 Since you are registering a new package, please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+### 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new package registration met all of the guidelines for auto-merging and is scheduled to be merged when the mandatory waiting period (3 days) has elapsed.
 
-## 3. To pause or stop registration
+### 3. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_1.0.0_is_jll_false.md
+++ b/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_1.0.0_is_jll_false.md
@@ -1,14 +1,14 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-### 1. New package registration
+## 1. New package registration
 
 Please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-### 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new package registration met all of the guidelines for auto-merging and is scheduled to be merged when the mandatory waiting period (3 days) has elapsed.
 
-### 3. To pause or stop registration
+## 3. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_1.0.0_is_jll_false.md
+++ b/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_1.0.0_is_jll_false.md
@@ -1,8 +1,10 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
+
+If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. New package registration
 
-Since you are registering a new package, please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
+Please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
 ### 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
@@ -10,6 +12,8 @@ Your new package registration met all of the guidelines for auto-merging and is 
 
 ### 3. To pause or stop registration
 
-If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
+If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
+
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
 
 <!-- [noblock] -->

--- a/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_1.0.0_is_jll_false.md
+++ b/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_1.0.0_is_jll_false.md
@@ -1,6 +1,4 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
-
-If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. New package registration
 

--- a/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_1.0.0_is_jll_true.md
+++ b/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_1.0.0_is_jll_true.md
@@ -1,10 +1,10 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new `_jll` package registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-### 2. To pause or stop registration
+## 2. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_1.0.0_is_jll_true.md
+++ b/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_1.0.0_is_jll_true.md
@@ -1,10 +1,10 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new `_jll` package registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-## 2. To pause or stop registration
+### 2. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_1.0.0_is_jll_true.md
+++ b/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_1.0.0_is_jll_true.md
@@ -1,6 +1,4 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
-
-If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 

--- a/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_1.0.0_is_jll_true.md
+++ b/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_1.0.0_is_jll_true.md
@@ -1,4 +1,6 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
+
+If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
@@ -6,6 +8,8 @@ Your new `_jll` package registration met all of the guidelines for auto-merging 
 
 ### 2. To pause or stop registration
 
-If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
+If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
+
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
 
 <!-- [noblock] -->

--- a/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_1.0.0_is_jll_true.md
+++ b/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_1.0.0_is_jll_true.md
@@ -1,12 +1,10 @@
-## 1. Introduction
-
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new `_jll` package registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-## 3. To pause or stop registration
+## 2. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_0.1.0_is_jll_false.md
+++ b/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_0.1.0_is_jll_false.md
@@ -1,10 +1,10 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new version registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-### 2. To pause or stop registration
+## 2. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_0.1.0_is_jll_false.md
+++ b/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_0.1.0_is_jll_false.md
@@ -1,10 +1,10 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new version registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-## 2. To pause or stop registration
+### 2. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_0.1.0_is_jll_false.md
+++ b/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_0.1.0_is_jll_false.md
@@ -1,12 +1,10 @@
-## 1. Introduction
-
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new version registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-## 3. To pause or stop registration
+## 2. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_0.1.0_is_jll_false.md
+++ b/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_0.1.0_is_jll_false.md
@@ -1,6 +1,4 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
-
-If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 

--- a/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_0.1.0_is_jll_false.md
+++ b/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_0.1.0_is_jll_false.md
@@ -1,4 +1,6 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
+
+If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
@@ -6,6 +8,8 @@ Your new version registration met all of the guidelines for auto-merging and is 
 
 ### 2. To pause or stop registration
 
-If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
+If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
+
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
 
 <!-- [noblock] -->

--- a/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_0.1.0_is_jll_true.md
+++ b/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_0.1.0_is_jll_true.md
@@ -1,10 +1,10 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new version registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-### 2. To pause or stop registration
+## 2. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_0.1.0_is_jll_true.md
+++ b/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_0.1.0_is_jll_true.md
@@ -1,10 +1,10 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new version registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-## 2. To pause or stop registration
+### 2. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_0.1.0_is_jll_true.md
+++ b/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_0.1.0_is_jll_true.md
@@ -1,12 +1,10 @@
-## 1. Introduction
-
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new version registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-## 3. To pause or stop registration
+## 2. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_0.1.0_is_jll_true.md
+++ b/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_0.1.0_is_jll_true.md
@@ -1,6 +1,4 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
-
-If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 

--- a/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_0.1.0_is_jll_true.md
+++ b/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_0.1.0_is_jll_true.md
@@ -1,4 +1,6 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
+
+If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
@@ -6,6 +8,8 @@ Your new version registration met all of the guidelines for auto-merging and is 
 
 ### 2. To pause or stop registration
 
-If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
+If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
+
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
 
 <!-- [noblock] -->

--- a/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_1.0.0_is_jll_false.md
+++ b/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_1.0.0_is_jll_false.md
@@ -1,10 +1,10 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new version registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-### 2. To pause or stop registration
+## 2. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_1.0.0_is_jll_false.md
+++ b/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_1.0.0_is_jll_false.md
@@ -1,10 +1,10 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new version registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-## 2. To pause or stop registration
+### 2. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_1.0.0_is_jll_false.md
+++ b/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_1.0.0_is_jll_false.md
@@ -1,12 +1,10 @@
-## 1. Introduction
-
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new version registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-## 3. To pause or stop registration
+## 2. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_1.0.0_is_jll_false.md
+++ b/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_1.0.0_is_jll_false.md
@@ -1,6 +1,4 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
-
-If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 

--- a/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_1.0.0_is_jll_false.md
+++ b/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_1.0.0_is_jll_false.md
@@ -1,4 +1,6 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
+
+If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
@@ -6,6 +8,8 @@ Your new version registration met all of the guidelines for auto-merging and is 
 
 ### 2. To pause or stop registration
 
-If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
+If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
+
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
 
 <!-- [noblock] -->

--- a/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_1.0.0_is_jll_true.md
+++ b/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_1.0.0_is_jll_true.md
@@ -1,10 +1,10 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new version registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-### 2. To pause or stop registration
+## 2. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_1.0.0_is_jll_true.md
+++ b/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_1.0.0_is_jll_true.md
@@ -1,10 +1,10 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new version registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-## 2. To pause or stop registration
+### 2. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_1.0.0_is_jll_true.md
+++ b/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_1.0.0_is_jll_true.md
@@ -1,12 +1,10 @@
-## 1. Introduction
-
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new version registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-## 3. To pause or stop registration
+## 2. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_1.0.0_is_jll_true.md
+++ b/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_1.0.0_is_jll_true.md
@@ -1,6 +1,4 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
-
-If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 

--- a/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_1.0.0_is_jll_true.md
+++ b/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_1.0.0_is_jll_true.md
@@ -1,4 +1,6 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
+
+If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
@@ -6,6 +8,8 @@ Your new version registration met all of the guidelines for auto-merging and is 
 
 ### 2. To pause or stop registration
 
-If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
+If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
+
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
 
 <!-- [noblock] -->

--- a/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_0.1.0_is_jll_false.md
+++ b/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_0.1.0_is_jll_false.md
@@ -1,12 +1,10 @@
-## 1. Introduction
-
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new version registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-## 3. Declare v1.0?
+## 2. Declare v1.0?
 
 On a separate note, I see that you are registering a release with a version number of the form `v0.X.Y`.
 
@@ -14,7 +12,7 @@ Does your package have a stable public API? If so, then it's time for you to reg
 
 If your package does not yet have a stable public API, then of course you are not yet ready to release version `v1.0.0`.
 
-## 4. To pause or stop registration
+## 3. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_0.1.0_is_jll_false.md
+++ b/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_0.1.0_is_jll_false.md
@@ -1,4 +1,6 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
+
+If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
@@ -14,6 +16,8 @@ If your package does not yet have a stable public API, then of course you are no
 
 ### 3. To pause or stop registration
 
-If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
+If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
+
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
 
 <!-- [noblock] -->

--- a/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_0.1.0_is_jll_false.md
+++ b/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_0.1.0_is_jll_false.md
@@ -1,10 +1,10 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new version registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-### 2. Declare v1.0?
+## 2. Declare v1.0?
 
 On a separate note, I see that you are registering a release with a version number of the form `v0.X.Y`.
 
@@ -12,7 +12,7 @@ Does your package have a stable public API? If so, then it's time for you to reg
 
 If your package does not yet have a stable public API, then of course you are not yet ready to release version `v1.0.0`.
 
-### 3. To pause or stop registration
+## 3. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_0.1.0_is_jll_false.md
+++ b/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_0.1.0_is_jll_false.md
@@ -1,6 +1,4 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
-
-If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 

--- a/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_0.1.0_is_jll_false.md
+++ b/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_0.1.0_is_jll_false.md
@@ -1,10 +1,10 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new version registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-## 2. Declare v1.0?
+### 2. Declare v1.0?
 
 On a separate note, I see that you are registering a release with a version number of the form `v0.X.Y`.
 
@@ -12,7 +12,7 @@ Does your package have a stable public API? If so, then it's time for you to reg
 
 If your package does not yet have a stable public API, then of course you are not yet ready to release version `v1.0.0`.
 
-## 3. To pause or stop registration
+### 3. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_0.1.0_is_jll_true.md
+++ b/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_0.1.0_is_jll_true.md
@@ -1,12 +1,10 @@
-## 1. Introduction
-
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new version registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-## 3. Declare v1.0?
+## 2. Declare v1.0?
 
 On a separate note, I see that you are registering a release with a version number of the form `v0.X.Y`.
 
@@ -14,7 +12,7 @@ Does your package have a stable public API? If so, then it's time for you to reg
 
 If your package does not yet have a stable public API, then of course you are not yet ready to release version `v1.0.0`.
 
-## 4. To pause or stop registration
+## 3. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_0.1.0_is_jll_true.md
+++ b/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_0.1.0_is_jll_true.md
@@ -1,4 +1,6 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
+
+If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
@@ -14,6 +16,8 @@ If your package does not yet have a stable public API, then of course you are no
 
 ### 3. To pause or stop registration
 
-If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
+If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
+
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
 
 <!-- [noblock] -->

--- a/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_0.1.0_is_jll_true.md
+++ b/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_0.1.0_is_jll_true.md
@@ -1,10 +1,10 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new version registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-### 2. Declare v1.0?
+## 2. Declare v1.0?
 
 On a separate note, I see that you are registering a release with a version number of the form `v0.X.Y`.
 
@@ -12,7 +12,7 @@ Does your package have a stable public API? If so, then it's time for you to reg
 
 If your package does not yet have a stable public API, then of course you are not yet ready to release version `v1.0.0`.
 
-### 3. To pause or stop registration
+## 3. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_0.1.0_is_jll_true.md
+++ b/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_0.1.0_is_jll_true.md
@@ -1,6 +1,4 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
-
-If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 

--- a/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_0.1.0_is_jll_true.md
+++ b/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_0.1.0_is_jll_true.md
@@ -1,10 +1,10 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new version registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-## 2. Declare v1.0?
+### 2. Declare v1.0?
 
 On a separate note, I see that you are registering a release with a version number of the form `v0.X.Y`.
 
@@ -12,7 +12,7 @@ Does your package have a stable public API? If so, then it's time for you to reg
 
 If your package does not yet have a stable public API, then of course you are not yet ready to release version `v1.0.0`.
 
-## 3. To pause or stop registration
+### 3. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_1.0.0_is_jll_false.md
+++ b/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_1.0.0_is_jll_false.md
@@ -1,10 +1,10 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new version registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-### 2. To pause or stop registration
+## 2. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_1.0.0_is_jll_false.md
+++ b/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_1.0.0_is_jll_false.md
@@ -1,10 +1,10 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new version registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-## 2. To pause or stop registration
+### 2. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_1.0.0_is_jll_false.md
+++ b/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_1.0.0_is_jll_false.md
@@ -1,12 +1,10 @@
-## 1. Introduction
-
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new version registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-## 3. To pause or stop registration
+## 2. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_1.0.0_is_jll_false.md
+++ b/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_1.0.0_is_jll_false.md
@@ -1,6 +1,4 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
-
-If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 

--- a/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_1.0.0_is_jll_false.md
+++ b/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_1.0.0_is_jll_false.md
@@ -1,4 +1,6 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
+
+If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
@@ -6,6 +8,8 @@ Your new version registration met all of the guidelines for auto-merging and is 
 
 ### 2. To pause or stop registration
 
-If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
+If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
+
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
 
 <!-- [noblock] -->

--- a/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_1.0.0_is_jll_true.md
+++ b/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_1.0.0_is_jll_true.md
@@ -1,10 +1,10 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new version registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-### 2. To pause or stop registration
+## 2. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_1.0.0_is_jll_true.md
+++ b/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_1.0.0_is_jll_true.md
@@ -1,10 +1,10 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new version registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-## 2. To pause or stop registration
+### 2. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_1.0.0_is_jll_true.md
+++ b/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_1.0.0_is_jll_true.md
@@ -1,12 +1,10 @@
-## 1. Introduction
-
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new version registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-## 3. To pause or stop registration
+## 2. To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
 

--- a/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_1.0.0_is_jll_true.md
+++ b/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_1.0.0_is_jll_true.md
@@ -1,6 +1,4 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
-
-If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 

--- a/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_1.0.0_is_jll_true.md
+++ b/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_1.0.0_is_jll_true.md
@@ -1,4 +1,6 @@
-Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). Meeting these guidelines is only required for the pull request to be **merged automatically**. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.
+Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
+
+If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
 ### 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
@@ -6,6 +8,8 @@ Your new version registration met all of the guidelines for auto-merging and is 
 
 ### 2. To pause or stop registration
 
-If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. You can edit blocking comments, adding `[noblock]` to them in order to unblock auto-merging.
+If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
+
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
 
 <!-- [noblock] -->


### PR DESCRIPTION
* removes `## 1. Introduction` header at the top. I think it's nicer to have the intro text without a header, and it also shortens the comment a bit.
* Simplify and clarify some of the text
* remove unused `comment_text_merge_now`

# PR
<img width="937" alt="Screenshot 2024-06-15 at 12 16 22" src="https://github.com/JuliaRegistries/RegistryCI.jl/assets/5846501/f1f74ec2-2bcc-4e35-9cbd-85eabee8c8e2">

# Master
<img width="925" alt="Screenshot 2024-06-15 at 12 07 40" src="https://github.com/JuliaRegistries/RegistryCI.jl/assets/5846501/8c1c82e1-b88a-4f39-b55d-5772c6f911b0">
