### PR TITLE
remove section numbers from AutoMerge comment

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryCI"
 uuid = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
 authors = ["Dilum Aluthge <dilum@aluthge.com>", "Fredrik Ekre <ekrefredrik@gmail.com>", "contributors"]
-version = "10.4.0"
+version = "10.5.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/AutoMerge/util.jl
+++ b/src/AutoMerge/util.jl
@@ -104,9 +104,18 @@ function _comment_bot_intro()
 end
 
 function _new_package_section()
-    return string("## New package registration", "\n\n",
-    "Please make sure that you have read the ",
+    return string("## Package naming guidelines", "\n\n",
+    "Since you are registering a new package, ",
+    "please make sure that you have read the ",
     "[package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).\n\n")
+end
+
+function _automerge_guidelines_failed_section_title()
+    return "## Some [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are not met ❌\n\n"
+end
+
+function _automerge_guidelines_passed_section_title()
+    "## All [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are met! ✅\n\n"
 end
 
 function _what_next_if_fail(; point_to_slack=false)
@@ -126,17 +135,9 @@ function _what_next_if_fail(; point_to_slack=false)
     return msg
 end
 
-function _automerge_guidelines_failed_section_title()
-    return "## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌\n\n"
-end
-
-function _automerge_guidelines_passed_section_title()
-    "## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅\n\n"
-end
-
 function _comment_noblock()
     result = string(
-        "## To pause or stop registration\n\n",
+        "## Pausing or stopping registration\n\n",
         "If you want to prevent this pull request from ",
         "being auto-merged, simply leave a comment. ",
         "If you want to post a comment without blocking ",

--- a/src/AutoMerge/util.jl
+++ b/src/AutoMerge/util.jl
@@ -103,15 +103,15 @@ function _comment_bot_intro()
     "the pull request needs to be manually reviewed and merged by a human.\n\n")
 end
 
-function _new_package_section(n)
-    return string("## $n. New package registration", "\n\n",
+function _new_package_section()
+    return string("## New package registration", "\n\n",
     "Please make sure that you have read the ",
     "[package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).\n\n")
 end
 
-function _what_next_if_fail(n; point_to_slack=false)
+function _what_next_if_fail(; point_to_slack=false)
     msg = """
-    ## $n. *Needs action*: here's what to do next
+    ## *Needs action*: here's what to do next
 
     1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so."""
     msg = string(msg, "\n",
@@ -126,17 +126,17 @@ function _what_next_if_fail(n; point_to_slack=false)
     return msg
 end
 
-function _automerge_guidelines_failed_section_title(n)
-    return "## $n. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌\n\n"
+function _automerge_guidelines_failed_section_title()
+    return "## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌\n\n"
 end
 
-function _automerge_guidelines_passed_section_title(n)
-    "## $n. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅\n\n"
+function _automerge_guidelines_passed_section_title()
+    "## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅\n\n"
 end
 
-function _comment_noblock(n)
+function _comment_noblock()
     result = string(
-        "## $n. To pause or stop registration\n\n",
+        "## To pause or stop registration\n\n",
         "If you want to prevent this pull request from ",
         "being auto-merged, simply leave a comment. ",
         "If you want to post a comment without blocking ",
@@ -155,12 +155,12 @@ function comment_text_pass(
     suggest_onepointzero &= version < v"1.0.0"
     result = string(
         _comment_bot_intro(),
-        _automerge_guidelines_passed_section_title(1),
+        _automerge_guidelines_passed_section_title(),
         "Your new version registration met all of the ",
         "guidelines for auto-merging and is scheduled to ",
         "be merged in the next round.\n\n",
-        _onepointzero_suggestion(2, suggest_onepointzero, version),
-        _comment_noblock(suggest_onepointzero ? 3 : 2),
+        _onepointzero_suggestion(suggest_onepointzero, version),
+        _comment_noblock(),
         "<!-- [noblock] -->",
     )
     return result
@@ -173,24 +173,24 @@ function comment_text_pass(
     if is_jll
         result = string(
             _comment_bot_intro(),
-            _automerge_guidelines_passed_section_title(1),
+            _automerge_guidelines_passed_section_title(),
             "Your new `_jll` package registration met all of the ",
             "guidelines for auto-merging and is scheduled to ",
             "be merged in the next round.\n\n",
-            _onepointzero_suggestion(2, suggest_onepointzero, version),
-            _comment_noblock(suggest_onepointzero ? 3 : 2),
+            _onepointzero_suggestion(suggest_onepointzero, version),
+            _comment_noblock(),
             "<!-- [noblock] -->",
         )
     else
         result = string(
             _comment_bot_intro(),
-            _new_package_section(1),
-            _automerge_guidelines_passed_section_title(2),
+            _new_package_section(),
+            _automerge_guidelines_passed_section_title(),
             "Your new package registration met all of the ",
             "guidelines for auto-merging and is scheduled to ",
             "be merged when the mandatory waiting period ($new_package_waiting_period) has elapsed.\n\n",
-            _onepointzero_suggestion(3, suggest_onepointzero, version),
-            _comment_noblock(suggest_onepointzero ? 4 : 3),
+            _onepointzero_suggestion(suggest_onepointzero, version),
+            _comment_noblock(),
             "<!-- [noblock] -->",
         )
     end
@@ -208,12 +208,12 @@ function comment_text_fail(
     reasons_formatted = string(join(string.("- ", reasons), "\n"), "\n\n")
     result = string(
         _comment_bot_intro(),
-        _new_package_section(1),
-        _automerge_guidelines_failed_section_title(2),
+        _new_package_section(),
+        _automerge_guidelines_failed_section_title(),
         reasons_formatted,
-        _what_next_if_fail(3; point_to_slack=point_to_slack),
-        _onepointzero_suggestion(4, suggest_onepointzero, version),
-        _comment_noblock(suggest_onepointzero ? 5 : 4),
+        _what_next_if_fail(; point_to_slack=point_to_slack),
+        _onepointzero_suggestion(suggest_onepointzero, version),
+        _comment_noblock(),
         "<!-- [noblock] -->",
     )
     return result
@@ -230,11 +230,11 @@ function comment_text_fail(
     reasons_formatted = string(join(string.("- ", reasons), "\n"), "\n\n")
     result = string(
         _comment_bot_intro(),
-        _automerge_guidelines_failed_section_title(1),
+        _automerge_guidelines_failed_section_title(),
         reasons_formatted,
-        _what_next_if_fail(2; point_to_slack=point_to_slack),
-        _onepointzero_suggestion(3, suggest_onepointzero, version),
-        _comment_noblock(suggest_onepointzero ? 4 : 3),
+        _what_next_if_fail(; point_to_slack=point_to_slack),
+        _onepointzero_suggestion(suggest_onepointzero, version),
+        _comment_noblock(),
         "<!-- [noblock] -->",
     )
     return result
@@ -259,10 +259,10 @@ function now_utc()
     return Dates.now(utc)
 end
 
-function _onepointzero_suggestion(n, suggest_onepointzero::Bool, version::VersionNumber)
+function _onepointzero_suggestion(suggest_onepointzero::Bool, version::VersionNumber)
     if suggest_onepointzero && version < v"1.0.0"
         result = string(
-            "## $n. Declare v1.0?\n\n",
+            "## Declare v1.0?\n\n",
             "On a separate note, I see that you are registering ",
             "a release with a version number of the form ",
             "`v0.X.Y`.\n\n",

--- a/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_0.1.0_point_to_slack_false.md
+++ b/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_0.1.0_point_to_slack_false.md
@@ -1,10 +1,10 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## New package registration
+## Package naming guidelines
 
-Please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
+Since you are registering a new package, please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## Some [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are not met ❌
 
 - Example guideline failed. Please fix it.
 
@@ -15,7 +15,7 @@ Please make sure that you have read the [package naming guidelines](https://juli
 
 If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged.
 
-## To pause or stop registration
+## Pausing or stopping registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_0.1.0_point_to_slack_false.md
+++ b/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_0.1.0_point_to_slack_false.md
@@ -1,21 +1,21 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. New package registration
+## New package registration
 
 Please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-## 3. *Needs action*: here's what to do next
+## *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so.
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless the AutoMerge issue is that you skipped a version number).
 
 If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged.
 
-## 4. To pause or stop registration
+## To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_0.1.0_point_to_slack_true.md
+++ b/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_0.1.0_point_to_slack_true.md
@@ -1,10 +1,10 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## New package registration
+## Package naming guidelines
 
-Please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
+Since you are registering a new package, please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## Some [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are not met ❌
 
 - Example guideline failed. Please fix it.
 
@@ -15,7 +15,7 @@ Please make sure that you have read the [package naming guidelines](https://juli
 
 If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged. Then, send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) for better visibility.
 
-## To pause or stop registration
+## Pausing or stopping registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_0.1.0_point_to_slack_true.md
+++ b/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_0.1.0_point_to_slack_true.md
@@ -1,21 +1,21 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. New package registration
+## New package registration
 
 Please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-## 3. *Needs action*: here's what to do next
+## *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so.
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless the AutoMerge issue is that you skipped a version number).
 
 If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged. Then, send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) for better visibility.
 
-## 4. To pause or stop registration
+## To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_1.0.0_point_to_slack_false.md
+++ b/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_1.0.0_point_to_slack_false.md
@@ -1,10 +1,10 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## New package registration
+## Package naming guidelines
 
-Please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
+Since you are registering a new package, please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## Some [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are not met ❌
 
 - Example guideline failed. Please fix it.
 
@@ -15,7 +15,7 @@ Please make sure that you have read the [package naming guidelines](https://juli
 
 If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged.
 
-## To pause or stop registration
+## Pausing or stopping registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_1.0.0_point_to_slack_false.md
+++ b/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_1.0.0_point_to_slack_false.md
@@ -1,21 +1,21 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. New package registration
+## New package registration
 
 Please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-## 3. *Needs action*: here's what to do next
+## *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so.
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless the AutoMerge issue is that you skipped a version number).
 
 If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged.
 
-## 4. To pause or stop registration
+## To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_1.0.0_point_to_slack_true.md
+++ b/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_1.0.0_point_to_slack_true.md
@@ -1,10 +1,10 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## New package registration
+## Package naming guidelines
 
-Please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
+Since you are registering a new package, please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## Some [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are not met ❌
 
 - Example guideline failed. Please fix it.
 
@@ -15,7 +15,7 @@ Please make sure that you have read the [package naming guidelines](https://juli
 
 If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged. Then, send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) for better visibility.
 
-## To pause or stop registration
+## Pausing or stopping registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_1.0.0_point_to_slack_true.md
+++ b/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_1.0.0_point_to_slack_true.md
@@ -1,21 +1,21 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. New package registration
+## New package registration
 
 Please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-## 3. *Needs action*: here's what to do next
+## *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so.
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless the AutoMerge issue is that you skipped a version number).
 
 If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged. Then, send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) for better visibility.
 
-## 4. To pause or stop registration
+## To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_0.1.0_point_to_slack_false.md
+++ b/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_0.1.0_point_to_slack_false.md
@@ -1,10 +1,10 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## New package registration
+## Package naming guidelines
 
-Please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
+Since you are registering a new package, please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## Some [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are not met ❌
 
 - Example guideline failed. Please fix it.
 
@@ -23,7 +23,7 @@ Does your package have a stable public API? If so, then it's time for you to reg
 
 If your package does not yet have a stable public API, then of course you are not yet ready to release version `v1.0.0`.
 
-## To pause or stop registration
+## Pausing or stopping registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_0.1.0_point_to_slack_false.md
+++ b/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_0.1.0_point_to_slack_false.md
@@ -1,21 +1,21 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. New package registration
+## New package registration
 
 Please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-## 3. *Needs action*: here's what to do next
+## *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so.
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless the AutoMerge issue is that you skipped a version number).
 
 If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged.
 
-## 4. Declare v1.0?
+## Declare v1.0?
 
 On a separate note, I see that you are registering a release with a version number of the form `v0.X.Y`.
 
@@ -23,7 +23,7 @@ Does your package have a stable public API? If so, then it's time for you to reg
 
 If your package does not yet have a stable public API, then of course you are not yet ready to release version `v1.0.0`.
 
-## 5. To pause or stop registration
+## To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_0.1.0_point_to_slack_true.md
+++ b/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_0.1.0_point_to_slack_true.md
@@ -1,10 +1,10 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## New package registration
+## Package naming guidelines
 
-Please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
+Since you are registering a new package, please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## Some [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are not met ❌
 
 - Example guideline failed. Please fix it.
 
@@ -23,7 +23,7 @@ Does your package have a stable public API? If so, then it's time for you to reg
 
 If your package does not yet have a stable public API, then of course you are not yet ready to release version `v1.0.0`.
 
-## To pause or stop registration
+## Pausing or stopping registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_0.1.0_point_to_slack_true.md
+++ b/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_0.1.0_point_to_slack_true.md
@@ -1,21 +1,21 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. New package registration
+## New package registration
 
 Please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-## 3. *Needs action*: here's what to do next
+## *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so.
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless the AutoMerge issue is that you skipped a version number).
 
 If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged. Then, send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) for better visibility.
 
-## 4. Declare v1.0?
+## Declare v1.0?
 
 On a separate note, I see that you are registering a release with a version number of the form `v0.X.Y`.
 
@@ -23,7 +23,7 @@ Does your package have a stable public API? If so, then it's time for you to reg
 
 If your package does not yet have a stable public API, then of course you are not yet ready to release version `v1.0.0`.
 
-## 5. To pause or stop registration
+## To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_1.0.0_point_to_slack_false.md
+++ b/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_1.0.0_point_to_slack_false.md
@@ -1,10 +1,10 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## New package registration
+## Package naming guidelines
 
-Please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
+Since you are registering a new package, please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## Some [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are not met ❌
 
 - Example guideline failed. Please fix it.
 
@@ -15,7 +15,7 @@ Please make sure that you have read the [package naming guidelines](https://juli
 
 If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged.
 
-## To pause or stop registration
+## Pausing or stopping registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_1.0.0_point_to_slack_false.md
+++ b/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_1.0.0_point_to_slack_false.md
@@ -1,21 +1,21 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. New package registration
+## New package registration
 
 Please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-## 3. *Needs action*: here's what to do next
+## *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so.
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless the AutoMerge issue is that you skipped a version number).
 
 If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged.
 
-## 4. To pause or stop registration
+## To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_1.0.0_point_to_slack_true.md
+++ b/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_1.0.0_point_to_slack_true.md
@@ -1,10 +1,10 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## New package registration
+## Package naming guidelines
 
-Please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
+Since you are registering a new package, please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## Some [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are not met ❌
 
 - Example guideline failed. Please fix it.
 
@@ -15,7 +15,7 @@ Please make sure that you have read the [package naming guidelines](https://juli
 
 If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged. Then, send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) for better visibility.
 
-## To pause or stop registration
+## Pausing or stopping registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_1.0.0_point_to_slack_true.md
+++ b/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_1.0.0_point_to_slack_true.md
@@ -1,21 +1,21 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. New package registration
+## New package registration
 
 Please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-## 3. *Needs action*: here's what to do next
+## *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so.
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless the AutoMerge issue is that you skipped a version number).
 
 If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged. Then, send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) for better visibility.
 
-## 4. To pause or stop registration
+## To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_0.1.0_point_to_slack_false.md
+++ b/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_0.1.0_point_to_slack_false.md
@@ -1,6 +1,6 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## Some [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are not met ❌
 
 - Example guideline failed. Please fix it.
 
@@ -11,7 +11,7 @@ Hello, I am an automated registration bot. I help manage the registration proces
 
 If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged.
 
-## To pause or stop registration
+## Pausing or stopping registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_0.1.0_point_to_slack_false.md
+++ b/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_0.1.0_point_to_slack_false.md
@@ -1,17 +1,17 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-## 2. *Needs action*: here's what to do next
+## *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so.
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless the AutoMerge issue is that you skipped a version number).
 
 If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged.
 
-## 3. To pause or stop registration
+## To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_0.1.0_point_to_slack_true.md
+++ b/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_0.1.0_point_to_slack_true.md
@@ -1,6 +1,6 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## Some [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are not met ❌
 
 - Example guideline failed. Please fix it.
 
@@ -11,7 +11,7 @@ Hello, I am an automated registration bot. I help manage the registration proces
 
 If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged. Then, send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) for better visibility.
 
-## To pause or stop registration
+## Pausing or stopping registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_0.1.0_point_to_slack_true.md
+++ b/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_0.1.0_point_to_slack_true.md
@@ -1,17 +1,17 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-## 2. *Needs action*: here's what to do next
+## *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so.
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless the AutoMerge issue is that you skipped a version number).
 
 If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged. Then, send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) for better visibility.
 
-## 3. To pause or stop registration
+## To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_1.0.0_point_to_slack_false.md
+++ b/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_1.0.0_point_to_slack_false.md
@@ -1,6 +1,6 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## Some [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are not met ❌
 
 - Example guideline failed. Please fix it.
 
@@ -11,7 +11,7 @@ Hello, I am an automated registration bot. I help manage the registration proces
 
 If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged.
 
-## To pause or stop registration
+## Pausing or stopping registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_1.0.0_point_to_slack_false.md
+++ b/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_1.0.0_point_to_slack_false.md
@@ -1,17 +1,17 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-## 2. *Needs action*: here's what to do next
+## *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so.
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless the AutoMerge issue is that you skipped a version number).
 
 If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged.
 
-## 3. To pause or stop registration
+## To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_1.0.0_point_to_slack_true.md
+++ b/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_1.0.0_point_to_slack_true.md
@@ -1,6 +1,6 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## Some [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are not met ❌
 
 - Example guideline failed. Please fix it.
 
@@ -11,7 +11,7 @@ Hello, I am an automated registration bot. I help manage the registration proces
 
 If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged. Then, send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) for better visibility.
 
-## To pause or stop registration
+## Pausing or stopping registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_1.0.0_point_to_slack_true.md
+++ b/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_1.0.0_point_to_slack_true.md
@@ -1,17 +1,17 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-## 2. *Needs action*: here's what to do next
+## *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so.
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless the AutoMerge issue is that you skipped a version number).
 
 If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged. Then, send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) for better visibility.
 
-## 3. To pause or stop registration
+## To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_0.1.0_point_to_slack_false.md
+++ b/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_0.1.0_point_to_slack_false.md
@@ -1,17 +1,17 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-## 2. *Needs action*: here's what to do next
+## *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so.
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless the AutoMerge issue is that you skipped a version number).
 
 If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged.
 
-## 3. Declare v1.0?
+## Declare v1.0?
 
 On a separate note, I see that you are registering a release with a version number of the form `v0.X.Y`.
 
@@ -19,7 +19,7 @@ Does your package have a stable public API? If so, then it's time for you to reg
 
 If your package does not yet have a stable public API, then of course you are not yet ready to release version `v1.0.0`.
 
-## 4. To pause or stop registration
+## To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_0.1.0_point_to_slack_false.md
+++ b/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_0.1.0_point_to_slack_false.md
@@ -1,6 +1,6 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## Some [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are not met ❌
 
 - Example guideline failed. Please fix it.
 
@@ -19,7 +19,7 @@ Does your package have a stable public API? If so, then it's time for you to reg
 
 If your package does not yet have a stable public API, then of course you are not yet ready to release version `v1.0.0`.
 
-## To pause or stop registration
+## Pausing or stopping registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_0.1.0_point_to_slack_true.md
+++ b/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_0.1.0_point_to_slack_true.md
@@ -1,17 +1,17 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-## 2. *Needs action*: here's what to do next
+## *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so.
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless the AutoMerge issue is that you skipped a version number).
 
 If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged. Then, send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) for better visibility.
 
-## 3. Declare v1.0?
+## Declare v1.0?
 
 On a separate note, I see that you are registering a release with a version number of the form `v0.X.Y`.
 
@@ -19,7 +19,7 @@ Does your package have a stable public API? If so, then it's time for you to reg
 
 If your package does not yet have a stable public API, then of course you are not yet ready to release version `v1.0.0`.
 
-## 4. To pause or stop registration
+## To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_0.1.0_point_to_slack_true.md
+++ b/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_0.1.0_point_to_slack_true.md
@@ -1,6 +1,6 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## Some [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are not met ❌
 
 - Example guideline failed. Please fix it.
 
@@ -19,7 +19,7 @@ Does your package have a stable public API? If so, then it's time for you to reg
 
 If your package does not yet have a stable public API, then of course you are not yet ready to release version `v1.0.0`.
 
-## To pause or stop registration
+## Pausing or stopping registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_1.0.0_point_to_slack_false.md
+++ b/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_1.0.0_point_to_slack_false.md
@@ -1,6 +1,6 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## Some [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are not met ❌
 
 - Example guideline failed. Please fix it.
 
@@ -11,7 +11,7 @@ Hello, I am an automated registration bot. I help manage the registration proces
 
 If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged.
 
-## To pause or stop registration
+## Pausing or stopping registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_1.0.0_point_to_slack_false.md
+++ b/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_1.0.0_point_to_slack_false.md
@@ -1,17 +1,17 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-## 2. *Needs action*: here's what to do next
+## *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so.
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless the AutoMerge issue is that you skipped a version number).
 
 If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged.
 
-## 3. To pause or stop registration
+## To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_1.0.0_point_to_slack_true.md
+++ b/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_1.0.0_point_to_slack_true.md
@@ -1,6 +1,6 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## Some [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are not met ❌
 
 - Example guideline failed. Please fix it.
 
@@ -11,7 +11,7 @@ Hello, I am an automated registration bot. I help manage the registration proces
 
 If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged. Then, send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) for better visibility.
 
-## To pause or stop registration
+## Pausing or stopping registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_1.0.0_point_to_slack_true.md
+++ b/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_1.0.0_point_to_slack_true.md
@@ -1,17 +1,17 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
+## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - Example guideline failed. Please fix it.
 
-## 2. *Needs action*: here's what to do next
+## *Needs action*: here's what to do next
 
 1. Please try to update your package to conform to these guidelines. The [General registry's README](https://github.com/JuliaRegistries/General/blob/master/README.md) has an FAQ that can help figure out how to do so.
 2. After you have fixed the AutoMerge issues, simply retrigger Registrator, the same way you did in the initial registration. This will automatically update this pull request. You do not need to change the version number in your `Project.toml` file (unless the AutoMerge issue is that you skipped a version number).
 
 If you need help fixing the AutoMerge issues, or want your pull request to be manually merged instead, please post a comment explaining what you need help with or why you would like this pull request to be manually merged. Then, send a message to the `#pkg-registration` channel in the [public Julia Slack](https://julialang.org/slack/) for better visibility.
 
-## 3. To pause or stop registration
+## To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_0.1.0_is_jll_false.md
+++ b/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_0.1.0_is_jll_false.md
@@ -1,14 +1,14 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## New package registration
+## Package naming guidelines
 
-Please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
+Since you are registering a new package, please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## All [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are met! ✅
 
 Your new package registration met all of the guidelines for auto-merging and is scheduled to be merged when the mandatory waiting period (3 days) has elapsed.
 
-## To pause or stop registration
+## Pausing or stopping registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_0.1.0_is_jll_false.md
+++ b/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_0.1.0_is_jll_false.md
@@ -1,14 +1,14 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. New package registration
+## New package registration
 
 Please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new package registration met all of the guidelines for auto-merging and is scheduled to be merged when the mandatory waiting period (3 days) has elapsed.
 
-## 3. To pause or stop registration
+## To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_0.1.0_is_jll_true.md
+++ b/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_0.1.0_is_jll_true.md
@@ -1,10 +1,10 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## All [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are met! ✅
 
 Your new `_jll` package registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-## To pause or stop registration
+## Pausing or stopping registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_0.1.0_is_jll_true.md
+++ b/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_0.1.0_is_jll_true.md
@@ -1,10 +1,10 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new `_jll` package registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-## 2. To pause or stop registration
+## To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_1.0.0_is_jll_false.md
+++ b/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_1.0.0_is_jll_false.md
@@ -1,14 +1,14 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## New package registration
+## Package naming guidelines
 
-Please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
+Since you are registering a new package, please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## All [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are met! ✅
 
 Your new package registration met all of the guidelines for auto-merging and is scheduled to be merged when the mandatory waiting period (3 days) has elapsed.
 
-## To pause or stop registration
+## Pausing or stopping registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_1.0.0_is_jll_false.md
+++ b/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_1.0.0_is_jll_false.md
@@ -1,14 +1,14 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. New package registration
+## New package registration
 
 Please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new package registration met all of the guidelines for auto-merging and is scheduled to be merged when the mandatory waiting period (3 days) has elapsed.
 
-## 3. To pause or stop registration
+## To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_1.0.0_is_jll_true.md
+++ b/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_1.0.0_is_jll_true.md
@@ -1,10 +1,10 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## All [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are met! ✅
 
 Your new `_jll` package registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-## To pause or stop registration
+## Pausing or stopping registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_1.0.0_is_jll_true.md
+++ b/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_1.0.0_is_jll_true.md
@@ -1,10 +1,10 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new `_jll` package registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-## 2. To pause or stop registration
+## To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_0.1.0_is_jll_false.md
+++ b/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_0.1.0_is_jll_false.md
@@ -1,14 +1,14 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. New package registration
+## New package registration
 
 Please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new package registration met all of the guidelines for auto-merging and is scheduled to be merged when the mandatory waiting period (3 days) has elapsed.
 
-## 3. Declare v1.0?
+## Declare v1.0?
 
 On a separate note, I see that you are registering a release with a version number of the form `v0.X.Y`.
 
@@ -16,7 +16,7 @@ Does your package have a stable public API? If so, then it's time for you to reg
 
 If your package does not yet have a stable public API, then of course you are not yet ready to release version `v1.0.0`.
 
-## 4. To pause or stop registration
+## To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_0.1.0_is_jll_false.md
+++ b/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_0.1.0_is_jll_false.md
@@ -1,10 +1,10 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## New package registration
+## Package naming guidelines
 
-Please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
+Since you are registering a new package, please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## All [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are met! ✅
 
 Your new package registration met all of the guidelines for auto-merging and is scheduled to be merged when the mandatory waiting period (3 days) has elapsed.
 
@@ -16,7 +16,7 @@ Does your package have a stable public API? If so, then it's time for you to reg
 
 If your package does not yet have a stable public API, then of course you are not yet ready to release version `v1.0.0`.
 
-## To pause or stop registration
+## Pausing or stopping registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_0.1.0_is_jll_true.md
+++ b/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_0.1.0_is_jll_true.md
@@ -1,6 +1,6 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## All [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are met! ✅
 
 Your new `_jll` package registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
@@ -12,7 +12,7 @@ Does your package have a stable public API? If so, then it's time for you to reg
 
 If your package does not yet have a stable public API, then of course you are not yet ready to release version `v1.0.0`.
 
-## To pause or stop registration
+## Pausing or stopping registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_0.1.0_is_jll_true.md
+++ b/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_0.1.0_is_jll_true.md
@@ -1,10 +1,10 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new `_jll` package registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-## 2. Declare v1.0?
+## Declare v1.0?
 
 On a separate note, I see that you are registering a release with a version number of the form `v0.X.Y`.
 
@@ -12,7 +12,7 @@ Does your package have a stable public API? If so, then it's time for you to reg
 
 If your package does not yet have a stable public API, then of course you are not yet ready to release version `v1.0.0`.
 
-## 3. To pause or stop registration
+## To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_1.0.0_is_jll_false.md
+++ b/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_1.0.0_is_jll_false.md
@@ -1,14 +1,14 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## New package registration
+## Package naming guidelines
 
-Please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
+Since you are registering a new package, please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## All [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are met! ✅
 
 Your new package registration met all of the guidelines for auto-merging and is scheduled to be merged when the mandatory waiting period (3 days) has elapsed.
 
-## To pause or stop registration
+## Pausing or stopping registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_1.0.0_is_jll_false.md
+++ b/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_1.0.0_is_jll_false.md
@@ -1,14 +1,14 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. New package registration
+## New package registration
 
 Please make sure that you have read the [package naming guidelines](https://julialang.github.io/Pkg.jl/dev/creating-packages/#Package-naming-guidelines-1).
 
-## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new package registration met all of the guidelines for auto-merging and is scheduled to be merged when the mandatory waiting period (3 days) has elapsed.
 
-## 3. To pause or stop registration
+## To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_1.0.0_is_jll_true.md
+++ b/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_1.0.0_is_jll_true.md
@@ -1,10 +1,10 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## All [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are met! ✅
 
 Your new `_jll` package registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-## To pause or stop registration
+## Pausing or stopping registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_1.0.0_is_jll_true.md
+++ b/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_1.0.0_is_jll_true.md
@@ -1,10 +1,10 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new `_jll` package registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-## 2. To pause or stop registration
+## To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_0.1.0_is_jll_false.md
+++ b/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_0.1.0_is_jll_false.md
@@ -1,10 +1,10 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## All [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are met! ✅
 
 Your new version registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-## To pause or stop registration
+## Pausing or stopping registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_0.1.0_is_jll_false.md
+++ b/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_0.1.0_is_jll_false.md
@@ -1,10 +1,10 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new version registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-## 2. To pause or stop registration
+## To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_0.1.0_is_jll_true.md
+++ b/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_0.1.0_is_jll_true.md
@@ -1,10 +1,10 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## All [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are met! ✅
 
 Your new version registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-## To pause or stop registration
+## Pausing or stopping registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_0.1.0_is_jll_true.md
+++ b/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_0.1.0_is_jll_true.md
@@ -1,10 +1,10 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new version registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-## 2. To pause or stop registration
+## To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_1.0.0_is_jll_false.md
+++ b/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_1.0.0_is_jll_false.md
@@ -1,10 +1,10 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## All [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are met! ✅
 
 Your new version registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-## To pause or stop registration
+## Pausing or stopping registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_1.0.0_is_jll_false.md
+++ b/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_1.0.0_is_jll_false.md
@@ -1,10 +1,10 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new version registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-## 2. To pause or stop registration
+## To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_1.0.0_is_jll_true.md
+++ b/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_1.0.0_is_jll_true.md
@@ -1,10 +1,10 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## All [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are met! ✅
 
 Your new version registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-## To pause or stop registration
+## Pausing or stopping registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_1.0.0_is_jll_true.md
+++ b/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_1.0.0_is_jll_true.md
@@ -1,10 +1,10 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new version registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-## 2. To pause or stop registration
+## To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_0.1.0_is_jll_false.md
+++ b/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_0.1.0_is_jll_false.md
@@ -1,10 +1,10 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new version registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-## 2. Declare v1.0?
+## Declare v1.0?
 
 On a separate note, I see that you are registering a release with a version number of the form `v0.X.Y`.
 
@@ -12,7 +12,7 @@ Does your package have a stable public API? If so, then it's time for you to reg
 
 If your package does not yet have a stable public API, then of course you are not yet ready to release version `v1.0.0`.
 
-## 3. To pause or stop registration
+## To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_0.1.0_is_jll_false.md
+++ b/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_0.1.0_is_jll_false.md
@@ -1,6 +1,6 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## All [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are met! ✅
 
 Your new version registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
@@ -12,7 +12,7 @@ Does your package have a stable public API? If so, then it's time for you to reg
 
 If your package does not yet have a stable public API, then of course you are not yet ready to release version `v1.0.0`.
 
-## To pause or stop registration
+## Pausing or stopping registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_0.1.0_is_jll_true.md
+++ b/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_0.1.0_is_jll_true.md
@@ -1,10 +1,10 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new version registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-## 2. Declare v1.0?
+## Declare v1.0?
 
 On a separate note, I see that you are registering a release with a version number of the form `v0.X.Y`.
 
@@ -12,7 +12,7 @@ Does your package have a stable public API? If so, then it's time for you to reg
 
 If your package does not yet have a stable public API, then of course you are not yet ready to release version `v1.0.0`.
 
-## 3. To pause or stop registration
+## To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_0.1.0_is_jll_true.md
+++ b/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_0.1.0_is_jll_true.md
@@ -1,6 +1,6 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## All [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are met! ✅
 
 Your new version registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
@@ -12,7 +12,7 @@ Does your package have a stable public API? If so, then it's time for you to reg
 
 If your package does not yet have a stable public API, then of course you are not yet ready to release version `v1.0.0`.
 
-## To pause or stop registration
+## Pausing or stopping registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_1.0.0_is_jll_false.md
+++ b/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_1.0.0_is_jll_false.md
@@ -1,10 +1,10 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## All [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are met! ✅
 
 Your new version registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-## To pause or stop registration
+## Pausing or stopping registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_1.0.0_is_jll_false.md
+++ b/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_1.0.0_is_jll_false.md
@@ -1,10 +1,10 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new version registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-## 2. To pause or stop registration
+## To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_1.0.0_is_jll_true.md
+++ b/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_1.0.0_is_jll_true.md
@@ -1,10 +1,10 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## All [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are met! ✅
 
 Your new version registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-## To pause or stop registration
+## Pausing or stopping registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 

--- a/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_1.0.0_is_jll_true.md
+++ b/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_1.0.0_is_jll_true.md
@@ -1,10 +1,10 @@
 Hello, I am an automated registration bot. I help manage the registration process by checking your registration against a set of [AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/). If all these guidelines are met, this pull request will be merged automatically, completing your registration. It is **strongly recommended** to follow the guidelines, since otherwise the pull request needs to be manually reviewed and merged by a human.
 
-## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
+## [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new version registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round.
 
-## 2. To pause or stop registration
+## To pause or stop registration
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment. 
 


### PR DESCRIPTION
* remove section numbers: distracting, not useful
* tweak titles: improve legibility a little

Sorry for all the churn here, but it helps to see it in action for a bit to realize what else could be improved.

To me this looks a little nicer, but I'm not 100% sure if it's actually better 