### PR TITLE
Open tagbot trigger issues for testitem repos

### DIFF
--- a/src/TagBot/TagBot.jl
+++ b/src/TagBot/TagBot.jl
@@ -71,7 +71,7 @@ function tagbot_file(repo; issue_comments=false)
         f.typ == "file" || continue
         file = GH.file(repo, f.path; auth=AUTH[])
         contents = String(base64decode(file.content))
-        if occursin("JuliaRegistries/TagBot", contents)
+        if occursin("JuliaRegistries/TagBot", contents) || occursin("julia-vscode/testitem-workflow/.github/workflows/juliaci.yml", contents)
             issue_comments && !occursin("issue_comment", contents) && continue
             return f.path, contents
         end


### PR DESCRIPTION
Repos that use the `julia-vscode/testitem-workflow/.github/workflows/juliaci.yml` are also TagBot enabled.