### PR TITLE
Allow LazyJLLWrappers for JLLs

### DIFF
--- a/src/AutoMerge/jll.jl
+++ b/src/AutoMerge/jll.jl
@@ -31,17 +31,17 @@ const guideline_allowed_jll_nonrecursive_dependencies = Guideline(;
 function meets_allowed_jll_nonrecursive_dependencies(
     working_directory::AbstractString, pkg, version
 )
-    # If you are a JLL package, you are only allowed to have five kinds of dependencies:
+    # If you are a JLL package, you are only allowed to have the following dependencies:
     # 1. Pkg
     # 2. Libdl
     # 3. Artifacts
-    # 4. JLLWrappers
+    # 4. JLLWrappers (or LazyJLLWrappers)
     # 5. LazyArtifacts
     # 6. TOML
-    # 8. MPIPreferences
-    # 7. other JLL packages
+    # 7. MPIPreferences
+    # 8. other JLL packages
     all_dependencies = _get_all_dependencies_nonrecursive(working_directory, pkg, version)
-    allowed_dependencies = ("Pkg", "Libdl", "Artifacts", "JLLWrappers", "LazyArtifacts", "TOML", "MPIPreferences")
+    allowed_dependencies = ("Pkg", "Libdl", "Artifacts", "JLLWrappers", "LazyJLLWrappers", "LazyArtifacts", "TOML", "MPIPreferences")
     for dep in all_dependencies
         if dep ∉ allowed_dependencies && !is_jll_name(dep)
             return false,


### PR DESCRIPTION
BinaryBuilder2 generates JLLs that use `LazyJLLWrappers` instead of `JLLWrappers`, we need to allow that here for them to get registered.