### PR TITLE
Move blocked label updating earlier

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryCI"
 uuid = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
 authors = ["Dilum Aluthge <dilum@aluthge.com>", "Fredrik Ekre <ekrefredrik@gmail.com>", "contributors"]
-version = "10.8.0"
+version = "10.8.1"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/AutoMerge/cron.jl
+++ b/src/AutoMerge/cron.jl
@@ -321,7 +321,6 @@ function cron_or_api_build(
         @info(
             string(
                 "Pull request: $(pr_number). ",
-                "Type: $(pr_type). ",
                 "Decision: do not merge. ",
                 "Reason: pull request has one or more blocking comments.",
             )


### PR DESCRIPTION
Currently, we don't update the labels regarding blocked/not-blocked unless the auto merge commit status is OK, the waiting period has elapsed, etc. This means many PRs that are blocked aren't labeled. It also means that the blocked label won't be properly removed in the following situation:

- the PR has automerge status passing, but a comment is blocking
- blocked label is added
- the pr is updated and automerge starts failing
- blocking comment is removed
- status quo: block label is *not* removed bc we don't get to the code that updates the label
- PR: block label is removed, since we update the block label first

This PR fixes it by moving the block check earlier, once we are confident it is a registration PR, so the label is updated reliably.