### PR TITLE
Fix a missing space in a log message

### DIFF
--- a/src/AutoMerge/guidelines.jl
+++ b/src/AutoMerge/guidelines.jl
@@ -1052,7 +1052,7 @@ function _run_pkg_commands(
     @info("""
         IMPORTANT: If you see any messages of the form "Error: Some registries failed to update"
         or "registry dirty"
-        please disregard those messages. Those messages are normal and do not indicate an error
+        please disregard those messages. Those messages are normal and do not indicate an error.
     """)
     cmd_ran_successfully = success(pipeline(cmd; stdout=stdout, stderr=stderr))
     cd(original_directory)

--- a/src/AutoMerge/guidelines.jl
+++ b/src/AutoMerge/guidelines.jl
@@ -1049,11 +1049,11 @@ function _run_pkg_commands(
         pushfirst!(cmd.exec, xvfb)
     end
     @info(before_message)
-    @info(string(
-        "IMPORTANT: If you see any messages of the form \"Error: Some registries failed to update\"",
-        "or \"registry dirty\", ",
-        "please disregard those messages. Those messages are normal and do not indicate an error.",
-    ))
+    @info("""
+        IMPORTANT: If you see any messages of the form "Error: Some registries failed to update"
+        or "registry dirty"
+        please disregard those messages. Those messages are normal and do not indicate an error
+    """)
     cmd_ran_successfully = success(pipeline(cmd; stdout=stdout, stderr=stderr))
     cd(original_directory)
 


### PR DESCRIPTION
Currently, the log message looks like this:

> [ Info: IMPORTANT: If you see any messages of the form "Error: Some registries failed to update"or "registry dirty", please disregard those messages. Those messages are normal and do not indicate an error.

Note that there is a space missing here:
```
update"or
```

This PR adds the missing space.