### PR TITLE
Bump version number from 10.8.1 to 10.9.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryCI"
 uuid = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
 authors = ["Dilum Aluthge <dilum@aluthge.com>", "Fredrik Ekre <ekrefredrik@gmail.com>", "contributors"]
-version = "10.8.1"
+version = "10.9.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"


### PR DESCRIPTION
In preparation for a new release.

I'd like to get a new release out that includes #575.

I decided to consider #575 as a new feature, so I bumped the minor version number here.