### PR TITLE
allow "changelog" in release notes for breaking changelog guideline

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryCI"
 uuid = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
 authors = ["Dilum Aluthge <dilum@aluthge.com>", "Fredrik Ekre <ekrefredrik@gmail.com>", "contributors"]
-version = "10.10.0"
+version = "10.10.1"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/AutoMerge/guidelines.jl
+++ b/src/AutoMerge/guidelines.jl
@@ -8,7 +8,7 @@ using HTTP: HTTP
 const _AUTOMERGE_REQUIRE_STDLIB_COMPAT = false
 
 const guideline_registry_consistency_tests_pass = Guideline(;
-    info="Registy consistency tests",
+    info="Registry consistency tests",
     docs=nothing,
     check=data ->
         meets_registry_consistency_tests_pass(data.registry_head, data.registry_deps),
@@ -325,7 +325,7 @@ end
 # This check checks for an explanation of why a breaking change is breaking
 const guideline_breaking_explanation = Guideline(;
     info = "Release notes have not been provided that explain why this is a breaking change.",
-    docs = "If this is a breaking change, release notes must be given that explain why this is a breaking change (i.e. mention \"breaking\"). To update the release notes, please see the \"Providing and updating release notes\" subsection under \"Additional information\" below.",
+    docs = "If this is a breaking change, release notes must be given that explain why this is a breaking change (i.e. mention \"breaking\" or \"changelog\"). To update the release notes, please see the \"Providing and updating release notes\" subsection under \"Additional information\" below.",
     check=data -> meets_breaking_explanation_check(data))
 
 function meets_breaking_explanation_check(data::GitHubAutoMergeData)
@@ -374,7 +374,7 @@ function meets_breaking_explanation_check(labels::Vector, body::AbstractString)
         if release_notes === nothing
             msg = breaking_explanation_message(false)
             return false, msg
-        elseif !occursin(r"breaking", lowercase(release_notes))
+        elseif !occursin(r"breaking|changelog", lowercase(release_notes))
             msg = breaking_explanation_message(true)
             return false, msg
         else

--- a/test/automerge-unit.jl
+++ b/test/automerge-unit.jl
@@ -334,6 +334,13 @@ end
         `````
         <!-- END RELEASE NOTES -->
         """
+        body_good_changelog = """
+        <!-- BEGIN RELEASE NOTES -->
+        `````
+        See the changelog at xyz for a list of changes.
+        `````
+        <!-- END RELEASE NOTES -->
+        """
         body_bad = """
         <!-- BEGIN RELEASE NOTES -->
         `````
@@ -346,6 +353,7 @@ end
         body_bad_no_notes = ""
 
         @test AutoMerge.meets_breaking_explanation_check(["BREAKING"], body_good)[1]
+        @test AutoMerge.meets_breaking_explanation_check(["BREAKING"], body_good_changelog)[1]
         @test !AutoMerge.meets_breaking_explanation_check(["BREAKING"], body_bad)[1]
         @test !AutoMerge.meets_breaking_explanation_check(["BREAKING"], body_bad_no_notes)[1]
 


### PR DESCRIPTION
This was suggested by @fredrikekre on Slack. I think it makes sense that if some folks maintain a detailed changelog, then it should suffice for them to point to it. I think it is good if we can keep the requirements minimally burdensome while achieving the outcome, so to me this seems like a good balance (since having a good changelog is a good outcome here).