### PR TITLE
fix unit tests: don't test SnoopCompileCore's repo

### DIFF
--- a/test/automerge-unit.jl
+++ b/test/automerge-unit.jl
@@ -115,12 +115,10 @@ end
         result = AutoMerge.parse_registry_pkg_info(
             registry_path, "SnoopCompileCore", "2.5.2"
         )
-        @test result == (;
-            uuid="e2b509da-e806-4183-be48-004708413034",
-            repo="https://github.com/timholy/SnoopCompile.jl.git",
-            subdir="SnoopCompileCore",
-            tree_hash="bb6d6df44d9aa3494c997aebdee85b713b92c0de",
-        )
+        # Don't test repo field since SnoopCompile.jl has moved repositories (and we don't control it)
+        @test result.uuid == "e2b509da-e806-4183-be48-004708413034"
+        @test result.subdir == "SnoopCompileCore"
+        @test result.tree_hash == "bb6d6df44d9aa3494c997aebdee85b713b92c0de"
     end
 end
 


### PR DESCRIPTION
since it has moved and we don't control it. The repo field is tested earlier anyway. Cherry-picked out of #609 since CI is also failing on #610 due to this. IIUC we only test SnoopCompileCore since it is an example of a subdir package.

This is included in #610 so if that gets through the merge queue we can just close this.