### PR TITLE
Move configuration to struct and add `GENERAL_AUTOMERGE_CONFIG`

### DIFF
--- a/AutoMerge.jl/src/AutoMerge.jl
+++ b/AutoMerge.jl/src/AutoMerge.jl
@@ -17,6 +17,12 @@ using RegistryTools: RegistryTools
 using Tar: Tar
 using RegistryCI: RegistryCI
 
+if VERSION >= v"1.11.0-DEV.469"
+    eval(Meta.parse("""
+    public run, AutoMergeConfiguration, GENERAL_AUTOMERGE_CONFIG, TagBot
+    """))
+end
+
 include("TagBot/TagBot.jl")
 
 include("types.jl")

--- a/AutoMerge.jl/src/TagBot/TagBot.jl
+++ b/AutoMerge.jl/src/TagBot/TagBot.jl
@@ -8,6 +8,12 @@ using SHA: sha1
 using GitHub: GitHub
 using JSON: JSON
 
+if VERSION >= v"1.11.0-DEV.469"
+    eval(Meta.parse("""
+    public main
+    """))
+end
+
 const GH = GitHub
 
 const AUTH = Ref{GH.OAuth2}()

--- a/AutoMerge.jl/src/public.jl
+++ b/AutoMerge.jl/src/public.jl
@@ -16,32 +16,15 @@ Any field from `AutoMergeConfiguration` can be overridden via keyword arguments.
 
 # Example
 
-Here is an example of how `General` registry is configured
+Here is an example of how `General` registry is configured:
 
 ```julia
 using AutoMerge
-using Dates
 
-AutoMerge.run(
-    merge_new_packages = ENV["MERGE_NEW_PACKAGES"] == "true",
-    merge_new_versions = ENV["MERGE_NEW_VERSIONS"] == "true",
-    new_package_waiting_period = Day(3),
-    new_jll_package_waiting_period = Minute(20),
-    new_version_waiting_period = Minute(10),
-    new_jll_version_waiting_period = Minute(10),
-    registry = "JuliaLang/General",
-    tagbot_enabled = true,
-    authorized_authors = String["JuliaRegistrator"],
-    authorized_authors_special_jll_exceptions = String["jlbuild"],
-    suggest_onepointzero = false,
-    point_to_slack = false,
-    additional_statuses = String[],
-    additional_check_runs = String[],
-    check_license = true,
-    check_breaking_explanation = true,
-    public_registries = String["https://github.com/HolyLab/HolyLabRegistry"],
-)
+AutoMerge.run(AutoMerge.GENERAL_AUTOMERGE_CONFIG)
 ```
+
+See [`AutoMerge.GENERAL_AUTOMERGE_CONFIG`](@ref) for the specific values used by General.
 """
 function run(
     config::AutoMergeConfiguration,

--- a/AutoMerge.jl/src/public.jl
+++ b/AutoMerge.jl/src/public.jl
@@ -1,43 +1,18 @@
 """
-    run([env, cicfg::CIService]; kwargs...)
+    run(config::AutoMergeConfiguration, env=ENV, cicfg::CIService=auto_detect_ci_service(; env=env); config_overrides...)
 
 Run the `AutoMerge` service.
 
 # Arguments
 
+- `config`: AutoMergeConfiguration struct containing all configuration options
 - `env`: an `AbstractDictionary` used to read environmental variables from.
    Defaults to `ENV` but a plain `Dict` can be passed to mimic an alternate environment.
-- `ciccfg`: Configuration struct describing the continuous integration (CI) environment in which AutoMerge is being run.
+- `cicfg`: Configuration struct describing the continuous integration (CI) environment in which AutoMerge is being run.
 
 # Keyword Arguments
 
-- `merge_new_packages`: should AutoMerge merge registration PRs for new packages
-- `merge_new_versions`: should AutoMerge merge registration PRs for new versions of packages
-- `new_package_waiting_period`: new package waiting period, e.g `Day(3)`.
-- `new_jll_package_waiting_period`: new JLL package waiting period, e.g `Minute(20)`.
-- `new_version_waiting_period`: new package version waiting period, e.g `Minute(10)`.
-- `new_jll_version_waiting_period`: new JLL package version waiting period, e.g `Minute(10)`.
-- `registry`: the registry name you want to run AutoMerge on.
-- `tagbot_enabled`: if tagbot is enabled.
-- `authorized_authors`: list of who can submit registration, e.g `String["JuliaRegistrator"]`.
-- `authorized_authors_special_jll_exceptions`: a list of users who can submit JLL packages (which have strict rules about allowed dependencies and are subject to `new_jll_*_waiting_period`s instead of `new_*_waiting_period`s).
-- `additional_statuses`: list of additional commit statuses that must pass before AutoMerge will merge a PR
-- `additional_check_runs`: list of additional check runs that must pass before AutoMerge will merge a PR
-- `error_exit_if_automerge_not_applicable`: if `false`, AutoMerge will not error on PRs made by non-AutoMerge-authorized users
-- `master_branch`: name of `master_branch`, e.g you may want to specify this to `"main"` for new GitHub repositories.
-- `master_branch_is_default_branch`: if `master_branch` specified above is the default branch.
-- `suggest_onepointzero`: should the AutoMerge comment include a suggestion to tag a 1.0 release for v0.x.y packages.
-- `point_to_slack`: should the AutoMerge comment recommend sending a message to the `#pkg-registration` Julia-Slack channel when auto-merging is not possible.
-- `registry_deps`: list of registry dependencies, e.g your packages may depend on `General`.
-- `api_url`: the registry host API URL, default is `"https://api.github.com"`.
-- `check_license`: check package has a valid license, default is `false`.
-- `check_breaking_explanation`: Check whether the PR has release notes (collected via Registrator.jl) with a breaking change explanation, default is `false`.
-- `public_registries`: If a new package registration has a UUID that matches
-   that of a package already registered in one of these registries supplied here
-   (and has either a different name or different URL) then an error will be thrown.
-   This to prevent AutoMerge from being used for "dependency confusion"
-   attacks on those registries.
-- `read_only`: run in read only mode, default is `false`.
+Any field from `AutoMergeConfiguration` can be overridden via keyword arguments. See the documentation for [`AutoMergeConfiguration`](@ref) for details on available fields.
 
 # Example
 
@@ -68,70 +43,41 @@ AutoMerge.run(
 )
 ```
 """
-function run(;
+function run(
+    config::AutoMergeConfiguration,
     env=ENV,
-    cicfg::CIService=auto_detect_ci_service(; env=env),
-    merge_new_packages::Bool,
-    merge_new_versions::Bool,
-    new_package_waiting_period,
-    new_jll_package_waiting_period,
-    new_version_waiting_period,
-    new_jll_version_waiting_period,
-    registry::String,
-    #
-    tagbot_enabled::Bool=false,
-    #
-    authorized_authors::Vector{String},
-    authorized_authors_special_jll_exceptions::Vector{String},
-    #
-    additional_statuses::AbstractVector{<:AbstractString}=String[],
-    additional_check_runs::AbstractVector{<:AbstractString}=String[],
-    #
-    error_exit_if_automerge_not_applicable::Bool=false,
-    #
-    master_branch::String="master",
-    master_branch_is_default_branch::Bool=true,
-    suggest_onepointzero::Bool=true,
-    point_to_slack::Bool=false,
-    #
-    registry_deps::Vector{<:AbstractString}=String[],
-    api_url::String="https://api.github.com",
-    check_license::Bool=false,
-    check_breaking_explanation::Bool=false,
-    # A list of public Julia registries (repository URLs)
-    # which will be checked for UUID collisions in order to
-    # mitigate the dependency confusion vulnerability. See
-    # the `dependency_confusion.jl` file for details.
-    public_registries::Vector{<:AbstractString}=String[],
-    read_only::Bool=false,
-    environment_variables_to_pass::Vector{<:AbstractString}=String[],
+    cicfg::CIService=auto_detect_ci_service(; env=env);
+    config_overrides...
 )::Nothing
-    all_statuses = deepcopy(additional_statuses)
-    all_check_runs = deepcopy(additional_check_runs)
+    # Apply configuration overrides
+    config = AutoMergeConfiguration(; ((k => getproperty(config, k)) for k in propertynames(config))..., config_overrides...)
+
+    all_statuses = deepcopy(config.additional_statuses)
+    all_check_runs = deepcopy(config.additional_check_runs)
     push!(all_statuses, "automerge/decision")
     unique!(all_statuses)
     unique!(all_check_runs)
-    api = GitHub.GitHubWebAPI(HTTP.URI(api_url))
+    api = GitHub.GitHubWebAPI(HTTP.URI(config.api_url))
 
     registry_head = directory_of_cloned_registry(cicfg; env=env)
 
     # Figure out what type of build this is
-    run_pr_build = conditions_met_for_pr_build(cicfg; env=env, master_branch=master_branch)
+    run_pr_build = conditions_met_for_pr_build(cicfg; env=env, config.master_branch)
     run_merge_build = conditions_met_for_merge_build(
-        cicfg; env=env, master_branch=master_branch
+        cicfg; env=env, config.master_branch
     )
 
     if !(run_pr_build || run_merge_build)
         throw_not_automerge_applicable(
             AutoMergeWrongBuildType,
             "Build not determined to be either a PR build or a merge build. Exiting.";
-            error_exit_if_automerge_not_applicable=error_exit_if_automerge_not_applicable,
+            config.error_exit_if_automerge_not_applicable,
         )
         return nothing
     end
 
     # Authentication
-    key = if run_pr_build || !tagbot_enabled
+    key = if run_pr_build || !config.tagbot_enabled
         "AUTOMERGE_GITHUB_TOKEN"
     else
         "AUTOMERGE_TAGBOT_TOKEN"
@@ -139,7 +85,7 @@ function run(;
     auth = my_retry(() -> GitHub.authenticate(api, env[key]))
     whoami = my_retry(() -> username(api, cicfg; auth=auth))
     @info("Authenticated to GitHub as \"$(whoami)\"")
-    registry_repo = my_retry(() -> GitHub.repo(api, registry; auth=auth))
+    registry_repo = my_retry(() -> GitHub.repo(api, config.registry; auth=auth))
 
     if run_pr_build
         pr_number = pull_request_number(cicfg; env=env)
@@ -151,21 +97,21 @@ function run(;
             registry_repo,
             registry_head;
             auth=auth,
-            authorized_authors=authorized_authors,
-            authorized_authors_special_jll_exceptions=authorized_authors_special_jll_exceptions,
-            error_exit_if_automerge_not_applicable=error_exit_if_automerge_not_applicable,
-            master_branch=master_branch,
-            master_branch_is_default_branch=master_branch_is_default_branch,
-            suggest_onepointzero=suggest_onepointzero,
-            point_to_slack=point_to_slack,
+            config.authorized_authors,
+            config.authorized_authors_special_jll_exceptions,
+            config.error_exit_if_automerge_not_applicable,
+            config.master_branch,
+            config.master_branch_is_default_branch,
+            config.suggest_onepointzero,
+            config.point_to_slack,
             whoami=whoami,
-            registry_deps=registry_deps,
-            check_license=check_license,
-            check_breaking_explanation=check_breaking_explanation,
-            public_registries=public_registries,
-            read_only=read_only,
-            environment_variables_to_pass=environment_variables_to_pass,
-            new_package_waiting_period=new_package_waiting_period,
+            config.registry_deps,
+            config.check_license,
+            config.check_breaking_explanation,
+            config.public_registries,
+            config.read_only,
+            config.environment_variables_to_pass,
+            config.new_package_waiting_period,
         )
     else
         always_assert(run_merge_build)
@@ -173,18 +119,18 @@ function run(;
             api,
             registry_repo;
             auth=auth,
-            authorized_authors=authorized_authors,
-            authorized_authors_special_jll_exceptions=authorized_authors_special_jll_exceptions,
-            merge_new_packages=merge_new_packages,
-            merge_new_versions=merge_new_versions,
-            new_package_waiting_period=new_package_waiting_period,
-            new_jll_package_waiting_period=new_jll_package_waiting_period,
-            new_version_waiting_period=new_version_waiting_period,
-            new_jll_version_waiting_period=new_jll_version_waiting_period,
+            config.authorized_authors,
+            config.authorized_authors_special_jll_exceptions,
+            config.merge_new_packages,
+            config.merge_new_versions,
+            config.new_package_waiting_period,
+            config.new_jll_package_waiting_period,
+            config.new_version_waiting_period,
+            config.new_jll_version_waiting_period,
             whoami=whoami,
             all_statuses=all_statuses,
             all_check_runs=all_check_runs,
-            read_only=read_only,
+            config.read_only,
         )
     end
     return nothing

--- a/AutoMerge.jl/src/types.jl
+++ b/AutoMerge.jl/src/types.jl
@@ -111,6 +111,27 @@ const GENERAL_AUTOMERGE_CONFIG = AutoMergeConfiguration(
     check_breaking_explanation = true,
 )
 
+
+@doc """
+    AutoMerge.GENERAL_AUTOMERGE_CONFIG
+
+This is the [`AutoMergeConfiguration`](@ref) object intended for use by the
+[General registry](https://github.com/JuliaRegistries/General).
+General uses the `AutoMerge.GENERAL_AUTOMERGE_CONFIG` from the latest released version of
+AutoMerge.jl (once its manifest has been updated).
+
+!!! warning
+    The values of the fields chosen here may change in non-breaking releases
+    of AutoMerge.jl at the discretion of the maintainers of the General registry,
+    in order to configure the registry for the current needs of the community.
+
+Here are the settings chosen for General in this version of AutoMerge.jl:
+```julia
+julia> AutoMerge.GENERAL_AUTOMERGE_CONFIG
+$(sprint(show, MIME"text/plain"(), GENERAL_AUTOMERGE_CONFIG))
+
+```
+""" GENERAL_AUTOMERGE_CONFIG
 struct NewPackage end
 struct NewVersion end
 

--- a/AutoMerge.jl/test/automerge-integration.jl
+++ b/AutoMerge.jl/test/automerge-integration.jl
@@ -241,8 +241,8 @@ hello_world_commit2 = "57b0aec49622faa962c6752d4bc39a62b91fe37c"
                         "TRAVIS_REPO_SLUG" => AUTOMERGE_INTEGRATION_TEST_REPO,
                     ) do
                         sleep(1)
-                        run_thunk =
-                            () -> AutoMerge.run(;
+
+                        config = AutoMerge.AutoMergeConfiguration(;
                                 merge_new_packages=true,
                                 merge_new_versions=true,
                                 new_package_waiting_period=Minute(typemax(Int32)),
@@ -257,8 +257,9 @@ hello_world_commit2 = "57b0aec49622faa962c6752d4bc39a62b91fe37c"
                                 master_branch_is_default_branch=false,
                                 point_to_slack=point_to_slack,
                                 check_license=check_license,
-                                public_registries=public_registries,
-                            )
+                                public_registries=public_registries)
+                        run_thunk =
+                            () -> AutoMerge.run(config)
                         @info "Running integration test for " test_number master_dir feature_dir public_dir title point_to_slack check_license pass commit
                         if pass
                             run_thunk()
@@ -285,8 +286,8 @@ hello_world_commit2 = "57b0aec49622faa962c6752d4bc39a62b91fe37c"
                                 GitHub.delete_comment(repo, blocking_comment; auth=auth, handle_error=false)
                             end
                         end
-                        AutoMerge.run(;
-                            merge_new_packages=true,
+                        config = AutoMerge.AutoMergeConfiguration(;
+                        merge_new_packages=true,
                             merge_new_versions=true,
                             new_package_waiting_period=Minute(typemax(Int32)),
                             new_jll_package_waiting_period=Minute(typemax(Int32)),
@@ -297,10 +298,10 @@ hello_world_commit2 = "57b0aec49622faa962c6752d4bc39a62b91fe37c"
                             authorized_authors_special_jll_exceptions=String[whoami],
                             error_exit_if_automerge_not_applicable=true,
                             master_branch=master,
-                            master_branch_is_default_branch=false,
-                        )
+                            master_branch_is_default_branch=false,)
+                        AutoMerge.run(config)
                         sleep(1)
-                        merge = () -> AutoMerge.run(;
+                        config = AutoMerge.AutoMergeConfiguration(;
                             merge_new_packages=true,
                             merge_new_versions=true,
                             new_package_waiting_period=Minute(0),
@@ -314,6 +315,7 @@ hello_world_commit2 = "57b0aec49622faa962c6752d4bc39a62b91fe37c"
                             master_branch=master,
                             master_branch_is_default_branch=false,
                         )
+                        merge = () -> AutoMerge.run(config)
                         merge()
                         if create_blocking_comment
                             # Check we have the blocked label

--- a/docs/src/guidelines.md
+++ b/docs/src/guidelines.md
@@ -6,7 +6,7 @@ CurrentModule = RegistryCI
 
 These are the guidelines that a pull request must pass in order to be automatically merged.
 
-All of those guidelines are enabled on the General registry.
+All of those guidelines are enabled on the General registry (see [`AutoMerge.GENERAL_AUTOMERGE_CONFIG`](@ref) for the precise configuration of AutoMerge used by General).
 
 For other registries, some of these guidelines can be disabled.
 

--- a/docs/src/private-registries.md
+++ b/docs/src/private-registries.md
@@ -57,27 +57,14 @@ In order to enable automerge support, you will also have to copy the `automerge.
 
 ```julia
 using AutoMerge
+using AutoMerge: AutoMergeConfiguration
 using Dates
-AutoMerge.run(
-    merge_new_packages = ENV["MERGE_NEW_PACKAGES"] == "true",
-    merge_new_versions = ENV["MERGE_NEW_VERSIONS"] == "true",
-    new_package_waiting_period = Day(3),
-    new_jll_package_waiting_period = Minute(20),
-    new_version_waiting_period = Minute(10),
-    new_jll_version_waiting_period = Minute(10),
-    registry = "MyOrg/MyRegistry",
-    tagbot_enabled = true,
-    authorized_authors = String["TrustedUser"],
-    authorized_authors_special_jll_exceptions = String[""],
-    suggest_onepointzero = false,
-    additional_statuses = String[],
-    additional_check_runs = String[],
-    check_license = true,
-    check_breaking_explanation = true,
-    public_registries = String["https://github.com/HolyLab/HolyLabRegistry"],
-)
+config = AutoMergeConfiguration(; config_settings...)
+AutoMerge.run(config)
 ```
-Most importantly, the following should be changed
+where `config_settings` must set all of the required fields from [`AutoMergeConfiguration`](@ref) (and optionally the settings with default values too). One can refer to [`AutoMerge.GENERAL_AUTOMERGE_CONFIG`](@ref) to see the settings that General uses. If one wants to opt-in to following the same rules as General (which may change in non-breaking releases of AutoMerge.jl), one can directly set `config = AutoMerge.GENERAL_AUTOMERGE_CONFIG`, and pass keyword arguments to `run` to override specific values.
+
+Most importantly, the following configuration settings must be updated for your registry:
 ```
 registry = "MyOrg/MyRegistry",
 authorized_authors = String["TrustedUser"],

--- a/docs/src/public.md
+++ b/docs/src/public.md
@@ -18,10 +18,6 @@ CurrentModule = AutoMerge
 
 ```@docs
 AutoMerge.run
-```
-
-```@autodocs
-Modules = [RegistryCI, AutoMerge]
-Public = true
-Private = false
+AutoMerge.AutoMergeConfiguration
+AutoMerge.GENERAL_AUTOMERGE_CONFIG
 ```

--- a/example_github_workflow_files/automerge.yml
+++ b/example_github_workflow_files/automerge.yml
@@ -35,4 +35,4 @@ jobs:
           AUTOMERGE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AUTOMERGE_TAGBOT_TOKEN: ${{ secrets.TAGBOT_TOKEN }}
           JULIA_DEBUG: AutoMerge
-        run: julia --project=.ci/ -e 'using AutoMerge; using Dates; AutoMerge.run(merge_new_packages = true, merge_new_versions = true, new_package_waiting_period = Day(3), new_jll_package_waiting_period = Minute(15), new_version_waiting_period = Minute(15), new_jll_version_waiting_period = Minute(15), registry = "JuliaRegistries/General", tagbot_enabled=true, authorized_authors = String["JuliaRegistrator"], authorized_authors_special_jll_exceptions = String["jlbuild"], suggest_onepointzero = false, additional_statuses = String[], additional_check_runs = String["Travis CI - Pull Request"], check_breaking_explanation = true)'
+        run: julia --project=.ci/ -e 'using AutoMerge; AutoMerge.run(AutoMerge.GENERAL_AUTOMERGE_CONFIG)'


### PR DESCRIPTION
closes #612 

Once we release AutoMerge.jl we can update General to use it, following the examples here.