### PR TITLE
AutoMerge: integration test CI - try to fix pending status checks on PRs

### DIFF
--- a/.github/workflows/ci_integration.yml
+++ b/.github/workflows/ci_integration.yml
@@ -27,25 +27,40 @@ env:
 
 jobs:
   automerge-integration:
-    # We don't actually want to run integration tests on pull requests,
-    # because we want to avoid hitting rate limits.
-    # So, if this is a PR build, mark the integration tests as "skipped".
-    if: github.event_name != 'pull_request'
     name: AutoMerge Integration
     runs-on: ubuntu-latest
     steps:
+      # Fast placeholder so the required check is green on PRs,
+      # while real tests only run in merge_group/push/workflow_dispatch.
+      - name: Placeholder on PR builds
+        if: ${{ github.event_name == 'pull_request' }}
+        run: echo "Integration tests are required but only run from the merge queue or on push/workflow_dispatch."
+
       - uses: actions/checkout@v4
+        if: ${{ github.event_name != 'pull_request' }}
+
       - uses: julia-actions/setup-julia@v2
+        if: ${{ github.event_name != 'pull_request' }}
         with:
           version: '1'
           arch: x64
+
       - uses: julia-actions/cache@v2
+        if: ${{ github.event_name != 'pull_request' }}
+
       - uses: julia-actions/julia-buildpkg@v1
+        if: ${{ github.event_name != 'pull_request' }}
         with:
           project: AutoMerge.jl
+
       - run: git config --global user.email "noreply@example.com"
+        if: ${{ github.event_name != 'pull_request' }}
+
       - run: git config --global user.name "GitHub Actions"
+        if: ${{ github.event_name != 'pull_request' }}
+
       - uses: julia-actions/julia-runtest@v1
+        if: ${{ github.event_name != 'pull_request' }}
         with:
           project: AutoMerge.jl
         env:
@@ -53,10 +68,14 @@ jobs:
           AUTOMERGE_INTEGRATION_TEST_REPO: "bcbi-test/automerge-integration-test-repo"
           BCBI_TEST_USER_GITHUB_TOKEN: ${{ secrets.BCBI_TEST_USER_GITHUB_TOKEN }}
           INTEGRATION_TEST_READ_ONLY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: julia-actions/julia-processcoverage@v1
+        if: ${{ github.event_name != 'pull_request' }}
         with:
           directories: AutoMerge.jl/src
+
       - uses: codecov/codecov-action@v5
+        if: ${{ github.event_name != 'pull_request' }}
         with:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
We have an issue where PRs get stuck because they see the required status check of “integration tests” as pending. We run integration tests only in the merge queue (so post-approval) and they must be a required status check to ensure the merge queue only merges to trunk if they pass. However then once integration tests run on some PR, on the other PRs it shows up as pending so those PRs won’t enter the merge queue since not all required status checks are passing.

We have tried to work around this in the current CI file but are not successful. I asked chatgpt 5 thinking for help, it said:

> your job-level if: makes the required check never report on PRs, so GitHub keeps it in the “expected/pending” state and blocks the PR from entering the merge queue.

and said we should use step-level conditionals instead, as done here.

IIUC this way we will get "passing" integration tests on PRs (allowing them to be admitted into the merge queue) and they will run for-real in the merge queue.