### PR TITLE
AutoMerge: integration tests: relax concurrency group for no-op PR jobs

### DIFF
--- a/.github/workflows/ci_integration.yml
+++ b/.github/workflows/ci_integration.yml
@@ -18,7 +18,10 @@ on:
 permissions: read-all
 
 concurrency:
-  group: integration-tests-global-lock
+  # Use a unique group for our no-op PR runs (so they never contend),
+  # but use a shared lock for merge_group/push/workflow_dispatch which
+  # need exclusive access to the test registry.
+  group: ${{ github.event_name == 'pull_request' && format('integration-tests-noop-{0}', github.run_id) || 'integration-tests-global-lock' }}
   cancel-in-progress: false
 
 env:


### PR DESCRIPTION
followup to #621 - we can't run our no-op PR jobs because they are waiting for the real jobs to finish (which takes an hour!). Here we modify the concurrency group so we only contest the lock when we actually want access to the resource being locked (the test registry).

Similar to #621 I will merge this in order to proceed with testing.