### PR TITLE
Append path separator to depot path

### DIFF
--- a/AutoMerge/src/guidelines.jl
+++ b/AutoMerge/src/guidelines.jl
@@ -1097,7 +1097,9 @@ function _run_pkg_commands(
     # kwarg to the `AutoMerge.run` function.
 
     env = Dict(
-        "JULIA_DEPOT_PATH" => mktempdir(),
+        # Append trailing path separator to `JULIA_DEPOT_PATH` to be able to
+        # load Julia stdlibs from Julia's bundle.
+        "JULIA_DEPOT_PATH" => mktempdir() * (Sys.iswindows() ? ";" : ":"),
         "JULIA_PKG_PRECOMPILE_AUTO" => "0",
         "JULIA_REGISTRYCI_AUTOMERGE" => "true",
         "PYTHON" => "",


### PR DESCRIPTION
The trailing path separator must be retained to be able to load stdlibs from Julia bundle, instead of recompile them all over again: https://docs.julialang.org/en/v1/manual/environment-variables/#JULIA_DEPOT_PATH.