### PR TITLE
add log statement for automerge comment

### DIFF
--- a/AutoMerge/src/automerge_comment.jl
+++ b/AutoMerge/src/automerge_comment.jl
@@ -1,11 +1,15 @@
 function update_automerge_comment!(data::GitHubAutoMergeData, body::AbstractString)::Nothing
-    @info """Creating or updating automerge comment with contents:
-
-    $body"""
     if data.read_only
-        @info "`read_only` mode; skipping updating automerge comment."
+        @info """
+        `read_only` mode; skipping updating automerge comment with contents:
+
+        $body"""
         return nothing
     end
+    @info """
+    Creating or updating automerge comment with contents:
+
+    $body"""
     api = data.api
     repo = data.registry
     pr = data.pr


### PR DESCRIPTION
This way we can see what the comment would be from read-only staging runs, or what the comment was set to from the actions logs (without needing to rely on the edit history in github). 