### PR TITLE
AutoMerge: Require version numbers to be `≥ 0.1.0` (except for Yggdrasil JLLs)

### DIFF
--- a/AutoMerge/src/guidelines.jl
+++ b/AutoMerge/src/guidelines.jl
@@ -830,7 +830,7 @@ const guideline_no_zero_dot_zero_version_number = Guideline(;
 )
 
 function meets_no_zero_dot_zero_version_number(version)
-    meets_this_guideline = version.major != 0
+    meets_this_guideline = version >= "0.1.0"
     if meets_this_guideline
         return true, ""
     else

--- a/AutoMerge/src/guidelines.jl
+++ b/AutoMerge/src/guidelines.jl
@@ -824,27 +824,18 @@ function meets_sequential_version_number(
     return meets_sequential_version_number(_all_versions, new_version)
 end
 
-const guideline_standard_initial_version_number = Guideline(;
-    info="Standard initial version number. Must be one of: `0.0.1`, `0.1.0`, `1.0.0`, or `X.0.0`.",
-    check=data -> meets_standard_initial_version_number(data.version),
+const guideline_no_zero_dot_zero_version_number = Guideline(;
+    info="Version number must not be of the form 0.0.x",
+    check=data -> meets_no_zero_dot_zero_version_number(data.version),
 )
 
-function meets_standard_initial_version_number(version)
-    meets_this_guideline =
-        version == v"0.0.1" ||
-        version == v"0.1.0" ||
-        version == v"1.0.0" ||
-        _is_x_0_0(version)
+function meets_no_zero_dot_zero_version_number(version)
+    meets_this_guideline = version.major != 0
     if meets_this_guideline
         return true, ""
     else
-        return false, "Version number is not 0.0.1, 0.1.0, 1.0.0, or X.0.0"
+        return false, "Version number must not be of the form 0.0.x"
     end
-end
-
-function _is_x_0_0(version::VersionNumber)
-    result = (version.major >= 1) && (version.minor == 0) && (version.patch == 0)
-    return result
 end
 
 const guideline_version_number_no_prerelease = Guideline(;
@@ -1330,6 +1321,7 @@ function get_automerge_guidelines(
         (guideline_repo_url_requirement, true),
         (guideline_version_number_no_prerelease, true),
         (guideline_version_number_no_build, !this_pr_can_use_special_jll_exceptions),
+        (guideline_no_zero_dot_zero_version_number, !this_pr_can_use_special_jll_exceptions),
         (guideline_compat_for_julia, true),
         (guideline_compat_for_all_deps, true),
         (guideline_allowed_jll_nonrecursive_dependencies, this_is_jll_package),
@@ -1377,6 +1369,7 @@ function get_automerge_guidelines(
         (guideline_sequential_version_number, !this_pr_can_use_special_jll_exceptions && !package_author_approved),
         (guideline_version_number_no_prerelease, true),
         (guideline_version_number_no_build, !this_pr_can_use_special_jll_exceptions),
+        (guideline_no_zero_dot_zero_version_number, !this_pr_can_use_special_jll_exceptions),
         (guideline_compat_for_julia, true),
         (guideline_compat_for_all_deps, true),
         (

--- a/AutoMerge/src/guidelines.jl
+++ b/AutoMerge/src/guidelines.jl
@@ -825,7 +825,7 @@ function meets_sequential_version_number(
 end
 
 const guideline_no_zero_dot_zero_version_number = Guideline(;
-    info="Version number must not be of the form 0.0.x",
+    info="Version number must be ≥ 0.1.0",
     check=data -> meets_no_zero_dot_zero_version_number(data.version),
 )
 
@@ -834,7 +834,7 @@ function meets_no_zero_dot_zero_version_number(version)
     if meets_this_guideline
         return true, ""
     else
-        return false, "Version number must not be of the form 0.0.x"
+        return false, "Version number must be ≥ 0.1.0"
     end
 end
 

--- a/AutoMerge/src/guidelines.jl
+++ b/AutoMerge/src/guidelines.jl
@@ -830,7 +830,7 @@ const guideline_no_zero_dot_zero_version_number = Guideline(;
 )
 
 function meets_no_zero_dot_zero_version_number(version)
-    meets_this_guideline = version >= "0.1.0"
+    meets_this_guideline = version >= v"0.1.0"
     if meets_this_guideline
         return true, ""
     else

--- a/AutoMerge/test/automerge-unit.jl
+++ b/AutoMerge/test/automerge-unit.jl
@@ -400,23 +400,26 @@ end
         names = [x.name for x in name_uuids]
         @test issorted(names)
     end
-    @testset "Standard initial version number" begin
-        @test !AutoMerge.meets_standard_initial_version_number(v"0.0.1")[1]
-        @test AutoMerge.meets_standard_initial_version_number(v"0.1.0")[1]
-        @test AutoMerge.meets_standard_initial_version_number(v"1.0.0")[1]
-        @test !AutoMerge.meets_standard_initial_version_number(v"0.0.2")[1]
-        @test !AutoMerge.meets_standard_initial_version_number(v"0.1.1")[1]
-        @test !AutoMerge.meets_standard_initial_version_number(v"0.2.0")[1]
-        @test !AutoMerge.meets_standard_initial_version_number(v"1.0.1")[1]
-        @test !AutoMerge.meets_standard_initial_version_number(v"1.1.0")[1]
-        @test !AutoMerge.meets_standard_initial_version_number(v"1.1.1")[1]
-        @test AutoMerge.meets_standard_initial_version_number(v"2.0.0")[1]
-        @test !AutoMerge.meets_standard_initial_version_number(v"2.0.1")[1]
-        @test !AutoMerge.meets_standard_initial_version_number(v"2.1.0")[1]
-        @test !AutoMerge.meets_standard_initial_version_number(v"2.1.1")[1]
-        @test AutoMerge.meets_standard_initial_version_number(v"3.0.0")[1]
-        @test !AutoMerge.meets_standard_initial_version_number(v"3.0.1")[1]
-        @test !AutoMerge.meets_standard_initial_version_number(v"3.1.0")[1]
+    @testset "Version number must be ≥ 0.1.0" begin
+        @test !AutoMerge.meets_no_zero_dot_zero_version_number(v"0.0.0")[1]
+        @test !AutoMerge.meets_no_zero_dot_zero_version_number(v"0.0.1")[1]
+        @test !AutoMerge.meets_no_zero_dot_zero_version_number(v"0.0.2")[1]
+        @test !AutoMerge.meets_no_zero_dot_zero_version_number(v"0.0.3")[1]
+        @test AutoMerge.meets_no_zero_dot_zero_version_number(v"0.1.0")[1]
+        @test AutoMerge.meets_no_zero_dot_zero_version_number(v"1.0.0")[1]
+        @test !AutoMerge.meets_no_zero_dot_zero_version_number(v"0.0.2")[1]
+        @test AutoMerge.meets_no_zero_dot_zero_version_number(v"0.1.1")[1]
+        @test AutoMerge.meets_no_zero_dot_zero_version_number(v"0.2.0")[1]
+        @test AutoMerge.meets_no_zero_dot_zero_version_number(v"1.0.1")[1]
+        @test AutoMerge.meets_no_zero_dot_zero_version_number(v"1.1.0")[1]
+        @test AutoMerge.meets_no_zero_dot_zero_version_number(v"1.1.1")[1]
+        @test AutoMerge.meets_no_zero_dot_zero_version_number(v"2.0.0")[1]
+        @test AutoMerge.meets_no_zero_dot_zero_version_number(v"2.0.1")[1]
+        @test AutoMerge.meets_no_zero_dot_zero_version_number(v"2.1.0")[1]
+        @test AutoMerge.meets_no_zero_dot_zero_version_number(v"2.1.1")[1]
+        @test AutoMerge.meets_no_zero_dot_zero_version_number(v"3.0.0")[1]
+        @test AutoMerge.meets_no_zero_dot_zero_version_number(v"3.0.1")[1]
+        @test AutoMerge.meets_no_zero_dot_zero_version_number(v"3.1.0")[1]
     end
     @testset "Repo URL ends with /name.jl.git where name is the package name" begin
         @test AutoMerge.url_has_correct_ending(

--- a/AutoMerge/test/automerge-unit.jl
+++ b/AutoMerge/test/automerge-unit.jl
@@ -401,7 +401,7 @@ end
         @test issorted(names)
     end
     @testset "Standard initial version number" begin
-        @test AutoMerge.meets_standard_initial_version_number(v"0.0.1")[1]
+        @test !AutoMerge.meets_standard_initial_version_number(v"0.0.1")[1]
         @test AutoMerge.meets_standard_initial_version_number(v"0.1.0")[1]
         @test AutoMerge.meets_standard_initial_version_number(v"1.0.0")[1]
         @test !AutoMerge.meets_standard_initial_version_number(v"0.0.2")[1]


### PR DESCRIPTION
Continue to accept `0.1.0`, `1.0.0`, and `X.0.0`