### PR TITLE
Explain that auto-merge runs periodically.

### DIFF
--- a/AutoMerge/src/util.jl
+++ b/AutoMerge/src/util.jl
@@ -396,7 +396,9 @@ function _comment_noblock(n)
         "auto-merging, you must include the text ",
         "`[noblock]` in your comment.",
         "\n\n_Tip: You can edit blocking comments to add `[noblock]` ",
-        "in order to unblock auto-merging._\n\n",
+        "in order to unblock auto-merging. Auto-merge runs periodically. ",
+        "After unblocking a comment you may have to wait up to 15 minutes._",
+        "\n\n",
     )
     return result
 end

--- a/AutoMerge/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_0.1.0_point_to_slack_false.md
+++ b/AutoMerge/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_0.1.0_point_to_slack_false.md
@@ -86,6 +86,6 @@ If you need help fixing the AutoMerge issues, or want your pull request to be ma
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment.
 
-_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging. Auto-merge runs periodically. After unblocking a comment you may have to wait up to 15 minutes._
 
 <!-- [noblock] -->

--- a/AutoMerge/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_0.1.0_point_to_slack_true.md
+++ b/AutoMerge/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_0.1.0_point_to_slack_true.md
@@ -86,6 +86,6 @@ If you need help fixing the AutoMerge issues, or want your pull request to be ma
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment.
 
-_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging. Auto-merge runs periodically. After unblocking a comment you may have to wait up to 15 minutes._
 
 <!-- [noblock] -->

--- a/AutoMerge/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_1.0.0_point_to_slack_false.md
+++ b/AutoMerge/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_1.0.0_point_to_slack_false.md
@@ -86,6 +86,6 @@ If you need help fixing the AutoMerge issues, or want your pull request to be ma
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment.
 
-_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging. Auto-merge runs periodically. After unblocking a comment you may have to wait up to 15 minutes._
 
 <!-- [noblock] -->

--- a/AutoMerge/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_1.0.0_point_to_slack_true.md
+++ b/AutoMerge/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_1.0.0_point_to_slack_true.md
@@ -86,6 +86,6 @@ If you need help fixing the AutoMerge issues, or want your pull request to be ma
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment.
 
-_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging. Auto-merge runs periodically. After unblocking a comment you may have to wait up to 15 minutes._
 
 <!-- [noblock] -->

--- a/AutoMerge/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_0.1.0_point_to_slack_false.md
+++ b/AutoMerge/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_0.1.0_point_to_slack_false.md
@@ -94,6 +94,6 @@ If your package does not yet have a stable public API, then of course you are no
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment.
 
-_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging. Auto-merge runs periodically. After unblocking a comment you may have to wait up to 15 minutes._
 
 <!-- [noblock] -->

--- a/AutoMerge/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_0.1.0_point_to_slack_true.md
+++ b/AutoMerge/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_0.1.0_point_to_slack_true.md
@@ -94,6 +94,6 @@ If your package does not yet have a stable public API, then of course you are no
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment.
 
-_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging. Auto-merge runs periodically. After unblocking a comment you may have to wait up to 15 minutes._
 
 <!-- [noblock] -->

--- a/AutoMerge/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_1.0.0_point_to_slack_false.md
+++ b/AutoMerge/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_1.0.0_point_to_slack_false.md
@@ -86,6 +86,6 @@ If you need help fixing the AutoMerge issues, or want your pull request to be ma
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment.
 
-_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging. Auto-merge runs periodically. After unblocking a comment you may have to wait up to 15 minutes._
 
 <!-- [noblock] -->

--- a/AutoMerge/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_1.0.0_point_to_slack_true.md
+++ b/AutoMerge/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_1.0.0_point_to_slack_true.md
@@ -86,6 +86,6 @@ If you need help fixing the AutoMerge issues, or want your pull request to be ma
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment.
 
-_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging. Auto-merge runs periodically. After unblocking a comment you may have to wait up to 15 minutes._
 
 <!-- [noblock] -->

--- a/AutoMerge/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_0.1.0_point_to_slack_false.md
+++ b/AutoMerge/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_0.1.0_point_to_slack_false.md
@@ -82,6 +82,6 @@ If you need help fixing the AutoMerge issues, or want your pull request to be ma
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment.
 
-_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging. Auto-merge runs periodically. After unblocking a comment you may have to wait up to 15 minutes._
 
 <!-- [noblock] -->

--- a/AutoMerge/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_0.1.0_point_to_slack_true.md
+++ b/AutoMerge/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_0.1.0_point_to_slack_true.md
@@ -82,6 +82,6 @@ If you need help fixing the AutoMerge issues, or want your pull request to be ma
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment.
 
-_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging. Auto-merge runs periodically. After unblocking a comment you may have to wait up to 15 minutes._
 
 <!-- [noblock] -->

--- a/AutoMerge/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_1.0.0_point_to_slack_false.md
+++ b/AutoMerge/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_1.0.0_point_to_slack_false.md
@@ -82,6 +82,6 @@ If you need help fixing the AutoMerge issues, or want your pull request to be ma
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment.
 
-_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging. Auto-merge runs periodically. After unblocking a comment you may have to wait up to 15 minutes._
 
 <!-- [noblock] -->

--- a/AutoMerge/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_1.0.0_point_to_slack_true.md
+++ b/AutoMerge/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_false_version_1.0.0_point_to_slack_true.md
@@ -82,6 +82,6 @@ If you need help fixing the AutoMerge issues, or want your pull request to be ma
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment.
 
-_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging. Auto-merge runs periodically. After unblocking a comment you may have to wait up to 15 minutes._
 
 <!-- [noblock] -->

--- a/AutoMerge/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_0.1.0_point_to_slack_false.md
+++ b/AutoMerge/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_0.1.0_point_to_slack_false.md
@@ -90,6 +90,6 @@ If your package does not yet have a stable public API, then of course you are no
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment.
 
-_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging. Auto-merge runs periodically. After unblocking a comment you may have to wait up to 15 minutes._
 
 <!-- [noblock] -->

--- a/AutoMerge/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_0.1.0_point_to_slack_true.md
+++ b/AutoMerge/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_0.1.0_point_to_slack_true.md
@@ -90,6 +90,6 @@ If your package does not yet have a stable public API, then of course you are no
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment.
 
-_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging. Auto-merge runs periodically. After unblocking a comment you may have to wait up to 15 minutes._
 
 <!-- [noblock] -->

--- a/AutoMerge/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_1.0.0_point_to_slack_false.md
+++ b/AutoMerge/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_1.0.0_point_to_slack_false.md
@@ -82,6 +82,6 @@ If you need help fixing the AutoMerge issues, or want your pull request to be ma
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment.
 
-_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging. Auto-merge runs periodically. After unblocking a comment you may have to wait up to 15 minutes._
 
 <!-- [noblock] -->

--- a/AutoMerge/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_1.0.0_point_to_slack_true.md
+++ b/AutoMerge/test/reference_comments/comment_pass_false_type_new_version_suggest_onepointzero_true_version_1.0.0_point_to_slack_true.md
@@ -82,6 +82,6 @@ If you need help fixing the AutoMerge issues, or want your pull request to be ma
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment.
 
-_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging. Auto-merge runs periodically. After unblocking a comment you may have to wait up to 15 minutes._
 
 <!-- [noblock] -->

--- a/AutoMerge/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_0.1.0_is_jll_false.md
+++ b/AutoMerge/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_0.1.0_is_jll_false.md
@@ -12,6 +12,6 @@ Your new package registration met all of the guidelines for auto-merging and is 
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment.
 
-_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging. Auto-merge runs periodically. After unblocking a comment you may have to wait up to 15 minutes._
 
 <!-- [noblock] -->

--- a/AutoMerge/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_0.1.0_is_jll_true.md
+++ b/AutoMerge/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_0.1.0_is_jll_true.md
@@ -8,6 +8,6 @@ Your new `_jll` package registration met all of the guidelines for auto-merging 
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment.
 
-_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging. Auto-merge runs periodically. After unblocking a comment you may have to wait up to 15 minutes._
 
 <!-- [noblock] -->

--- a/AutoMerge/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_1.0.0_is_jll_false.md
+++ b/AutoMerge/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_1.0.0_is_jll_false.md
@@ -12,6 +12,6 @@ Your new package registration met all of the guidelines for auto-merging and is 
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment.
 
-_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging. Auto-merge runs periodically. After unblocking a comment you may have to wait up to 15 minutes._
 
 <!-- [noblock] -->

--- a/AutoMerge/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_1.0.0_is_jll_true.md
+++ b/AutoMerge/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_1.0.0_is_jll_true.md
@@ -8,6 +8,6 @@ Your new `_jll` package registration met all of the guidelines for auto-merging 
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment.
 
-_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging. Auto-merge runs periodically. After unblocking a comment you may have to wait up to 15 minutes._
 
 <!-- [noblock] -->

--- a/AutoMerge/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_0.1.0_is_jll_false.md
+++ b/AutoMerge/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_0.1.0_is_jll_false.md
@@ -20,6 +20,6 @@ If your package does not yet have a stable public API, then of course you are no
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment.
 
-_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging. Auto-merge runs periodically. After unblocking a comment you may have to wait up to 15 minutes._
 
 <!-- [noblock] -->

--- a/AutoMerge/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_0.1.0_is_jll_true.md
+++ b/AutoMerge/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_0.1.0_is_jll_true.md
@@ -16,6 +16,6 @@ If your package does not yet have a stable public API, then of course you are no
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment.
 
-_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging. Auto-merge runs periodically. After unblocking a comment you may have to wait up to 15 minutes._
 
 <!-- [noblock] -->

--- a/AutoMerge/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_1.0.0_is_jll_false.md
+++ b/AutoMerge/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_1.0.0_is_jll_false.md
@@ -12,6 +12,6 @@ Your new package registration met all of the guidelines for auto-merging and is 
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment.
 
-_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging. Auto-merge runs periodically. After unblocking a comment you may have to wait up to 15 minutes._
 
 <!-- [noblock] -->

--- a/AutoMerge/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_1.0.0_is_jll_true.md
+++ b/AutoMerge/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_1.0.0_is_jll_true.md
@@ -8,6 +8,6 @@ Your new `_jll` package registration met all of the guidelines for auto-merging 
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment.
 
-_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging. Auto-merge runs periodically. After unblocking a comment you may have to wait up to 15 minutes._
 
 <!-- [noblock] -->

--- a/AutoMerge/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_0.1.0_is_jll_false.md
+++ b/AutoMerge/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_0.1.0_is_jll_false.md
@@ -19,6 +19,6 @@ Code changes from v1.0.0:
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment.
 
-_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging. Auto-merge runs periodically. After unblocking a comment you may have to wait up to 15 minutes._
 
 <!-- [noblock] -->

--- a/AutoMerge/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_0.1.0_is_jll_true.md
+++ b/AutoMerge/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_0.1.0_is_jll_true.md
@@ -19,6 +19,6 @@ Code changes from v1.0.0:
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment.
 
-_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging. Auto-merge runs periodically. After unblocking a comment you may have to wait up to 15 minutes._
 
 <!-- [noblock] -->

--- a/AutoMerge/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_1.0.0_is_jll_false.md
+++ b/AutoMerge/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_1.0.0_is_jll_false.md
@@ -19,6 +19,6 @@ Code changes from v1.0.0:
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment.
 
-_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging. Auto-merge runs periodically. After unblocking a comment you may have to wait up to 15 minutes._
 
 <!-- [noblock] -->

--- a/AutoMerge/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_1.0.0_is_jll_true.md
+++ b/AutoMerge/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_false_version_1.0.0_is_jll_true.md
@@ -19,6 +19,6 @@ Code changes from v1.0.0:
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment.
 
-_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging. Auto-merge runs periodically. After unblocking a comment you may have to wait up to 15 minutes._
 
 <!-- [noblock] -->

--- a/AutoMerge/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_0.1.0_is_jll_false.md
+++ b/AutoMerge/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_0.1.0_is_jll_false.md
@@ -27,6 +27,6 @@ If your package does not yet have a stable public API, then of course you are no
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment.
 
-_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging. Auto-merge runs periodically. After unblocking a comment you may have to wait up to 15 minutes._
 
 <!-- [noblock] -->

--- a/AutoMerge/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_0.1.0_is_jll_true.md
+++ b/AutoMerge/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_0.1.0_is_jll_true.md
@@ -27,6 +27,6 @@ If your package does not yet have a stable public API, then of course you are no
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment.
 
-_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging. Auto-merge runs periodically. After unblocking a comment you may have to wait up to 15 minutes._
 
 <!-- [noblock] -->

--- a/AutoMerge/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_1.0.0_is_jll_false.md
+++ b/AutoMerge/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_1.0.0_is_jll_false.md
@@ -19,6 +19,6 @@ Code changes from v1.0.0:
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment.
 
-_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging. Auto-merge runs periodically. After unblocking a comment you may have to wait up to 15 minutes._
 
 <!-- [noblock] -->

--- a/AutoMerge/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_1.0.0_is_jll_true.md
+++ b/AutoMerge/test/reference_comments/comment_pass_true_type_new_version_suggest_onepointzero_true_version_1.0.0_is_jll_true.md
@@ -19,6 +19,6 @@ Code changes from v1.0.0:
 
 If you want to prevent this pull request from being auto-merged, simply leave a comment. If you want to post a comment without blocking auto-merging, you must include the text `[noblock]` in your comment.
 
-_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging._
+_Tip: You can edit blocking comments to add `[noblock]` in order to unblock auto-merging. Auto-merge runs periodically. After unblocking a comment you may have to wait up to 15 minutes._
 
 <!-- [noblock] -->


### PR DESCRIPTION
People were expressing some confusion on Slack.

>> The comment says
>> 
>>> Tip: You can edit blocking comments to add [noblock] in order to unblock auto-merging.
>>
>> So try that first
>
> Something I didn't initially get was that auto merge retries.. I thought I had lost the one chance. The tip is good but it might help to spell that out

The wording here, “Auto-merge runs periodically. After unblocking a comment you may have to wait up to 15 minutes” was suggested in that thread.