### PR TITLE
AutoMerge: Guard AutoMerge diff-stats against missing git tree objects

### DIFF
--- a/AutoMerge/src/util.jl
+++ b/AutoMerge/src/util.jl
@@ -165,10 +165,28 @@ function format_diff_stats(full_diff::AbstractString, stat::AbstractString, shor
 end
 
 function get_diff_stats(old_tree_sha::AbstractString, new_tree_sha::AbstractString; clone_dir::AbstractString)
+    old_tree_exists = tree_object_exists(old_tree_sha; clone_dir)
+    new_tree_exists = tree_object_exists(new_tree_sha; clone_dir)
+    if !(old_tree_exists && new_tree_exists)
+        old_tree_status = old_tree_exists ? "present" : "missing"
+        new_tree_status = new_tree_exists ? "present" : "missing"
+        missing = String[]
+        old_tree_exists || push!(missing, "old_tree_sha=$old_tree_sha")
+        new_tree_exists || push!(missing, "new_tree_sha=$new_tree_sha")
+        error(
+            "Could not compute version diff stats because tree object(s) are missing in package repo clone: " *
+            "old_tree_sha=$old_tree_status, new_tree_sha=$new_tree_status. Missing SHA(s): $(join(missing, ", ")). " *
+            "This can happen if package history or tags were rewritten after an earlier registration."
+        )
+    end
     full_diff = readchomp(`git -C $clone_dir diff-tree --patch $old_tree_sha $new_tree_sha --no-color`)
     stat = readchomp(`git -C $clone_dir diff-tree --stat $old_tree_sha $new_tree_sha --stat-width=80 --no-color`)
     shortstat = readchomp(`git -C $clone_dir diff-tree --shortstat $old_tree_sha $new_tree_sha --no-color`)
     return format_diff_stats(full_diff, stat, shortstat; old_tree_sha, new_tree_sha)
+end
+
+function tree_object_exists(tree_sha::AbstractString; clone_dir::AbstractString)
+    return success(pipeline(`git -C $clone_dir cat-file -e $("$tree_sha^{tree}")`; stderr=devnull))
 end
 
 """

--- a/AutoMerge/test/automerge-unit.jl
+++ b/AutoMerge/test/automerge-unit.jl
@@ -246,6 +246,33 @@ end
             end
         end
     end
+
+    @testset "`AutoMerge.get_diff_stats` reports missing tree objects clearly" begin
+        mktempdir() do repo_dir
+            run(`git -C $repo_dir init`)
+            run(`git -C $repo_dir config user.name RegistryCITest`)
+            run(`git -C $repo_dir config user.email registryci@example.com`)
+            write(joinpath(repo_dir, "Project.toml"), "name = \"Example\"\n")
+            run(`git -C $repo_dir add Project.toml`)
+            run(`git -C $repo_dir commit -m init`)
+
+            old_tree_sha = readchomp(`git -C $repo_dir rev-parse $("HEAD^{tree}")`)
+            new_tree_sha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+            err = try
+                AutoMerge.get_diff_stats(old_tree_sha, new_tree_sha; clone_dir=repo_dir)
+                nothing
+            catch caught
+                caught
+            end
+
+            @test err isa ErrorException
+            @test occursin("Could not compute version diff stats because tree object(s) are missing", err.msg)
+            @test occursin("old_tree_sha=present", err.msg)
+            @test occursin("new_tree_sha=missing", err.msg)
+            @test occursin("new_tree_sha=$new_tree_sha", err.msg)
+        end
+    end
 end
 
 @testset "juliaup" begin


### PR DESCRIPTION
Fixes #655.

## Summary

- verify both tree objects exist in the package clone before running any `git diff-tree` command
- raise a targeted error that reports whether `old_tree_sha` and `new_tree_sha` are present or missing
- add a focused unit test covering the missing-tree-object failure path

## Testing

- `AUTOMERGE_RUN_INTEGRATION_TESTS=false julia --project=AutoMerge -e 'using Pkg; Pkg.test()'`
  - reaches the existing unrelated `Version can be added` / `Version can be imported` failures caused by the local `juliaup` environment, after the new diff-stats test path passes

cc @DilumAluthge

🤖 Generated by Codex.
