### PR TITLE
Tests: handle packed General registries in local Pkg.test

### DIFF
--- a/AutoMerge/test/runtests.jl
+++ b/AutoMerge/test/runtests.jl
@@ -16,6 +16,26 @@ using UUIDs
 # disable the Pkg server.
 ENV["JULIA_PKG_SERVER"] = ""
 
+function ensure_unpacked_general_registry()
+    registry_dir = joinpath(DEPOT_PATH[1], "registries", "General")
+    registry_toml = joinpath(registry_dir, "Registry.toml")
+    isfile(registry_toml) && return
+
+    packed_registry = joinpath(DEPOT_PATH[1], "registries", "General.toml")
+    if isfile(packed_registry)
+        try
+            Pkg.Registry.rm("General")
+        catch err
+            @info "Ignoring failure while removing packed General registry during test setup" err
+        end
+    end
+
+    Pkg.Registry.add("General")
+    isfile(registry_toml) || error("AutoMerge tests require an unpacked General registry at $registry_dir.")
+end
+
+ensure_unpacked_general_registry()
+
 @static if v"1.6-" <= Base.VERSION < v"1.11-"
     # BrokenRecord fails to precompile on Julia 1.11
     let

--- a/RegistryCI/test/runtests.jl
+++ b/RegistryCI/test/runtests.jl
@@ -16,6 +16,26 @@ using ReferenceTests
 # disable the Pkg server.
 ENV["JULIA_PKG_SERVER"] = ""
 
+function ensure_unpacked_general_registry()
+    registry_dir = joinpath(DEPOT_PATH[1], "registries", "General")
+    registry_toml = joinpath(registry_dir, "Registry.toml")
+    isfile(registry_toml) && return
+
+    packed_registry = joinpath(DEPOT_PATH[1], "registries", "General.toml")
+    if isfile(packed_registry)
+        try
+            Pkg.Registry.rm("General")
+        catch err
+            @info "Ignoring failure while removing packed General registry during test setup" err
+        end
+    end
+
+    Pkg.Registry.add("General")
+    isfile(registry_toml) || error("RegistryCI tests require an unpacked General registry at $registry_dir.")
+end
+
+ensure_unpacked_general_registry()
+
 @testset "RegistryCI.jl" begin
     @info("Running the RegistryCI.jl unit tests")
     include("registryci_registry_testing.jl")


### PR DESCRIPTION
Fixes #645.

## Summary

- teach the `RegistryCI` and `AutoMerge` test entrypoints to detect a packed `General.toml` registry layout
- remove and re-add `General` when needed so the suites have an unpacked `registries/General/Registry.toml` checkout
- keep the behavior scoped to test setup so package runtime code is unchanged

## Testing

- `julia --project=RegistryCI -e 'using Pkg; Pkg.test(test_args=["false"])'`
- `AUTOMERGE_RUN_INTEGRATION_TESTS=false julia --project=AutoMerge -e 'using Pkg; Pkg.test()'`
  - now gets past the packed-registry failure and reaches the existing unrelated `juliaup`-dependent `Version can be added` / `Version can be imported` failures

cc @DilumAluthge

🤖 Generated by Codex.
