### PR TITLE
RegistryCI: handle RegistryTools 2.4 typed round-trip output

### DIFF
--- a/RegistryCI/src/registry_testing.jl
+++ b/RegistryCI/src/registry_testing.jl
@@ -211,7 +211,7 @@ function test(path=pwd(); registry_deps::Vector{<:AbstractString}=String[])
                     compressed = RegistryTools.Compress.compress(
                         depsfile, RegistryTools.Compress.load(depsfile)
                     )
-                    @test _spacify_hyphens(compressed) == _spacify_hyphens(deps)
+                    @test _normalize_deps_roundtrip(compressed, vnums) == _normalize_deps_roundtrip(deps, vnums)
                 else
                     @debug "Deps.toml file does not exist" depsfile
                 end
@@ -257,10 +257,7 @@ function test(path=pwd(); registry_deps::Vector{<:AbstractString}=String[])
                     compressed = RegistryTools.Compress.compress(
                         compatfile, RegistryTools.Compress.load(compatfile)
                     )
-                    mapvalues = (f, dict) -> Dict(k => f(v) for (k, v) in dict)
-                    f_inner = v -> Pkg.Types.VersionRange.(v)
-                    f_outer = dict -> mapvalues(f_inner, dict)
-                    @test _spacify_hyphens(mapvalues(f_outer, compressed)) == _spacify_hyphens(mapvalues(f_outer, compat))
+                    @test _normalize_compat_roundtrip(compressed, vnums) == _normalize_compat_roundtrip(compat, vnums)
                 else
                     @debug "Compat.toml file does not exist" compatfile
                 end
@@ -281,6 +278,36 @@ function test(path=pwd(); registry_deps::Vector{<:AbstractString}=String[])
         end
     end
     return nothing
+end
+
+function _normalize_deps_roundtrip(dict::AbstractDict, versions::AbstractVector{VersionNumber})
+    normalized = Dict{VersionNumber, Dict{String, Base.UUID}}()
+    for (version_range, entries) in pairs(dict)
+        vrange = Pkg.Types.VersionRange(version_range)
+        typed_entries = Dict(
+            name => uuid isa Base.UUID ? uuid : Base.UUID(uuid) for (name, uuid) in pairs(entries)
+        )
+        for version in versions
+            version in vrange || continue
+            normalized[version] = typed_entries
+        end
+    end
+    return normalized
+end
+
+function _normalize_compat_roundtrip(dict::AbstractDict, versions::AbstractVector{VersionNumber})
+    normalized = Dict{VersionNumber, Dict{String, Pkg.Types.VersionSpec}}()
+    for (version_range, entries) in pairs(dict)
+        vrange = Pkg.Types.VersionRange(version_range)
+        typed_entries = Dict(
+            name => spec isa Pkg.Types.VersionSpec ? spec : Pkg.Types.VersionSpec(spec) for (name, spec) in pairs(entries)
+        )
+        for version in versions
+            version in vrange || continue
+            normalized[version] = typed_entries
+        end
+    end
+    return normalized
 end
 
 # Change all occurences of "digit-digit" to "digit - digit"

--- a/RegistryCI/test/registryci_registry_testing.jl
+++ b/RegistryCI/test/registryci_registry_testing.jl
@@ -44,6 +44,58 @@ if test_general
 end
 
 @testset "Synthetic tests" begin
+    @testset "Deps and compat roundtrip with RegistryTools typed values" begin
+        mktempdir() do tmpdir
+            registry_dir = joinpath(tmpdir, "TestRegistry")
+            mkpath(registry_dir)
+
+            write(joinpath(registry_dir, "Registry.toml"), """
+                name = "TestRegistry"
+                uuid = "12345678-1234-5678-9abc-123456789abc"
+                repo = "https://github.com/test/TestRegistry.git"
+
+                [packages]
+                87654321-4321-8765-cba9-987654321cba = { name = "TestPkg", path = "T/TestPkg" }
+                aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee = { name = "OtherPkg", path = "O/OtherPkg" }
+                """)
+
+            pkg_dir = joinpath(registry_dir, "T", "TestPkg")
+            mkpath(pkg_dir)
+            write(joinpath(pkg_dir, "Package.toml"), """
+                name = "TestPkg"
+                uuid = "87654321-4321-8765-cba9-987654321cba"
+                repo = "https://github.com/test/TestPkg.git"
+                """)
+            write(joinpath(pkg_dir, "Versions.toml"), """
+                ["1.0.0"]
+                git-tree-sha1 = "abcdef0123456789abcdef0123456789abcdef01"
+                """)
+            write(joinpath(pkg_dir, "Deps.toml"), """
+                ["1.0.0"]
+                OtherPkg = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+                """)
+            write(joinpath(pkg_dir, "Compat.toml"), """
+                ["1.0.0"]
+                OtherPkg = "1"
+                julia = "1"
+                """)
+
+            other_pkg_dir = joinpath(registry_dir, "O", "OtherPkg")
+            mkpath(other_pkg_dir)
+            write(joinpath(other_pkg_dir, "Package.toml"), """
+                name = "OtherPkg"
+                uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+                repo = "https://github.com/test/OtherPkg.git"
+                """)
+            write(joinpath(other_pkg_dir, "Versions.toml"), """
+                ["1.0.0"]
+                git-tree-sha1 = "0123456789abcdef0123456789abcdef01234567"
+                """)
+
+            @test RegistryCI.test(registry_dir) === nothing
+        end
+    end
+
     @testset "Yanked key validation" begin
         mktempdir() do tmpdir
             registry_dir = joinpath(tmpdir, "TestRegistry")


### PR DESCRIPTION
Fixes #644.

## Summary

- compare `Deps.toml` and `Compat.toml` round-trip content semantically instead of assuming RegistryTools returns only stringly typed values
- normalize compressed data by expanded version coverage, UUID values, and `VersionSpec` values so RegistryTools 2.4.x typed output remains valid
- add a synthetic registry test that exercises both deps and compat round-tripping through RegistryTools

## Testing

- `julia --project=RegistryCI -e 'using Pkg; Pkg.test(test_args=["false"])'`

cc @DilumAluthge

🤖 Generated by Codex.
