### PR TITLE
AutoMerge: reserve Julia module names as separate check

### DIFF
--- a/AutoMerge/src/guidelines.jl
+++ b/AutoMerge/src/guidelines.jl
@@ -301,6 +301,8 @@ const guideline_name_match_check = Guideline(;
     check=data -> meets_name_match_check(data.pkg, data.registry_master))
 
 function meets_name_match_check(pkg_name::AbstractString, registry_master::AbstractString)
+    result = meets_julia_module_name_check(pkg_name, julia_public_module_names())
+    result[1] || return result
     other_packages = get_all_pkg_names(registry_master)
     return meets_name_match_check(pkg_name, other_packages)
 end
@@ -315,6 +317,20 @@ function meets_name_match_check(
             return (false, "Package name already exists in the registry.")
         elseif lowercase(pkg_name) == lowercase(other_pkg)
             return (false, "Package name matches existing package name $(other_pkg) up-to-case.")
+        end
+    end
+    return (true, "")
+end
+
+function meets_julia_module_name_check(
+    pkg_name::AbstractString,
+    module_names::Vector{String},
+)
+    for module_name in module_names
+        if pkg_name == module_name
+            return (false, "Package name matches reserved Julia module name $(module_name).")
+        elseif lowercase(pkg_name) == lowercase(module_name)
+            return (false, "Package name matches reserved Julia module name $(module_name) up-to-case.")
         end
     end
     return (true, "")

--- a/AutoMerge/src/guidelines.jl
+++ b/AutoMerge/src/guidelines.jl
@@ -301,8 +301,6 @@ const guideline_name_match_check = Guideline(;
     check=data -> meets_name_match_check(data.pkg, data.registry_master))
 
 function meets_name_match_check(pkg_name::AbstractString, registry_master::AbstractString)
-    result = meets_julia_module_name_check(pkg_name, julia_public_module_names())
-    result[1] || return result
     other_packages = get_all_pkg_names(registry_master)
     return meets_name_match_check(pkg_name, other_packages)
 end
@@ -321,6 +319,11 @@ function meets_name_match_check(
     end
     return (true, "")
 end
+
+const guideline_julia_module_name_check = Guideline(;
+    info = "Name does not match a reserved Julia module name",
+    docs = "Packages must not match the name of a public Julia module, including up-to-case matches.",
+    check=data -> meets_julia_module_name_check(data.pkg, julia_public_module_names()))
 
 function meets_julia_module_name_check(
     pkg_name::AbstractString,
@@ -1368,6 +1371,7 @@ function get_automerge_guidelines(
         (guideline_uuid_sanity_check, true),
         # this is the non-optional part of name checking
         (guideline_name_match_check, true),
+        (guideline_julia_module_name_check, true),
         # We always run the `guideline_distance_check`
         # check last, because if the check fails, it
         # prints the list of similar package names in

--- a/AutoMerge/src/util.jl
+++ b/AutoMerge/src/util.jl
@@ -542,6 +542,23 @@ function julia_stdlib_list()
     return stdlib_list
 end
 
+function julia_public_module_names()
+    module_names = String[]
+    for module_parent in (Base, Core)
+        for module_name in names(module_parent)
+            value = try
+                getproperty(module_parent, module_name)
+            catch
+                continue
+            end
+            if value isa Module && parentmodule(value) === module_parent
+                push!(module_names, String(module_name))
+            end
+        end
+    end
+    return sort!(unique!(module_names))
+end
+
 function now_utc()
     utc = TimeZones.tz"UTC"
     return Dates.now(utc)

--- a/AutoMerge/test/automerge-unit.jl
+++ b/AutoMerge/test/automerge-unit.jl
@@ -325,7 +325,10 @@ end
     @testset "Package name match check" begin
         @test AutoMerge.meets_name_match_check("Flux", ["Abc", "Def"])[1]
         @test !AutoMerge.meets_name_match_check("Websocket", ["websocket"])[1]
-        @test !AutoMerge.meets_name_match_check("Logging", joinpath(DEPOT_PATH[1], "registries", "General"))[1]
+        @test AutoMerge.meets_name_match_check("Filesystem", joinpath(DEPOT_PATH[1], "registries", "General"))[1]
+    end
+    @testset "Julia module name check" begin
+        @test AutoMerge.meets_julia_module_name_check("Flux", ["Threads", "Filesystem"])[1]
         @test !AutoMerge.meets_julia_module_name_check("Threads", ["Threads", "Filesystem"])[1]
         @test !AutoMerge.meets_julia_module_name_check("filesystem", ["Threads", "Filesystem"])[1]
     end

--- a/AutoMerge/test/automerge-unit.jl
+++ b/AutoMerge/test/automerge-unit.jl
@@ -325,6 +325,9 @@ end
     @testset "Package name match check" begin
         @test AutoMerge.meets_name_match_check("Flux", ["Abc", "Def"])[1]
         @test !AutoMerge.meets_name_match_check("Websocket", ["websocket"])[1]
+        @test !AutoMerge.meets_name_match_check("Logging", joinpath(DEPOT_PATH[1], "registries", "General"))[1]
+        @test !AutoMerge.meets_julia_module_name_check("Threads", ["Threads", "Filesystem"])[1]
+        @test !AutoMerge.meets_julia_module_name_check("filesystem", ["Threads", "Filesystem"])[1]
     end
     @testset "Package name distance" begin
         @test AutoMerge.meets_distance_check("Flux", ["Abc", "Def"])[1]
@@ -544,6 +547,11 @@ end
         result, msg = AutoMerge.meets_uuid_match_check(nothing, registry_path)
         @test !result
         @test occursin("Project.toml checks failed", msg)
+
+        logging_uuid = only(filter(x -> x.name == "Logging", AutoMerge.get_all_pkg_name_uuids(registry_path))).uuid
+        result, msg = AutoMerge.meets_uuid_match_check(logging_uuid, AutoMerge.get_all_pkg_name_uuids(registry_path))
+        @test !result
+        @test occursin("Logging", msg)
     end
     @testset "`uuid_passes_sanity_check`" begin
         # Test standards-compliant UUIDs (variant = 2, version 1-8)


### PR DESCRIPTION
Fixes #627.

## Summary

- keep the existing stdlib name and UUID collision protections under test
- reject reserved public `Base` and `Core` module names such as `Threads`
- run the reserved-module-name rejection as its own non-optional guideline instead of folding it into `meets_name_match_check`
- add unit coverage for registry-name, stdlib-name, stdlib-UUID, and reserved-module collisions

## Testing

- `env -u JULIAUP_DEPOT_PATH julia +release --project=AutoMerge -e 'using AutoMerge, Test; @test AutoMerge.meets_name_match_check("Flux", ["Abc", "Def"])[1]; @test !AutoMerge.meets_name_match_check("Websocket", ["websocket"])[1]; @test AutoMerge.meets_name_match_check("Filesystem", joinpath(DEPOT_PATH[1], "registries", "General"))[1]; @test AutoMerge.meets_julia_module_name_check("Flux", ["Threads", "Filesystem"])[1]; @test !AutoMerge.meets_julia_module_name_check("Threads", ["Threads", "Filesystem"])[1]; @test !AutoMerge.meets_julia_module_name_check("filesystem", ["Threads", "Filesystem"])[1]'`
- `env -u JULIAUP_DEPOT_PATH AUTOMERGE_RUN_INTEGRATION_TESTS=false julia +release --project=AutoMerge -e 'using Pkg; Pkg.test()'`
  - reaches the existing unrelated `juliaup`-dependent `Version can be added` / `Version can be imported` failures

cc @DilumAluthge

🤖 Generated by Codex.
