### PR TITLE
AutoMerge: link release-notes guidance to the original commit

### DIFF
--- a/AutoMerge/src/guidelines.jl
+++ b/AutoMerge/src/guidelines.jl
@@ -478,14 +478,20 @@ function meets_breaking_explanation_check(data::GitHubAutoMergeData)
     # Look up PR here in case the labels are slow to be applied by the Registrator bot
     # which decides whether to add the BREAKING label
     pr = GitHub.pull_request(data.api, data.registry, data.pr.number; auth=data.auth)
-    return meets_breaking_explanation_check(pr.labels, pr.body)
+    return meets_breaking_explanation_check(pr.labels, pr.body; commit_url=commit_url_from_pull_request_body(pr))
 end
 
-function breaking_explanation_message(has_release_notes)
+function breaking_explanation_message(has_release_notes; commit_url=nothing)
+    retrigger_instructions =
+        if commit_url === nothing
+            "If you are using the comment bot `@JuliaRegistrator`, you can add release notes to this registration by re-triggering registration while specifying release notes:"
+        else
+            "If you are using the comment bot `@JuliaRegistrator`, you can add release notes to this registration by re-triggering registration on your [original commit]($(commit_url)) while specifying release notes:"
+        end
     example_detail = """
         <details><summary>Example of adding release notes with breaking notice</summary>
 
-        If you are using the comment bot `@JuliaRegistrator`, you can add release notes to this registration by re-triggering registration while specifying release notes:
+        $(retrigger_instructions)
 
         ```
         @JuliaRegistrator register
@@ -516,14 +522,29 @@ function breaking_explanation_message(has_release_notes)
     end
 end
 
-function meets_breaking_explanation_check(labels::Vector, body::AbstractString)
+function commit_url_from_pull_request_body(pull_request::GitHub.PullRequest)
+    repo_url = repository_from_pull_request_body(pull_request)
+    repo_url === nothing && return nothing
+    owner_repo = extract_github_owner_repo(repo_url)
+    owner_repo === nothing && return nothing
+    commit_sha = commit_from_pull_request_body(pull_request)
+    owner, repo = owner_repo
+    return "https://github.com/$owner/$repo/commit/$commit_sha"
+end
+
+function commit_url_from_pull_request_body(body::AbstractString)
+    pull_request = GitHub.PullRequest(; body=body)
+    return commit_url_from_pull_request_body(pull_request)
+end
+
+function meets_breaking_explanation_check(labels::Vector, body::AbstractString; commit_url=nothing)
     if has_label(labels, BREAKING_LABEL)
         release_notes = get_release_notes(body)
         if release_notes === nothing
-            msg = breaking_explanation_message(false)
+            msg = breaking_explanation_message(false; commit_url=commit_url)
             return false, msg
         elseif !occursin(r"breaking|changelog", lowercase(release_notes))
-            msg = breaking_explanation_message(true)
+            msg = breaking_explanation_message(true; commit_url=commit_url)
             return false, msg
         else
             return true, ""

--- a/AutoMerge/src/pull_requests.jl
+++ b/AutoMerge/src/pull_requests.jl
@@ -62,6 +62,12 @@ function commit_from_pull_request_body(pull_request::GitHub.PullRequest)
     return commit
 end
 
+function repository_from_pull_request_body(pull_request::GitHub.PullRequest)
+    pr_body = body(pull_request)
+    m = match(r"Repository: (.*)", pr_body)
+    return m === nothing ? nothing : convert(String, strip(m.captures[1]))
+end
+
 function parse_pull_request_title(::NewPackage, pull_request::GitHub.PullRequest)
     m = match(new_package_title_regex, title(pull_request))
     pkg = convert(String, m.captures[1])::String

--- a/AutoMerge/test/automerge-unit.jl
+++ b/AutoMerge/test/automerge-unit.jl
@@ -722,11 +722,28 @@ end
         <!-- END RELEASE NOTES -->
         """
         body_bad_no_notes = ""
+        body_with_commit = """
+        Repository: https://github.com/JuliaRegistries/RegistryCI.jl.git
+        Commit: 0123456789abcdef0123456789abcdef01234567
+        <!-- BEGIN RELEASE NOTES -->
+        `````
+        ## Features
+        - something
+        `````
+        <!-- END RELEASE NOTES -->
+        """
         breaking_label = GitHub.Label(; name="BREAKING")
         @test AutoMerge.meets_breaking_explanation_check([breaking_label], body_good)[1]
         @test AutoMerge.meets_breaking_explanation_check([breaking_label], body_good_changelog)[1]
         @test !AutoMerge.meets_breaking_explanation_check([breaking_label], body_bad)[1]
         @test !AutoMerge.meets_breaking_explanation_check([breaking_label], body_bad_no_notes)[1]
+        result, msg = AutoMerge.meets_breaking_explanation_check(
+            [breaking_label],
+            body_with_commit;
+            commit_url=AutoMerge.commit_url_from_pull_request_body(body_with_commit),
+        )
+        @test !result
+        @test occursin("[original commit](https://github.com/JuliaRegistries/RegistryCI.jl/commit/0123456789abcdef0123456789abcdef01234567)", msg)
 
         # Maybe this should fail as the label isn't applied by JuliaRegistrator, so the version isn't breaking?
         @test AutoMerge.meets_breaking_explanation_check([], body_good)[1]


### PR DESCRIPTION
Fixes #595.

## Summary

- parse the original repository URL from the Registrator PR body alongside the existing commit SHA
- include a direct link to the original GitHub commit in the breaking-change release-notes guidance when that context is available
- keep non-GitHub and non-comment-bot flows on the existing generic instructions

## Testing

- `AUTOMERGE_RUN_INTEGRATION_TESTS=false julia --project=AutoMerge -e 'using Pkg; Pkg.test()'`
  - reaches the existing unrelated `juliaup`-dependent `Version can be added` / `Version can be imported` failures

cc @DilumAluthge

🤖 Generated by Codex.
