### PR TITLE
AutoMerge: support REUSE-compatible LICENSES directories

### DIFF
--- a/AutoMerge/src/guidelines.jl
+++ b/AutoMerge/src/guidelines.jl
@@ -1018,14 +1018,14 @@ function meets_version_has_osi_license(pkg::String; pkg_code_path)
         "Could not check license because could not access package code. Perhaps the `can_download_code` check failed earlier."
     end
 
-    license_results = LicenseCheck.find_licenses(pkgdir)
+    license_results = find_package_licenses(pkgdir)
 
     # Failure mode 1: no licenses
     if isempty(license_results)
         @error "Could not find any licenses"
         return false,
         string(
-            "No licenses detected in the package's top-level folder. An OSI-approved license is required.",
+            "No licenses detected in the package's top-level folder or LICENSES/ directory. An OSI-approved license is required.",
         )
     end
 
@@ -1065,6 +1065,22 @@ function meets_version_has_osi_license(pkg::String; pkg_code_path)
     else
         return true, string(osi_string, " Found no other licenses.")
     end
+end
+
+function find_package_licenses(pkgdir::AbstractString)
+    license_results = copy(LicenseCheck.find_licenses(pkgdir))
+    licenses_dir = joinpath(pkgdir, "LICENSES")
+    if isdir(licenses_dir)
+        append!(
+            license_results,
+            (
+                ; license_filename=joinpath("LICENSES", result.license_filename),
+                licenses_found=result.licenses_found,
+                license_file_percent_covered=result.license_file_percent_covered,
+            ) for result in LicenseCheck.find_licenses(licenses_dir)
+        )
+    end
+    return license_results
 end
 
 const guideline_version_can_be_pkg_added = Guideline(;

--- a/AutoMerge/src/guidelines.jl
+++ b/AutoMerge/src/guidelines.jl
@@ -1071,14 +1071,16 @@ function find_package_licenses(pkgdir::AbstractString)
     license_results = copy(LicenseCheck.find_licenses(pkgdir))
     licenses_dir = joinpath(pkgdir, "LICENSES")
     if isdir(licenses_dir)
-        append!(
-            license_results,
-            (
-                ; license_filename=joinpath("LICENSES", result.license_filename),
-                licenses_found=result.licenses_found,
-                license_file_percent_covered=result.license_file_percent_covered,
-            ) for result in LicenseCheck.find_licenses(licenses_dir)
-        )
+        for result in LicenseCheck.find_licenses(licenses_dir)
+            push!(
+                license_results,
+                (;
+                    license_filename=joinpath("LICENSES", result.license_filename),
+                    licenses_found=result.licenses_found,
+                    license_file_percent_covered=result.license_file_percent_covered,
+                ),
+            )
+        end
     end
     return license_results
 end

--- a/AutoMerge/test/automerge-unit.jl
+++ b/AutoMerge/test/automerge-unit.jl
@@ -1133,9 +1133,15 @@ end
             result = has_osi_license_in_depot("UnbalancedOptimalTransport")
             @test !result[1]
 
-            # What about no license at all?
+            # REUSE-style projects can keep their license texts under LICENSES/
             pkg_path = pkgdir_from_depot(tmp_depot, "VisualStringDistances")
-            rm(joinpath(pkg_path, "LICENSE"))
+            mkpath(joinpath(pkg_path, "LICENSES"))
+            mv(joinpath(pkg_path, "LICENSE"), joinpath(pkg_path, "LICENSES", "MIT.txt"))
+            result = has_osi_license_in_depot("VisualStringDistances")
+            @test result[1]
+
+            # What about no license at all?
+            rm(joinpath(pkg_path, "LICENSES", "MIT.txt"))
             result = has_osi_license_in_depot("VisualStringDistances")
             @test !result[1]
         end

--- a/AutoMerge/test/automerge-unit.jl
+++ b/AutoMerge/test/automerge-unit.jl
@@ -1137,6 +1137,7 @@ end
             pkg_path = pkgdir_from_depot(tmp_depot, "VisualStringDistances")
             mkpath(joinpath(pkg_path, "LICENSES"))
             mv(joinpath(pkg_path, "LICENSE"), joinpath(pkg_path, "LICENSES", "MIT.txt"))
+            @test !ispath(joinpath(pkg_path, "LICENSE"))
             result = has_osi_license_in_depot("VisualStringDistances")
             @test result[1]
 


### PR DESCRIPTION
Fixes #581.
Fixes #532.

## Summary

- extend the AutoMerge license check to scan `LICENSES/` in addition to the package top level
- treat REUSE-style license texts under `LICENSES/` the same way as top-level license files
- add unit coverage where the only remaining OSI-approved license lives under `LICENSES/`

## Testing

- `AUTOMERGE_RUN_INTEGRATION_TESTS=false julia --project=AutoMerge -e 'using Pkg; Pkg.test()'`
  - reaches the existing unrelated `juliaup`-dependent `Version can be added` / `Version can be imported` failures

cc @DilumAluthge

🤖 Generated by Codex.
