### PR TITLE
AutoMerge: make new package messages friendlier

### DIFF
--- a/AutoMerge/src/util.jl
+++ b/AutoMerge/src/util.jl
@@ -362,6 +362,10 @@ function _new_package_section(n)
     "[package naming guidelines](https://pkgdocs.julialang.org/dev/creating-packages/#Package-naming-guidelines).\n\n")
 end
 
+function _new_package_welcome()
+    return "Welcome to the General registry, and thanks for sharing your work.\n\n"
+end
+
 function _what_next_if_fail(n; point_to_slack=false)
     msg = """
     ## $n. *Needs action*: here's what to do next
@@ -457,6 +461,7 @@ function comment_text_pass(
         result = string(
             _comment_bot_intro(),
             _automerge_guidelines_passed_section_title(1),
+            _new_package_welcome(),
             "Your new `_jll` package registration met all of the ",
             "guidelines for auto-merging and is scheduled to ",
             "be merged in the next round (~20 minutes).\n\n",
@@ -470,6 +475,7 @@ function comment_text_pass(
         result = string(
             _comment_bot_intro(),
             _new_package_section(1),
+            _new_package_welcome(),
             _automerge_guidelines_passed_section_title(2),
             "Your new package registration met all of the ",
             "guidelines for auto-merging and is scheduled to ",
@@ -497,6 +503,7 @@ function comment_text_fail(
     result = string(
         _comment_bot_intro(),
         _new_package_section(1),
+        _new_package_welcome(),
         _automerge_guidelines_failed_section_title(2),
         reasons_formatted,
         _what_next_if_fail(3; point_to_slack=point_to_slack),

--- a/AutoMerge/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_0.1.0_point_to_slack_false.md
+++ b/AutoMerge/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_0.1.0_point_to_slack_false.md
@@ -4,6 +4,8 @@ Hello, I am an automated registration bot. I help manage the registration proces
 
 Please make sure that you have read the [package naming guidelines](https://pkgdocs.julialang.org/dev/creating-packages/#Package-naming-guidelines).
 
+Welcome to the General registry, and thanks for sharing your work.
+
 ## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - The following dependencies do not have a `[compat]` entry that is upper-bounded and only includes a finite number of breaking releases: julia

--- a/AutoMerge/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_0.1.0_point_to_slack_true.md
+++ b/AutoMerge/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_0.1.0_point_to_slack_true.md
@@ -4,6 +4,8 @@ Hello, I am an automated registration bot. I help manage the registration proces
 
 Please make sure that you have read the [package naming guidelines](https://pkgdocs.julialang.org/dev/creating-packages/#Package-naming-guidelines).
 
+Welcome to the General registry, and thanks for sharing your work.
+
 ## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - The following dependencies do not have a `[compat]` entry that is upper-bounded and only includes a finite number of breaking releases: julia

--- a/AutoMerge/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_1.0.0_point_to_slack_false.md
+++ b/AutoMerge/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_1.0.0_point_to_slack_false.md
@@ -4,6 +4,8 @@ Hello, I am an automated registration bot. I help manage the registration proces
 
 Please make sure that you have read the [package naming guidelines](https://pkgdocs.julialang.org/dev/creating-packages/#Package-naming-guidelines).
 
+Welcome to the General registry, and thanks for sharing your work.
+
 ## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - The following dependencies do not have a `[compat]` entry that is upper-bounded and only includes a finite number of breaking releases: julia

--- a/AutoMerge/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_1.0.0_point_to_slack_true.md
+++ b/AutoMerge/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_false_version_1.0.0_point_to_slack_true.md
@@ -4,6 +4,8 @@ Hello, I am an automated registration bot. I help manage the registration proces
 
 Please make sure that you have read the [package naming guidelines](https://pkgdocs.julialang.org/dev/creating-packages/#Package-naming-guidelines).
 
+Welcome to the General registry, and thanks for sharing your work.
+
 ## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - The following dependencies do not have a `[compat]` entry that is upper-bounded and only includes a finite number of breaking releases: julia

--- a/AutoMerge/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_0.1.0_point_to_slack_false.md
+++ b/AutoMerge/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_0.1.0_point_to_slack_false.md
@@ -4,6 +4,8 @@ Hello, I am an automated registration bot. I help manage the registration proces
 
 Please make sure that you have read the [package naming guidelines](https://pkgdocs.julialang.org/dev/creating-packages/#Package-naming-guidelines).
 
+Welcome to the General registry, and thanks for sharing your work.
+
 ## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - The following dependencies do not have a `[compat]` entry that is upper-bounded and only includes a finite number of breaking releases: julia

--- a/AutoMerge/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_0.1.0_point_to_slack_true.md
+++ b/AutoMerge/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_0.1.0_point_to_slack_true.md
@@ -4,6 +4,8 @@ Hello, I am an automated registration bot. I help manage the registration proces
 
 Please make sure that you have read the [package naming guidelines](https://pkgdocs.julialang.org/dev/creating-packages/#Package-naming-guidelines).
 
+Welcome to the General registry, and thanks for sharing your work.
+
 ## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - The following dependencies do not have a `[compat]` entry that is upper-bounded and only includes a finite number of breaking releases: julia

--- a/AutoMerge/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_1.0.0_point_to_slack_false.md
+++ b/AutoMerge/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_1.0.0_point_to_slack_false.md
@@ -4,6 +4,8 @@ Hello, I am an automated registration bot. I help manage the registration proces
 
 Please make sure that you have read the [package naming guidelines](https://pkgdocs.julialang.org/dev/creating-packages/#Package-naming-guidelines).
 
+Welcome to the General registry, and thanks for sharing your work.
+
 ## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - The following dependencies do not have a `[compat]` entry that is upper-bounded and only includes a finite number of breaking releases: julia

--- a/AutoMerge/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_1.0.0_point_to_slack_true.md
+++ b/AutoMerge/test/reference_comments/comment_pass_false_type_new_package_suggest_onepointzero_true_version_1.0.0_point_to_slack_true.md
@@ -4,6 +4,8 @@ Hello, I am an automated registration bot. I help manage the registration proces
 
 Please make sure that you have read the [package naming guidelines](https://pkgdocs.julialang.org/dev/creating-packages/#Package-naming-guidelines).
 
+Welcome to the General registry, and thanks for sharing your work.
+
 ## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) which are not met ❌
 
 - The following dependencies do not have a `[compat]` entry that is upper-bounded and only includes a finite number of breaking releases: julia

--- a/AutoMerge/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_0.1.0_is_jll_false.md
+++ b/AutoMerge/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_0.1.0_is_jll_false.md
@@ -4,6 +4,8 @@ Hello, I am an automated registration bot. I help manage the registration proces
 
 Please make sure that you have read the [package naming guidelines](https://pkgdocs.julialang.org/dev/creating-packages/#Package-naming-guidelines).
 
+Welcome to the General registry, and thanks for sharing your work.
+
 ## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new package registration met all of the guidelines for auto-merging and is scheduled to be merged when the mandatory waiting period (3 days) has elapsed. Ignore when GitHub says "Review required": further approval is only necessary for manual merges, not for auto-merge.

--- a/AutoMerge/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_0.1.0_is_jll_true.md
+++ b/AutoMerge/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_0.1.0_is_jll_true.md
@@ -2,6 +2,8 @@ Hello, I am an automated registration bot. I help manage the registration proces
 
 ## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
+Welcome to the General registry, and thanks for sharing your work.
+
 Your new `_jll` package registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round (~20 minutes).
 
 ## 2. To pause or stop registration

--- a/AutoMerge/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_1.0.0_is_jll_false.md
+++ b/AutoMerge/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_1.0.0_is_jll_false.md
@@ -4,6 +4,8 @@ Hello, I am an automated registration bot. I help manage the registration proces
 
 Please make sure that you have read the [package naming guidelines](https://pkgdocs.julialang.org/dev/creating-packages/#Package-naming-guidelines).
 
+Welcome to the General registry, and thanks for sharing your work.
+
 ## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new package registration met all of the guidelines for auto-merging and is scheduled to be merged when the mandatory waiting period (3 days) has elapsed. Ignore when GitHub says "Review required": further approval is only necessary for manual merges, not for auto-merge.

--- a/AutoMerge/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_1.0.0_is_jll_true.md
+++ b/AutoMerge/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_false_version_1.0.0_is_jll_true.md
@@ -2,6 +2,8 @@ Hello, I am an automated registration bot. I help manage the registration proces
 
 ## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
+Welcome to the General registry, and thanks for sharing your work.
+
 Your new `_jll` package registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round (~20 minutes).
 
 ## 2. To pause or stop registration

--- a/AutoMerge/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_0.1.0_is_jll_false.md
+++ b/AutoMerge/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_0.1.0_is_jll_false.md
@@ -4,6 +4,8 @@ Hello, I am an automated registration bot. I help manage the registration proces
 
 Please make sure that you have read the [package naming guidelines](https://pkgdocs.julialang.org/dev/creating-packages/#Package-naming-guidelines).
 
+Welcome to the General registry, and thanks for sharing your work.
+
 ## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new package registration met all of the guidelines for auto-merging and is scheduled to be merged when the mandatory waiting period (3 days) has elapsed. Ignore when GitHub says "Review required": further approval is only necessary for manual merges, not for auto-merge.

--- a/AutoMerge/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_0.1.0_is_jll_true.md
+++ b/AutoMerge/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_0.1.0_is_jll_true.md
@@ -2,6 +2,8 @@ Hello, I am an automated registration bot. I help manage the registration proces
 
 ## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
+Welcome to the General registry, and thanks for sharing your work.
+
 Your new `_jll` package registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round (~20 minutes).
 
 ## 2. Declare v1.0?

--- a/AutoMerge/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_1.0.0_is_jll_false.md
+++ b/AutoMerge/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_1.0.0_is_jll_false.md
@@ -4,6 +4,8 @@ Hello, I am an automated registration bot. I help manage the registration proces
 
 Please make sure that you have read the [package naming guidelines](https://pkgdocs.julialang.org/dev/creating-packages/#Package-naming-guidelines).
 
+Welcome to the General registry, and thanks for sharing your work.
+
 ## 2. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
 Your new package registration met all of the guidelines for auto-merging and is scheduled to be merged when the mandatory waiting period (3 days) has elapsed. Ignore when GitHub says "Review required": further approval is only necessary for manual merges, not for auto-merge.

--- a/AutoMerge/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_1.0.0_is_jll_true.md
+++ b/AutoMerge/test/reference_comments/comment_pass_true_type_new_package_suggest_onepointzero_true_version_1.0.0_is_jll_true.md
@@ -2,6 +2,8 @@ Hello, I am an automated registration bot. I help manage the registration proces
 
 ## 1. [AutoMerge Guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) are all met! ✅
 
+Welcome to the General registry, and thanks for sharing your work.
+
 Your new `_jll` package registration met all of the guidelines for auto-merging and is scheduled to be merged in the next round (~20 minutes).
 
 ## 2. To pause or stop registration


### PR DESCRIPTION
Closes #543.

This adds the requested welcome sentence to the automated new-package comments and refreshes the reference comment fixtures to match.

Validation:
- `ENV_JULIA_REFERENCETESTS_UPDATE=true julia --project=AutoMerge -e 'ENV["JULIA_REFERENCETESTS_UPDATE"]="true"; using Pkg; Pkg.test()'`
  - Updated the affected reference comment fixtures.
  - The run later proceeds into the existing unrelated `juliaup`-dependent package-install test path.

cc @DilumAluthge

🤖 Generated by Codex.
