### PR TITLE
RegistryCI: reject compat entries for unknown package names

### DIFF
--- a/RegistryCI/src/registry_testing.jl
+++ b/RegistryCI/src/registry_testing.jl
@@ -73,6 +73,30 @@ function load_registry_dep_uuids(registry_deps_names::Vector{<:AbstractString}=S
     end
 end
 
+function load_registry_dep_package_names(
+    registry_deps_names::Vector{<:AbstractString}=String[],
+)
+    return with_temp_depot() do
+        for repo_spec in registry_deps_names
+            if is_valid_url(repo_spec)
+                Pkg.Registry.add(Pkg.RegistrySpec(; url=repo_spec))
+            else
+                Pkg.Registry.add(repo_spec)
+            end
+        end
+        extranames = Set{String}()
+        for spec in collect_registries()
+            if _include_this_registry(spec, registry_deps_names)
+                reg = Pkg.TOML.parsefile(joinpath(spec.path, "Registry.toml"))
+                for (_, data) in reg["packages"]
+                    push!(extranames, data["name"])
+                end
+            end
+        end
+        return extranames
+    end
+end
+
 #########################
 # Testing of registries #
 #########################
@@ -152,9 +176,13 @@ function test(path=pwd(); registry_deps::Vector{<:AbstractString}=String[])
         cd(path) do
             reg = Pkg.TOML.parsefile("Registry.toml")
             reguuids = Set{Base.UUID}(Base.UUID(x) for x in keys(reg["packages"]))
+            regnames = Set{String}(data["name"] for (_, data) in reg["packages"])
             stdlibuuids = gather_stdlib_uuids()
+            stdlibnames = Set{String}(name for (_, (name, _)) in RegistryTools.stdlibs())
             registry_dep_uuids = load_registry_dep_uuids(registry_deps)
+            registry_dep_names = load_registry_dep_package_names(registry_deps)
             alluuids = reguuids ∪ stdlibuuids ∪ registry_dep_uuids
+            allnames = regnames ∪ stdlibnames ∪ registry_dep_names
 
             # Test that each entry in Registry.toml has a corresponding Package.toml
             # at the expected path with the correct uuid and name
@@ -237,6 +265,7 @@ function test(path=pwd(); registry_deps::Vector{<:AbstractString}=String[])
                             )
                         end
                     end
+                    @test compatnames ⊆ (allnames ∪ Set(["julia"]))
 
                     # Make sure that each compat spec is a valid registry compat spec.
                     # https://github.com/JuliaRegistries/General/issues/104849

--- a/RegistryCI/test/registryci_registry_testing.jl
+++ b/RegistryCI/test/registryci_registry_testing.jl
@@ -90,4 +90,62 @@ end
             end
         end
     end
+
+    @testset "Compat entries must reference existing packages" begin
+        mktempdir() do tmpdir
+            registry_dir = joinpath(tmpdir, "TestRegistry")
+            mkpath(registry_dir)
+
+            write(joinpath(registry_dir, "Registry.toml"), """
+                name = "TestRegistry"
+                uuid = "12345678-1234-5678-9abc-123456789abc"
+                repo = "https://github.com/test/TestRegistry.git"
+
+                [packages]
+                87654321-4321-8765-cba9-987654321cba = { name = "TestPkg", path = "T/TestPkg" }
+                """)
+
+            pkg_dir = joinpath(registry_dir, "T", "TestPkg")
+            mkpath(pkg_dir)
+
+            write(joinpath(pkg_dir, "Package.toml"), """
+                name = "TestPkg"
+                uuid = "87654321-4321-8765-cba9-987654321cba"
+                repo = "https://github.com/test/TestPkg.git"
+                """)
+
+            write(joinpath(pkg_dir, "Versions.toml"), """
+                ["1.0.0"]
+                git-tree-sha1 = "abcdef0123456789abcdef0123456789abcdef01"
+                """)
+
+            write(joinpath(pkg_dir, "Deps.toml"), """
+                ["1.0.0"]
+                Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+                """)
+
+            write(joinpath(pkg_dir, "Compat.toml"), """
+                ["1.0.0"]
+                Printf = "1"
+                """)
+
+            @test RegistryCI.test(registry_dir) === nothing
+
+            write(joinpath(pkg_dir, "Compat.toml"), """
+                ["1.0.0"]
+                DoesNotExist = "1"
+                """)
+
+            write(joinpath(pkg_dir, "Deps.toml"), """
+                ["1.0.0"]
+                DoesNotExist = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+                """)
+
+            @testset "Unknown compat package name" begin
+                @test fails() do
+                    RegistryCI.test(registry_dir)
+                end
+            end
+        end
+    end
 end


### PR DESCRIPTION
Closes #531.

This extends the registry integrity checks so `Compat.toml` entries must name an existing package from the registry, a dependency registry, a stdlib, or `julia`. It also adds a synthetic regression test for a dependency/compat entry that uses a valid stdlib UUID under a bogus package name.

Validation:
- `julia --project=RegistryCI -e 'using Pkg; Pkg.test(test_args=["false"])'`

cc @DilumAluthge

🤖 Generated by Codex.
