### PR TITLE
AutoMerge: require compat for weak dependencies

### DIFF
--- a/AutoMerge/src/guidelines.jl
+++ b/AutoMerge/src/guidelines.jl
@@ -123,24 +123,36 @@ function meets_compat_for_all_deps(working_directory::AbstractString, pkg, versi
     package_relpath = get_package_relpath_in_registry(;
         package_name=pkg, registry_path=working_directory
     )
-    compat = parse_registry_toml(working_directory, package_relpath, "Compat.toml"; allow_missing = true)
-    deps = parse_registry_toml(working_directory, package_relpath, "Deps.toml"; allow_missing = true)
+    compat = parse_registry_toml(
+        working_directory, package_relpath, "Compat.toml"; allow_missing=true
+    )
+    deps = parse_registry_toml(
+        working_directory, package_relpath, "Deps.toml"; allow_missing=true
+    )
+    weakcompat = parse_registry_toml(
+        working_directory, package_relpath, "WeakCompat.toml"; allow_missing=true
+    )
+    weakdeps = parse_registry_toml(
+        working_directory, package_relpath, "WeakDeps.toml"; allow_missing=true
+    )
     # First, we construct a Dict in which the keys are the package's
     # dependencies, and the value is always false.
     dep_has_compat_with_upper_bound = Dict{String,Bool}()
-    for version_range in keys(deps)
-        if version in Pkg.Types.VersionRange(version_range)
-            for name in keys(deps[version_range])
-                if _AUTOMERGE_REQUIRE_STDLIB_COMPAT
-                    debug_msg = "Found a new (non-JLL) dependency: $(name)"
-                    apply_compat_requirement = !is_jll_name(name)
-                else
-                    debug_msg = "Found a new (non-stdlib non-JLL) dependency: $(name)"
-                    apply_compat_requirement = !is_jll_name(name) && !is_julia_stdlib(name)
-                end
-                if apply_compat_requirement
-                    @debug debug_msg
-                    dep_has_compat_with_upper_bound[name] = false
+    for dep_dict in (deps, weakdeps)
+        for version_range in keys(dep_dict)
+            if version in Pkg.Types.VersionRange(version_range)
+                for name in keys(dep_dict[version_range])
+                    if _AUTOMERGE_REQUIRE_STDLIB_COMPAT
+                        debug_msg = "Found a new (non-JLL) dependency: $(name)"
+                        apply_compat_requirement = !is_jll_name(name)
+                    else
+                        debug_msg = "Found a new (non-stdlib non-JLL) dependency: $(name)"
+                        apply_compat_requirement = !is_jll_name(name) && !is_julia_stdlib(name)
+                    end
+                    if apply_compat_requirement
+                        @debug debug_msg
+                        dep_has_compat_with_upper_bound[name] = false
+                    end
                 end
             end
         end
@@ -148,27 +160,29 @@ function meets_compat_for_all_deps(working_directory::AbstractString, pkg, versi
     # Now, we go through all the compat entries. If a dependency has a compat
     # entry with an upper bound, we change the corresponding value in the Dict
     # to true.
-    for version_range in keys(compat)
-        if version in Pkg.Types.VersionRange(version_range)
-            for (name, value) in compat[version_range]
-                if value isa Vector
-                    if !isempty(value)
-                        value_ranges = Pkg.Types.VersionRange.(value)
-                        each_range_has_upper_bound = _has_upper_bound.(value_ranges)
-                        if all(each_range_has_upper_bound)
+    for compat_dict in (compat, weakcompat)
+        for version_range in keys(compat_dict)
+            if version in Pkg.Types.VersionRange(version_range)
+                for (name, value) in compat_dict[version_range]
+                    if value isa Vector
+                        if !isempty(value)
+                            value_ranges = Pkg.Types.VersionRange.(value)
+                            each_range_has_upper_bound = _has_upper_bound.(value_ranges)
+                            if all(each_range_has_upper_bound)
+                                @debug(
+                                    "Dependency \"$(name)\" has compat entries that all have upper bounds"
+                                )
+                                dep_has_compat_with_upper_bound[name] = true
+                            end
+                        end
+                    else
+                        value_range = Pkg.Types.VersionRange(value)
+                        if _has_upper_bound(value_range)
                             @debug(
-                                "Dependency \"$(name)\" has compat entries that all have upper bounds"
+                                "Dependency \"$(name)\" has a compat entry with an upper bound"
                             )
                             dep_has_compat_with_upper_bound[name] = true
                         end
-                    end
-                else
-                    value_range = Pkg.Types.VersionRange(value)
-                    if _has_upper_bound(value_range)
-                        @debug(
-                            "Dependency \"$(name)\" has a compat entry with an upper bound"
-                        )
-                        dep_has_compat_with_upper_bound[name] = true
                     end
                 end
             end

--- a/AutoMerge/test/automerge-unit.jl
+++ b/AutoMerge/test/automerge-unit.jl
@@ -613,6 +613,46 @@ end
 end
 
 @testset "Guidelines for new versions" begin
+    @testset "Weak dependencies require compat bounds" begin
+        mktempdir() do tmp_registry
+            pkg_dir = joinpath(tmp_registry, "T", "TestPkg")
+            mkpath(pkg_dir)
+
+            write(joinpath(tmp_registry, "Registry.toml"), """
+            [packages]
+            87654321-4321-8765-cba9-987654321cba = { name = "TestPkg", path = "T/TestPkg" }
+            """)
+
+            write(joinpath(pkg_dir, "Package.toml"), """
+            name = "TestPkg"
+            uuid = "87654321-4321-8765-cba9-987654321cba"
+            repo = "https://github.com/test/TestPkg.jl.git"
+            """)
+
+            write(joinpath(pkg_dir, "WeakDeps.toml"), """
+            ["1.0.0"]
+            WeakDep = "7876af07-990d-54b4-ab0e-23690620f79a"
+            """)
+
+            result, message = AutoMerge.meets_compat_for_all_deps(
+                tmp_registry, "TestPkg", v"1.0.0"
+            )
+            @test !result
+            @test occursin("WeakDep", message)
+
+            write(joinpath(pkg_dir, "WeakCompat.toml"), """
+            ["1.0.0"]
+            WeakDep = "1"
+            """)
+
+            result, message = AutoMerge.meets_compat_for_all_deps(
+                tmp_registry, "TestPkg", v"1.0.0"
+            )
+            @test result
+            @test isempty(message)
+        end
+    end
+
     @testset "Sequential version number" begin
         @test AutoMerge.meets_sequential_version_number([v"0.0.1"], v"0.0.2")[1]
         @test AutoMerge.meets_sequential_version_number([v"0.1.0"], v"0.1.1")[1]


### PR DESCRIPTION
Closes #489.

This extends the existing dependency compat guideline to also read `WeakDeps.toml` and `WeakCompat.toml`, so weak dependencies are treated the same way as ordinary dependencies. The PR also adds a synthetic regression test for a weak dependency that is missing its compat bound.

Validation:
- `AUTOMERGE_RUN_INTEGRATION_TESTS=false julia --project=AutoMerge -e 'using Pkg; Pkg.test()'`
- Reached and exercised the new weakdep compat path.
- Then continued into the existing unrelated `juliaup`-driven package-install test path.

cc @DilumAluthge

🤖 Generated by Codex.
