### PR TITLE
AutoMerge: require DelimitedFiles compat before Julia 1.9

### DIFF
--- a/AutoMerge/src/guidelines.jl
+++ b/AutoMerge/src/guidelines.jl
@@ -119,6 +119,19 @@ function compat_violation_message(bad_dependencies)
 
 end
 
+function requires_delimitedfiles_compat(compat, version)
+    pre_delimitedfiles_pkg_julia = Pkg.Types.VersionSpec("1 - 1.8")
+    for version_range in keys(compat)
+        if version in Pkg.Types.VersionRange(version_range) && haskey(compat[version_range], "julia")
+            julia_compat = Pkg.Types.VersionSpec(compat[version_range]["julia"])
+            if !isempty(intersect(julia_compat, pre_delimitedfiles_pkg_julia))
+                return true
+            end
+        end
+    end
+    return false
+end
+
 function meets_compat_for_all_deps(working_directory::AbstractString, pkg, version)
     package_relpath = get_package_relpath_in_registry(;
         package_name=pkg, registry_path=working_directory
@@ -128,6 +141,7 @@ function meets_compat_for_all_deps(working_directory::AbstractString, pkg, versi
     # First, we construct a Dict in which the keys are the package's
     # dependencies, and the value is always false.
     dep_has_compat_with_upper_bound = Dict{String,Bool}()
+    delimitedfiles_requires_compat = requires_delimitedfiles_compat(compat, version)
     for version_range in keys(deps)
         if version in Pkg.Types.VersionRange(version_range)
             for name in keys(deps[version_range])
@@ -136,7 +150,12 @@ function meets_compat_for_all_deps(working_directory::AbstractString, pkg, versi
                     apply_compat_requirement = !is_jll_name(name)
                 else
                     debug_msg = "Found a new (non-stdlib non-JLL) dependency: $(name)"
-                    apply_compat_requirement = !is_jll_name(name) && !is_julia_stdlib(name)
+                    apply_compat_requirement =
+                        !is_jll_name(name) &&
+                        (
+                            !is_julia_stdlib(name) ||
+                            (name == "DelimitedFiles" && delimitedfiles_requires_compat)
+                        )
                 end
                 if apply_compat_requirement
                     @debug debug_msg

--- a/AutoMerge/test/automerge-unit.jl
+++ b/AutoMerge/test/automerge-unit.jl
@@ -613,6 +613,63 @@ end
 end
 
 @testset "Guidelines for new versions" begin
+    @testset "DelimitedFiles requires compat for pre-1.9 Julia support" begin
+        mktempdir() do tmp_registry
+            pkg_dir = joinpath(tmp_registry, "T", "TestPkg")
+            mkpath(pkg_dir)
+
+            write(joinpath(tmp_registry, "Registry.toml"), """
+            [packages]
+            87654321-4321-8765-cba9-987654321cba = { name = "TestPkg", path = "T/TestPkg" }
+            """)
+
+            write(joinpath(pkg_dir, "Package.toml"), """
+            name = "TestPkg"
+            uuid = "87654321-4321-8765-cba9-987654321cba"
+            repo = "https://github.com/test/TestPkg.jl.git"
+            """)
+
+            write(joinpath(pkg_dir, "Deps.toml"), """
+            ["1.0.0"]
+            DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+            """)
+
+            write(joinpath(pkg_dir, "Compat.toml"), """
+            ["1.0.0"]
+            julia = "1.6"
+            """)
+
+            result, message = AutoMerge.meets_compat_for_all_deps(
+                tmp_registry, "TestPkg", v"1.0.0"
+            )
+            @test !result
+            @test occursin("DelimitedFiles", message)
+
+            write(joinpath(pkg_dir, "Compat.toml"), """
+            ["1.0.0"]
+            julia = "1.6"
+            DelimitedFiles = "1.6"
+            """)
+
+            result, message = AutoMerge.meets_compat_for_all_deps(
+                tmp_registry, "TestPkg", v"1.0.0"
+            )
+            @test result
+            @test isempty(message)
+
+            write(joinpath(pkg_dir, "Compat.toml"), """
+            ["1.0.0"]
+            julia = "1.9"
+            """)
+
+            result, message = AutoMerge.meets_compat_for_all_deps(
+                tmp_registry, "TestPkg", v"1.0.0"
+            )
+            @test result
+            @test isempty(message)
+        end
+    end
+
     @testset "Sequential version number" begin
         @test AutoMerge.meets_sequential_version_number([v"0.0.1"], v"0.0.2")[1]
         @test AutoMerge.meets_sequential_version_number([v"0.1.0"], v"0.1.1")[1]


### PR DESCRIPTION
Closes #471.

This adds a targeted check for `DelimitedFiles`: when a package still supports Julia releases before `1.9`, `DelimitedFiles` must have an upper-bounded compat entry instead of being treated like an always-exempt stdlib. A regression test covers both the failing pre-`1.9` case and the post-`1.9` exemption.

Validation:
- `AUTOMERGE_RUN_INTEGRATION_TESTS=false julia --project=AutoMerge -e 'using Pkg; Pkg.test()'`
  - Reached and exercised the new `DelimitedFiles` compat path.
  - Then continued into the existing unrelated `juliaup`-driven package-install test path.

cc @DilumAluthge

🤖 Generated by Codex.
