### PR TITLE
RegistryCI: preserve nested formatting in roundtrip checks

### DIFF
--- a/RegistryCI/src/registry_testing.jl
+++ b/RegistryCI/src/registry_testing.jl
@@ -301,9 +301,11 @@ function _spacify_hyphens(dict::Dict{K, V}) where {K, V}
     for (k, v) in dict
         new_k = _spacify_hyphens(k)
         new_v = _spacify_hyphens(v)
+        new_dict[new_k] = new_v
     end
     return new_dict
 end
 
 _spacify_hyphens(range::Pkg.Types.VersionRange) = range
 _spacify_hyphens(ranges::Vector{Pkg.Types.VersionRange}) = ranges
+_spacify_hyphens(strings::Vector{String}) = _spacify_hyphens.(strings)

--- a/RegistryCI/test/registryci_registry_testing.jl
+++ b/RegistryCI/test/registryci_registry_testing.jl
@@ -44,6 +44,21 @@ if test_general
 end
 
 @testset "Synthetic tests" begin
+    @testset "_spacify_hyphens preserves nested formatting structure" begin
+        input = Dict(
+            "1-2" => Dict(
+                "3-4" => ["5-6", "7 - 8"],
+            ),
+        )
+        expected = Dict(
+            "1 - 2" => Dict(
+                "3 - 4" => ["5 - 6", "7 - 8"],
+            ),
+        )
+
+        @test RegistryCI._spacify_hyphens(input) == expected
+    end
+
     @testset "Yanked key validation" begin
         mktempdir() do tmpdir
             registry_dir = joinpath(tmpdir, "TestRegistry")


### PR DESCRIPTION
Closes #459.

This fixes the formatting-normalization helper used by the registry roundtrip tests so it actually recurses through nested dictionaries and vectors of strings. That makes the consistency checks sensitive to the nested formatting style they were intended to preserve, and adds a focused regression test for the helper itself.

Validation:
- `julia --project=RegistryCI -e 'using Pkg; Pkg.test(test_args=["false"])'`

cc @DilumAluthge

🤖 Generated by Codex.
