### PR TITLE
AutoMerge: reject compat changes across build bumps

### DIFF
--- a/AutoMerge/src/guidelines.jl
+++ b/AutoMerge/src/guidelines.jl
@@ -240,6 +240,70 @@ function meets_patch_release_does_not_narrow_julia_compat(
     end
 end
 
+const guideline_build_release_does_not_change_compat = Guideline(;
+    info="If it is a build-number release, then it does not change compat bounds for previous build releases with the same major.minor.patch.",
+    check=data -> meets_build_release_does_not_change_compat(
+        data.pkg,
+        data.version;
+        registry_head=data.registry_head,
+        registry_master=data.registry_master,
+    ),
+)
+
+function _same_release_line_ignoring_build(a::VersionNumber, b::VersionNumber)
+    return a.major == b.major && a.minor == b.minor && a.patch == b.patch
+end
+
+function compat_for_version(pkg::String, version::VersionNumber, registry_path::String)
+    package_relpath = get_package_relpath_in_registry(;
+        package_name=pkg, registry_path=registry_path
+    )
+    compat = parse_registry_toml(registry_path, package_relpath, "Compat.toml"; allow_missing = true)
+    result = Dict{String,Any}()
+    for version_range in keys(compat)
+        if version in Pkg.Types.VersionRange(version_range)
+            for (name, value) in compat[version_range]
+                result[name] = value
+            end
+        end
+    end
+    return result
+end
+
+function meets_build_release_does_not_change_compat(
+    pkg::String, new_version::VersionNumber; registry_head::String, registry_master::String
+)
+    isempty(new_version.build) && return true, ""
+    previous_build_versions = filter(
+        old_version ->
+            _same_release_line_ignoring_build(old_version, new_version) &&
+            !isempty(old_version.build),
+        all_versions(pkg, registry_master),
+    )
+    isempty(previous_build_versions) && return true, ""
+
+    previous_build_version = maximum(previous_build_versions)
+    old_compat = compat_for_version(pkg, previous_build_version, registry_master)
+    new_compat = compat_for_version(pkg, new_version, registry_head)
+    if old_compat == new_compat
+        return true, ""
+    end
+
+    msg = string(
+        "A build-number release is not allowed to change compat bounds for previous build releases with the same major.minor.patch. ",
+        "The compat entries have changed from ",
+        repr(old_compat),
+        " (in ",
+        previous_build_version,
+        ") to ",
+        repr(new_compat),
+        " (in ",
+        new_version,
+        ").",
+    )
+    return false, msg
+end
+
 const _AUTOMERGE_NEW_PACKAGE_MINIMUM_NAME_LENGTH = 5
 
 const guideline_name_length = Guideline(;
@@ -1381,6 +1445,10 @@ function get_automerge_guidelines(
         (guideline_compat_for_all_deps, true),
         (
             guideline_patch_release_does_not_narrow_julia_compat,
+            !this_pr_can_use_special_jll_exceptions,
+        ),
+        (
+            guideline_build_release_does_not_change_compat,
             !this_pr_can_use_special_jll_exceptions,
         ),
         (guideline_allowed_jll_nonrecursive_dependencies, this_is_jll_package),

--- a/AutoMerge/test/automerge-unit.jl
+++ b/AutoMerge/test/automerge-unit.jl
@@ -695,6 +695,72 @@ end
         @test !AutoMerge.range_did_not_narrow(r3, r2)[1]
     end
 
+    @testset "Build releases cannot change compat bounds" begin
+        mktempdir() do tmp_registry
+            pkg_dir = joinpath(tmp_registry, "M", "MicrosoftMPI_jll")
+            mkpath(pkg_dir)
+
+            write(joinpath(tmp_registry, "Registry.toml"), """
+            [packages]
+            87654321-4321-8765-cba9-987654321cba = { name = "MicrosoftMPI_jll", path = "M/MicrosoftMPI_jll" }
+            """)
+
+            write(joinpath(pkg_dir, "Package.toml"), """
+            name = "MicrosoftMPI_jll"
+            uuid = "87654321-4321-8765-cba9-987654321cba"
+            repo = "https://github.com/test/MicrosoftMPI_jll.jl.git"
+            """)
+
+            write(joinpath(pkg_dir, "Versions.toml"), """
+            ["10.2.1+4"]
+            git-tree-sha1 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+            ["10.2.1+5"]
+            git-tree-sha1 = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+            """)
+
+            write(joinpath(pkg_dir, "Compat.toml"), """
+            ["10.2.1+4"]
+            julia = "1.6"
+            JLLWrappers = "1"
+
+            ["10.2.1+5"]
+            julia = "1.6"
+            JLLWrappers = "1"
+            """)
+
+            result, message = AutoMerge.meets_build_release_does_not_change_compat(
+                "MicrosoftMPI_jll",
+                v"10.2.1+5";
+                registry_head=tmp_registry,
+                registry_master=tmp_registry,
+            )
+            @test result
+            @test isempty(message)
+
+            master_registry = mktempdir()
+            cp(tmp_registry, master_registry; force=true)
+            write(joinpath(tmp_registry, "M", "MicrosoftMPI_jll", "Compat.toml"), """
+            ["10.2.1+4"]
+            julia = "1.6"
+            JLLWrappers = "1"
+
+            ["10.2.1+5"]
+            julia = "1.6"
+            JLLWrappers = "1.2"
+            """)
+
+            result, message = AutoMerge.meets_build_release_does_not_change_compat(
+                "MicrosoftMPI_jll",
+                v"10.2.1+5";
+                registry_head=tmp_registry,
+                registry_master=master_registry,
+            )
+            @test !result
+            @test occursin("build-number release", message)
+        end
+    end
+
     @testset "Breaking change releases must have explanatory release notes" begin
         body_good = """
         <!-- BEGIN RELEASE NOTES -->


### PR DESCRIPTION
Closes #347.

This adds a new AutoMerge check for build-number releases: when a new version only changes the `+X` build suffix, it may not change the effective compat bounds relative to the previous build-tagged release with the same major.minor.patch. The PR includes a synthetic registry test covering both the allowed identical-compat case and the rejected changed-compat case.

Validation:
- `AUTOMERGE_RUN_INTEGRATION_TESTS=false julia --project=AutoMerge -e 'using Pkg; Pkg.test()'`
  - Reached the unit test suite with the new build-bump compat regression before the existing unrelated long-running `AutoMerge` tail.

cc @DilumAluthge

🤖 Generated by Codex.
