### PR TITLE
Add whole-repo typo-check CI job and fix reported typos

### DIFF
--- a/.github/workflows/ci_unit.yml
+++ b/.github/workflows/ci_unit.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: crate-ci/typos@80c8a4945eec0f6d464eaf9e65ed98ef085283d1 # v1.38.1
 
   registryci-unit:

--- a/.github/workflows/ci_unit.yml
+++ b/.github/workflows/ci_unit.yml
@@ -15,7 +15,6 @@ env:
 jobs:
 
   typos:
-    name: Typos
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci_unit.yml
+++ b/.github/workflows/ci_unit.yml
@@ -12,6 +12,9 @@ env:
   JULIA_PKG_UNPACK_REGISTRY: 'true'
   JULIA_PKG_USE_CLI_GIT: 'true'
 
+permissions:
+  contents: read
+
 jobs:
 
   typos:

--- a/.github/workflows/ci_unit.yml
+++ b/.github/workflows/ci_unit.yml
@@ -14,6 +14,13 @@ env:
 
 jobs:
 
+  typos:
+    name: Typos
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: crate-ci/typos@80c8a4945eec0f6d464eaf9e65ed98ef085283d1 # v1.38.1
+
   registryci-unit:
     name: RegistryCI Unit/Julia ${{ matrix.version }}/${{ matrix.os }}/${{ matrix.arch }}
     runs-on: ${{ matrix.os }}

--- a/AutoMerge/src/package_path_in_registry.jl
+++ b/AutoMerge/src/package_path_in_registry.jl
@@ -25,7 +25,7 @@ end
 # What the relative path of the package *should* be, in theory.
 # This function should ONLY be used in the
 # "PR only changes a subset of the allowed files" check.
-# For all other uses, you shoud use the `get_package_relpath_in_registry`
+# For all other uses, you should use the `get_package_relpath_in_registry`
 # function instead.
 function _get_package_relpath_per_name_scheme(; package_name::String)
     return RegistryTools.package_relpath(package_name)

--- a/RegistryCI/src/registry_testing.jl
+++ b/RegistryCI/src/registry_testing.jl
@@ -283,7 +283,7 @@ function test(path=pwd(); registry_deps::Vector{<:AbstractString}=String[])
     return nothing
 end
 
-# Change all occurences of "digit-digit" to "digit - digit"
+# Change all occurrences of "digit-digit" to "digit - digit"
 function _spacify_hyphens(str::AbstractString)
     r = r"(\d)-(\d)"
     s = s"\1 - \2"

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,4 @@
+[default]
+extend-ignore-identifiers-re = [
+    "_spacify_hyphens",
+]


### PR DESCRIPTION
## Summary
- add a GitHub Actions job to run `typos` across the whole repository
- pin the `crate-ci/typos` action to the full commit SHA for `v1.38.1`
- whitelist the intentional `_spacify_hyphens` identifier in its own follow-up commit
- fix the remaining source comment typos in `RegistryCI` and `AutoMerge`

🤖 Generated by Codex.