### PR TITLE
AutoMerge: require test/runtests.jl for new packages

### DIFF
--- a/AutoMerge/src/guidelines.jl
+++ b/AutoMerge/src/guidelines.jl
@@ -951,6 +951,21 @@ const guideline_src_names_OK = Guideline(;
     check=data -> meets_src_names_ok(data.pkg_code_path),
 )
 
+const guideline_has_runtests = Guideline(;
+    info="Package has `test/runtests.jl`",
+    docs="New packages must include a `test/runtests.jl` file.",
+    check=data -> meets_has_runtests(data.pkg_code_path),
+)
+
+function meets_has_runtests(pkg_code_path::String)
+    runtests = joinpath(pkg_code_path, "test", "runtests.jl")
+    if isfile(runtests)
+        return true, ""
+    else
+        return false, "New packages must include a `test/runtests.jl` file."
+    end
+end
+
 function meets_code_can_be_downloaded(registry_head, pkg, version, pr; pkg_code_path, pkg_clone_dir)
     uuid, package_repo, subdir, tree_hash_from_toml = parse_registry_pkg_info(
         registry_head, pkg, version
@@ -1341,6 +1356,7 @@ function get_automerge_guidelines(
         # after `guideline_code_can_be_downloaded` so
         # that it can use the downloaded code!
         (guideline_version_has_osi_license, check_license),
+        (guideline_has_runtests, true),
         (guideline_src_names_OK, true),
         (guideline_version_can_be_imported, true),
         (:update_status, true),

--- a/AutoMerge/test/automerge-unit.jl
+++ b/AutoMerge/test/automerge-unit.jl
@@ -349,6 +349,19 @@ end
         @test !AutoMerge.perform_distance_check([GitHub.Label(; name="Override AutoMerge: name similarity is okay")])
         @test !AutoMerge.perform_distance_check([GitHub.Label(; name="hi"), GitHub.Label(; name="Override AutoMerge: name similarity is okay")])
     end
+    @testset "New packages must have test/runtests.jl" begin
+        mktempdir() do pkgdir
+            mkpath(joinpath(pkgdir, "test"))
+            result, message = AutoMerge.meets_has_runtests(pkgdir)
+            @test !result
+            @test occursin("test/runtests.jl", message)
+
+            write(joinpath(pkgdir, "test", "runtests.jl"), "using Test\n")
+            result, message = AutoMerge.meets_has_runtests(pkgdir)
+            @test result
+            @test isempty(message)
+        end
+    end
     @testset "has_author_approved_label" begin
         @test !AutoMerge.has_package_author_approved_label(nothing)
         @test !AutoMerge.has_package_author_approved_label([GitHub.Label(; name="hi")])


### PR DESCRIPTION
Closes #313.

This adds a new-package guideline that requires a `test/runtests.jl` file after the package source has been downloaded, and includes unit coverage for both the missing-file and present-file cases.

Validation:
- `AUTOMERGE_RUN_INTEGRATION_TESTS=false julia --project=AutoMerge -e 'using Pkg; Pkg.test()'`
  - Reached the unit test suite with the new `test/runtests.jl` regression before the existing unrelated long-running `AutoMerge` tail.

cc @DilumAluthge

🤖 Generated by Codex.
