### PR TITLE
RegistryCI: reject stray package directories

### DIFF
--- a/RegistryCI/src/registry_testing.jl
+++ b/RegistryCI/src/registry_testing.jl
@@ -278,6 +278,19 @@ function test(path=pwd(); registry_deps::Vector{<:AbstractString}=String[])
                 )
                 @test length(i_parts) == length(i_parts′)
             end
+
+            # Make sure there are no package directories on disk that are missing from Registry.toml
+            expected_package_dirs = Set{String}(normpath(data["path"]) for (_, data) in reg["packages"])
+            actual_package_dirs = Set{String}()
+            for (root, _, files) in walkdir(path)
+                if basename(root) == ".git"
+                    continue
+                end
+                if "Package.toml" in files
+                    push!(actual_package_dirs, normpath(relpath(root, path)))
+                end
+            end
+            @test actual_package_dirs == expected_package_dirs
         end
     end
     return nothing

--- a/RegistryCI/src/registry_testing.jl
+++ b/RegistryCI/src/registry_testing.jl
@@ -280,6 +280,7 @@ function test(path=pwd(); registry_deps::Vector{<:AbstractString}=String[])
             end
 
             # Make sure there are no package directories on disk that are missing from Registry.toml
+            # https://github.com/JuliaRegistries/RegistryCI.jl/issues/310
             expected_package_dirs = Set{String}(normpath(data["path"]) for (_, data) in reg["packages"])
             actual_package_dirs = Set{String}()
             for (root, _, files) in walkdir(path)


### PR DESCRIPTION
Fixes #310.

This adds a registry consistency check that the on-disk package directories are exactly the ones listed in `Registry.toml`.

cc @DilumAluthge

🤖 Generated by Codex.
