### PR TITLE
RegistryCI: Add per-version compat consistency checks

### DIFF
--- a/RegistryCI/src/registry_testing.jl
+++ b/RegistryCI/src/registry_testing.jl
@@ -135,6 +135,49 @@ function load_compat(compatfile, versions)
     return r
 end
 
+function check_compat_entries_have_matching_deps(
+    vnums::Vector{VersionNumber},
+    deps_by_version::Dict{VersionNumber,Dict{String,Base.UUID}},
+    compat_by_version::Dict{VersionNumber,Dict{String,Pkg.Types.VersionSpec}},
+)
+    for version in vnums
+        compat_names = Set(keys(get(compat_by_version, version, Dict{String,Pkg.Types.VersionSpec}())))
+        dep_names = Set(keys(get(deps_by_version, version, Dict{String,Base.UUID}())))
+        push!(dep_names, "julia") # All packages have an implicit dependency on julia
+        if !(compat_names ⊆ dep_names)
+            invalid_names = sort!(collect(setdiff(compat_names, dep_names)))
+            throw(
+                ErrorException(
+                    "Compat entries must match active dependencies for version $(version). " *
+                    "Invalid compat entries: $(join(invalid_names, ", "))."
+                ),
+            )
+        end
+    end
+    return nothing
+end
+
+function load_package_data_if_present(::Type{T}, path::String, versions::Vector{VersionNumber}) where {T}
+    if isfile(path)
+        return load_package_data(T, path, versions)
+    end
+    return Dict{VersionNumber,Dict{String,T}}()
+end
+
+function merge_dep_data(
+    deps_by_version::Dict{VersionNumber,Dict{String,Base.UUID}},
+    weakdeps_by_version::Dict{VersionNumber,Dict{String,Base.UUID}},
+)
+    merged = copy(deps_by_version)
+    for (version, weakdeps) in weakdeps_by_version
+        version_deps = get!(() -> Dict{String,Base.UUID}(), merged, version)
+        merge!(version_deps, weakdeps)
+    end
+    return merged
+end
+
+is_jll_package(name::AbstractString) = endswith(name, "_jll")
+
 """
     test(path)
 
@@ -147,7 +190,10 @@ If your registry has packages that have dependencies that are registered in othe
 registries elsewhere, then you may provide the github urls for those registries
 using the `registry_deps` parameter.
 """
-function test(path=pwd(); registry_deps::Vector{<:AbstractString}=String[])
+function test(
+    path=pwd();
+    registry_deps::Vector{<:AbstractString}=String[],
+)
     @testset "(Registry|Package|Versions|Deps|Compat).toml" begin
         cd(path) do
             reg = Pkg.TOML.parsefile("Registry.toml")
@@ -221,23 +267,6 @@ function test(path=pwd(); registry_deps::Vector{<:AbstractString}=String[])
                 if isfile(compatfile)
                     compat = Pkg.TOML.parsefile(compatfile)
 
-                    # Test that all names with compat is a dependency
-                    compatnames = Set{String}(x for (_, d) in compat for (x, _) in d)
-                    if !(
-                        isempty(compatnames) ||
-                        (length(compatnames) == 1 && "julia" in compatnames)
-                    )
-                        depnames = Set{String}(
-                            x for (_, d) in Pkg.TOML.parsefile(depsfile) for (x, _) in d
-                        )
-                        push!(depnames, "julia") # All packages has an implicit dependency on julia
-                        if !(compatnames ⊆ depnames)
-                            throw(
-                                ErrorException("Assertion failed: compatnames ⊆ depnames")
-                            )
-                        end
-                    end
-
                     # Make sure that each compat spec is a valid registry compat spec.
                     # https://github.com/JuliaRegistries/General/issues/104849
                     for (versionrange, compatinfo) in pairs(compat)
@@ -251,6 +280,22 @@ function test(path=pwd(); registry_deps::Vector{<:AbstractString}=String[])
 
                     # Test that the way Pkg loads this data works
                     @test load_compat(compatfile, vnums)
+                    if !is_jll_package(pkg["name"])
+                        deps_by_version = load_package_data_if_present(
+                            Base.UUID, depsfile, vnums
+                        )
+                        weakdeps_by_version = load_package_data_if_present(
+                            Base.UUID, abspath(data["path"], "WeakDeps.toml"), vnums
+                        )
+                        compat_by_version = load_package_data(
+                            Pkg.Types.VersionSpec, compatfile, vnums
+                        )
+                        check_compat_entries_have_matching_deps(
+                            vnums,
+                            merge_dep_data(deps_by_version, weakdeps_by_version),
+                            compat_by_version,
+                        )
+                    end
                     # Make sure the content roundtrips through decompression/compression.
                     # However, before we check for equality, we change the compat ranges
                     # from `String`s to `VersionRanges`.

--- a/RegistryCI/test/registryci_registry_testing.jl
+++ b/RegistryCI/test/registryci_registry_testing.jl
@@ -9,6 +9,36 @@ using Test
 using TimeZones
 using MetaTesting: fails
 
+function write_test_registry!(registry_dir; versions_toml, deps_toml=nothing, compat_toml=nothing)
+    mkpath(registry_dir)
+    write(joinpath(registry_dir, "Registry.toml"), """
+        name = "TestRegistry"
+        uuid = "12345678-1234-5678-9abc-123456789abc"
+        repo = "https://github.com/test/TestRegistry.git"
+
+        [packages]
+        87654321-4321-8765-cba9-987654321cba = { name = "TestPkg", path = "T/TestPkg" }
+        """)
+
+    pkg_dir = joinpath(registry_dir, "T", "TestPkg")
+    mkpath(pkg_dir)
+
+    write(joinpath(pkg_dir, "Package.toml"), """
+        name = "TestPkg"
+        uuid = "87654321-4321-8765-cba9-987654321cba"
+        repo = "https://github.com/test/TestPkg.git"
+        """)
+
+    write(joinpath(pkg_dir, "Versions.toml"), versions_toml)
+    if deps_toml !== nothing
+        write(joinpath(pkg_dir, "Deps.toml"), deps_toml)
+    end
+    if compat_toml !== nothing
+        write(joinpath(pkg_dir, "Compat.toml"), compat_toml)
+    end
+    return pkg_dir
+end
+
 # Testing with General can be quite slow. We do it by default,
 # but locally you can run
 # julia --project -e 'using Pkg; Pkg.test(test_args=["false"])'
@@ -47,31 +77,14 @@ end
     @testset "Yanked key validation" begin
         mktempdir() do tmpdir
             registry_dir = joinpath(tmpdir, "TestRegistry")
-            mkpath(registry_dir)
-
-            write(joinpath(registry_dir, "Registry.toml"), """
-                name = "TestRegistry"
-                uuid = "12345678-1234-5678-9abc-123456789abc"
-                repo = "https://github.com/test/TestRegistry.git"
-
-                [packages]
-                87654321-4321-8765-cba9-987654321cba = { name = "TestPkg", path = "T/TestPkg" }
-                """)
-
-            pkg_dir = joinpath(registry_dir, "T", "TestPkg")
-            mkpath(pkg_dir)
-
-            write(joinpath(pkg_dir, "Package.toml"), """
-                name = "TestPkg"
-                uuid = "87654321-4321-8765-cba9-987654321cba"
-                repo = "https://github.com/test/TestPkg.git"
-                """)
-
-            write(joinpath(pkg_dir, "Versions.toml"), """
+            pkg_dir = write_test_registry!(
+                registry_dir;
+                versions_toml="""
                 ["1.0.0"]
                 git-tree-sha1 = "abcdef0123456789abcdef0123456789abcdef01"
                 yanked = true
-                """)
+                """,
+            )
 
             @test RegistryCI.test(registry_dir) === nothing
 
@@ -88,6 +101,84 @@ end
                     end
                 end
             end
+        end
+    end
+
+    @testset "Compat entries must match active dependencies per version" begin
+        mktempdir() do tmpdir
+            registry_dir = joinpath(tmpdir, "TestRegistry")
+            pkg_dir = write_test_registry!(
+                registry_dir;
+                versions_toml="""
+                ["1.0.0"]
+                git-tree-sha1 = "abcdef0123456789abcdef0123456789abcdef01"
+
+                ["1.1.0"]
+                git-tree-sha1 = "0123456789abcdef0123456789abcdef01234567"
+                """,
+                deps_toml="""
+                ["1.1.0"]
+                Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+                """,
+                compat_toml="""
+                ["1.0.0-1.1.0"]
+                Dates = "1"
+                julia = "1"
+                """,
+            )
+
+            vers = Pkg.TOML.parsefile(joinpath(pkg_dir, "Versions.toml"))
+            vnums = VersionNumber.(keys(vers))
+            deps_by_version = RegistryCI.load_package_data(
+                Base.UUID, joinpath(pkg_dir, "Deps.toml"), vnums
+            )
+            compat_by_version = RegistryCI.load_package_data(
+                Pkg.Types.VersionSpec, joinpath(pkg_dir, "Compat.toml"), vnums
+            )
+
+            @test_throws ErrorException RegistryCI.check_compat_entries_have_matching_deps(
+                vnums, deps_by_version, compat_by_version
+            )
+        end
+    end
+
+    @testset "Compat entries may be narrower than the dependency's total range" begin
+        mktempdir() do tmpdir
+            registry_dir = joinpath(tmpdir, "TestRegistry")
+            pkg_dir = write_test_registry!(
+                registry_dir;
+                versions_toml="""
+                ["1.0.0"]
+                git-tree-sha1 = "abcdef0123456789abcdef0123456789abcdef01"
+
+                ["1.1.0"]
+                git-tree-sha1 = "0123456789abcdef0123456789abcdef01234567"
+                """,
+                deps_toml="""
+                ["1.1.0"]
+                Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+                """,
+                compat_toml="""
+                ["1.0.0-1.1.0"]
+                julia = "1"
+
+                ["1.1.0"]
+                Dates = "1"
+                """,
+            )
+
+            vers = Pkg.TOML.parsefile(joinpath(pkg_dir, "Versions.toml"))
+            vnums = VersionNumber.(keys(vers))
+            deps_by_version = RegistryCI.load_package_data(
+                Base.UUID, joinpath(pkg_dir, "Deps.toml"), vnums
+            )
+            compat_by_version = RegistryCI.load_package_data(
+                Pkg.Types.VersionSpec, joinpath(pkg_dir, "Compat.toml"), vnums
+            )
+            @test RegistryCI.check_compat_entries_have_matching_deps(
+                vnums, deps_by_version, compat_by_version
+            ) === nothing
+            @test RegistryCI.test(registry_dir) === nothing
         end
     end
 end


### PR DESCRIPTION
@DilumAluthge

## Summary
- add a per-version compat consistency check for non-`_jll` packages in `RegistryCI.test`
- treat `WeakDeps.toml` entries as active dependencies for this check
- add regression coverage for compat ranges that incorrectly extend beyond the dependency range

Fixes #99.

🤖 Generated by Codex.
