### PR TITLE
AutoMerge: validate Artifacts.toml tree hashes

### DIFF
--- a/AutoMerge/src/guidelines.jl
+++ b/AutoMerge/src/guidelines.jl
@@ -888,6 +888,223 @@ const guideline_code_can_be_downloaded = Guideline(;
     ),
 )
 
+const guideline_artifacts_toml_check = Guideline(;
+    info="Artifacts.toml download verification.",
+    docs="Checks that each downloadable entry in `Artifacts.toml` has a `git-tree-sha1` that matches at least one declared download source.",
+    check=data -> meets_artifacts_toml_check(data.pkg_code_path),
+)
+
+function _artifact_variant_context(name::AbstractString, index::Int, total::Int)
+    total == 1 && return "Artifacts.toml entry `$(name)`"
+    return "Artifacts.toml entry `$(name)` variant $(index)"
+end
+
+function _artifact_download_context(
+    name::AbstractString, variant_index::Int, variant_total::Int, download_index::Int
+)
+    return string(
+        _artifact_variant_context(name, variant_index, variant_total),
+        " download $(download_index)",
+    )
+end
+
+function _artifact_variants(artifact_name::AbstractString, value)
+    if value isa AbstractDict
+        return Any[value]
+    elseif value isa AbstractVector
+        return Any[value...]
+    end
+    throw(
+        ArgumentError(
+            "Artifacts.toml entry `$(artifact_name)` must be a table or array of tables.",
+        ),
+    )
+end
+
+function _artifact_downloads(
+    artifact_name::AbstractString, variant_index::Int, variant_total::Int, value
+)
+    if value isa AbstractDict
+        return Any[value]
+    elseif value isa AbstractVector
+        return Any[value...]
+    end
+    throw(
+        ArgumentError(
+            string(
+                _artifact_variant_context(artifact_name, variant_index, variant_total),
+                " has an invalid `download` section.",
+            ),
+        ),
+    )
+end
+
+function _artifact_tree_hash(
+    artifact_name::AbstractString,
+    variant_index::Int,
+    variant_total::Int,
+    variant::AbstractDict,
+)
+    tree_hash_str = get(variant, "git-tree-sha1", nothing)
+    if !(tree_hash_str isa AbstractString)
+        throw(
+            ArgumentError(
+                string(
+                    _artifact_variant_context(artifact_name, variant_index, variant_total),
+                    " is missing a string `git-tree-sha1`.",
+                ),
+            ),
+        )
+    end
+    try
+        return Base.SHA1(tree_hash_str), tree_hash_str
+    catch err
+        throw(
+            ArgumentError(
+                string(
+                    _artifact_variant_context(artifact_name, variant_index, variant_total),
+                    " has an invalid `git-tree-sha1` `",
+                    tree_hash_str,
+                    "`: ",
+                    sprint(showerror, err),
+                ),
+            ),
+        )
+    end
+end
+
+function _validate_artifact_variant_downloads(
+    artifact_name::AbstractString,
+    variant::AbstractDict,
+    variant_index::Int,
+    variant_total::Int,
+)
+    downloads = get(variant, "download", nothing)
+    downloads === nothing && return nothing
+
+    normalized_downloads = _artifact_downloads(
+        artifact_name, variant_index, variant_total, downloads
+    )
+    isempty(normalized_downloads) && return nothing
+
+    tree_hash, tree_hash_str = _artifact_tree_hash(
+        artifact_name, variant_index, variant_total, variant
+    )
+    errors = String[]
+    for (download_index, download) in enumerate(normalized_downloads)
+        if !(download isa AbstractDict)
+            throw(
+                ArgumentError(
+                    string(
+                        _artifact_download_context(
+                            artifact_name, variant_index, variant_total, download_index
+                        ),
+                        " must be a table.",
+                    ),
+                ),
+            )
+        end
+        url = get(download, "url", nothing)
+        sha256 = get(download, "sha256", nothing)
+        if !(url isa AbstractString)
+            throw(
+                ArgumentError(
+                    string(
+                        _artifact_download_context(
+                            artifact_name, variant_index, variant_total, download_index
+                        ),
+                        " is missing a string `url`.",
+                    ),
+                ),
+            )
+        end
+        if !(sha256 isa AbstractString)
+            throw(
+                ArgumentError(
+                    string(
+                        _artifact_download_context(
+                            artifact_name, variant_index, variant_total, download_index
+                        ),
+                        " is missing a string `sha256`.",
+                    ),
+                ),
+            )
+        end
+
+        try
+            result = Pkg.Artifacts.download_artifact(
+                tree_hash, url, sha256; quiet_download=true
+            )
+            if result === true
+                return nothing
+            elseif result isa Exception
+                push!(errors, sprint(showerror, result))
+            else
+                push!(errors, sprint(show, result))
+            end
+        catch err
+            push!(errors, sprint(showerror, err))
+        end
+    end
+
+    throw(
+        ErrorException(
+            string(
+                _artifact_variant_context(artifact_name, variant_index, variant_total),
+                " has no download source matching `git-tree-sha1` `",
+                tree_hash_str,
+                "`. Errors: ",
+                join(errors, " | "),
+            ),
+        ),
+    )
+end
+
+function meets_artifacts_toml_check(pkg_code_path::AbstractString)
+    artifacts_toml_path = joinpath(pkg_code_path, "Artifacts.toml")
+    isfile(artifacts_toml_path) || return true, ""
+
+    parsed = TOML.tryparsefile(artifacts_toml_path)
+    if parsed isa TOML.ParserError
+        return false, "Artifacts.toml could not be parsed: $(parsed)"
+    end
+
+    depot_sep = Sys.iswindows() ? ";" : ":"
+    try
+        mktempdir() do tmp_depot
+            withenv(
+                "JULIA_DEPOT_PATH" => tmp_depot * depot_sep,
+                "JULIA_PKG_SERVER" => "",
+            ) do
+                for (artifact_name, value) in pairs(parsed)
+                    variants = _artifact_variants(artifact_name, value)
+                    for (variant_index, variant) in enumerate(variants)
+                        if !(variant isa AbstractDict)
+                            throw(
+                                ArgumentError(
+                                    string(
+                                        _artifact_variant_context(
+                                            artifact_name, variant_index, length(variants)
+                                        ),
+                                        " must be a table.",
+                                    ),
+                                ),
+                            )
+                        end
+                        _validate_artifact_variant_downloads(
+                            artifact_name, variant, variant_index, length(variants)
+                        )
+                    end
+                end
+            end
+        end
+    catch err
+        return false, sprint(showerror, err)
+    end
+
+    return true, ""
+end
+
 function _find_lowercase_duplicates(v)
     elts = Dict{String, String}()
     for x in v
@@ -1337,6 +1554,7 @@ function get_automerge_guidelines(
         (:update_status, true),
         (guideline_version_can_be_pkg_added, true),
         (guideline_code_can_be_downloaded, true),
+        (guideline_artifacts_toml_check, true),
         # `guideline_version_has_osi_license` must be run
         # after `guideline_code_can_be_downloaded` so
         # that it can use the downloaded code!
@@ -1387,6 +1605,7 @@ function get_automerge_guidelines(
         (:update_status, true),
         (guideline_version_can_be_pkg_added, true),
         (guideline_code_can_be_downloaded, true),
+        (guideline_artifacts_toml_check, true),
         # `guideline_version_has_osi_license` must be run
         # after `guideline_code_can_be_downloaded` so
         # that it can use the downloaded code!

--- a/AutoMerge/test/automerge-unit.jl
+++ b/AutoMerge/test/automerge-unit.jl
@@ -5,6 +5,8 @@ using JSON
 using Pkg
 using Printf
 using AutoMerge
+using SHA
+using Tar
 using Test
 using TimeZones
 
@@ -27,6 +29,29 @@ function setup_global_depot()::String
     run(setenv(`julia -e 'import Pkg; Pkg.add(["RegistryCI"])'`, env1))
     TEMP_DEPOT_FOR_TESTING = tmp_depot
     tmp_depot
+end
+
+function create_test_artifact_archive(; files::Dict{String,String})
+    tmpdir = mktempdir()
+    src_dir = joinpath(tmpdir, "src")
+    mkpath(src_dir)
+    for (relative_path, contents) in files
+        absolute_path = joinpath(src_dir, relative_path)
+        mkpath(dirname(absolute_path))
+        write(absolute_path, contents)
+    end
+    tar_path = joinpath(tmpdir, "artifact.tar")
+    Tar.create(src_dir, tar_path)
+    tar_gz_path = joinpath(tmpdir, "artifact.tar.gz")
+    open(tar_gz_path, "w") do io
+        run(pipeline(Cmd(["gzip", "-n", "-c", tar_path]), stdout=io))
+    end
+    return (
+        tmpdir=tmpdir,
+        tar_gz_path=tar_gz_path,
+        sha256=bytes2hex(open(sha256, tar_gz_path)),
+        tree_hash=string(Tar.tree_hash(tar_path)),
+    )
 end
 
 # Helper function to create a mock GitHub.PullRequest with only essential fields
@@ -1138,6 +1163,94 @@ end
             rm(joinpath(pkg_path, "LICENSE"))
             result = has_osi_license_in_depot("VisualStringDistances")
             @test !result[1]
+        end
+    end
+    @testset "`AutoMerge.meets_artifacts_toml_check`" begin
+        mktempdir() do pkg_dir
+            @test AutoMerge.meets_artifacts_toml_check(pkg_dir) == (true, "")
+        end
+
+        archive = create_test_artifact_archive(; files=Dict("file.txt" => "hello\n"))
+        try
+            mktempdir() do pkg_dir
+                write(
+                    joinpath(pkg_dir, "Artifacts.toml"),
+                    """
+                    [example]
+                    git-tree-sha1 = "$(archive.tree_hash)"
+                        [[example.download]]
+                        url = "file://$(archive.tar_gz_path)"
+                        sha256 = "$(archive.sha256)"
+                    """,
+                )
+                @test AutoMerge.meets_artifacts_toml_check(pkg_dir) == (true, "")
+            end
+
+            mktempdir() do pkg_dir
+                write(
+                    joinpath(pkg_dir, "Artifacts.toml"),
+                    """
+                    [example]
+                    git-tree-sha1 = "0000000000000000000000000000000000000000"
+                        [[example.download]]
+                        url = "file://$(archive.tar_gz_path)"
+                        sha256 = "$(archive.sha256)"
+                    """,
+                )
+                ok, msg = AutoMerge.meets_artifacts_toml_check(pkg_dir)
+                @test !ok
+                @test occursin("Artifacts.toml entry `example`", msg)
+                @test occursin("has no download source matching", msg)
+            end
+
+            mktempdir() do pkg_dir
+                write(joinpath(pkg_dir, "Artifacts.toml"), "[example\n")
+                ok, msg = AutoMerge.meets_artifacts_toml_check(pkg_dir)
+                @test !ok
+                @test occursin("Artifacts.toml could not be parsed", msg)
+            end
+
+            mktempdir() do pkg_dir
+                write(
+                    joinpath(pkg_dir, "Artifacts.toml"),
+                    """
+                    [example]
+                    git-tree-sha1 = "not-a-sha1"
+                        [[example.download]]
+                        url = "file://$(archive.tar_gz_path)"
+                        sha256 = "$(archive.sha256)"
+                    """,
+                )
+                ok, msg = AutoMerge.meets_artifacts_toml_check(pkg_dir)
+                @test !ok
+                @test occursin("invalid `git-tree-sha1`", msg)
+            end
+
+            mktempdir() do pkg_dir
+                write(
+                    joinpath(pkg_dir, "Artifacts.toml"),
+                    """
+                    [[multi]]
+                    os = "linux"
+                    arch = "x86_64"
+                    git-tree-sha1 = "$(archive.tree_hash)"
+                        [[multi.download]]
+                        url = "file:///does/not/exist/artifact.tar.gz"
+                        sha256 = "$(archive.sha256)"
+                        [[multi.download]]
+                        url = "file://$(archive.tar_gz_path)"
+                        sha256 = "$(archive.sha256)"
+
+                    [[multi]]
+                    os = "macos"
+                    arch = "aarch64"
+                    git-tree-sha1 = "1111111111111111111111111111111111111111"
+                    """,
+                )
+                @test AutoMerge.meets_artifacts_toml_check(pkg_dir) == (true, "")
+            end
+        finally
+            rm(archive.tmpdir; force=true, recursive=true)
         end
     end
     @testset "Config TOML functionality" begin


### PR DESCRIPTION
Fixes #481.

This adds an AutoMerge guideline that validates `Artifacts.toml` download entries against their declared `git-tree-sha1` values during registration checks.

cc @DilumAluthge
🤖 Generated by Codex.
