### PR TITLE
AutoMerge: require breaking bumps for removed exports

### DIFF
--- a/AutoMerge/src/guidelines.jl
+++ b/AutoMerge/src/guidelines.jl
@@ -539,6 +539,63 @@ function get_release_notes(body::AbstractString)
     return m === nothing ? nothing : m.captures[1]
 end
 
+const guideline_removed_exports_requires_breaking_bump = Guideline(;
+    info = "Removing exports requires a breaking version bump.",
+    docs = "If a release removes exported names from the previous release, then it must use a breaking version number.",
+    check=data -> meets_removed_exports_requires_breaking_bump(data),
+)
+
+function removed_exports_requires_breaking_bump_message(
+    previous_version::VersionNumber,
+    new_version::VersionNumber,
+    removed_exports::Vector{String},
+)
+    return string(
+        "This release removes exported names from v",
+        previous_version,
+        " but is registered as v",
+        new_version,
+        ", which is not a breaking version bump. Removed exports: ",
+        join(removed_exports, ", "),
+        ". Removing exports requires a breaking release.",
+    )
+end
+
+function meets_removed_exports_requires_breaking_bump(data)
+    previous_version = find_previous_semver_version(data.pkg, data.version, data.registry_master)
+    previous_version === nothing && return true, ""
+    is_breaking(previous_version, data.version) && return true, ""
+
+    previous_pkg_info = parse_registry_pkg_info(data.registry_master, data.pkg, previous_version)
+    mktempdir() do previous_pkg_root
+        clone_success = load_files_from_url_and_tree_hash(
+            _ -> nothing,
+            previous_pkg_root,
+            previous_pkg_info.repo,
+            previous_pkg_info.tree_hash,
+            data.pkg_clone_dir,
+        )
+        if !clone_success
+            return false,
+            "AutoMerge could not determine whether exports were removed because cloning the previous package version failed. Manual review is required."
+        end
+
+        result = detect_removed_exports(data.pkg, previous_pkg_root, data.pkg_code_path)
+        if !result.success
+            return false, result.message
+        elseif isempty(result.removed_exports)
+            return true, ""
+        else
+            return false,
+            removed_exports_requires_breaking_bump_message(
+                previous_version,
+                data.version,
+                result.removed_exports,
+            )
+        end
+    end
+end
+
 # This check looks for similar (but not exactly matching) names. It can be
 # overridden by a label.
 const guideline_distance_check = Guideline(;
@@ -1395,6 +1452,7 @@ function get_automerge_guidelines(
         (guideline_project_toml_check, true),
         (guideline_src_names_OK, true),
         (guideline_version_can_be_imported, true),
+        (guideline_removed_exports_requires_breaking_bump, true),
         (guideline_breaking_explanation, check_breaking_explanation && !this_is_jll_package),
     ]
     return guidelines

--- a/AutoMerge/src/util.jl
+++ b/AutoMerge/src/util.jl
@@ -338,6 +338,264 @@ function get_github_diff_link(data, previous_pkg_info, current_pkg_info)
 end
 
 #####
+##### Export comparison
+#####
+
+function detect_removed_exports(
+    pkg::AbstractString, previous_pkg_root::AbstractString, current_pkg_root::AbstractString
+)
+    previous_result = detect_package_exports(pkg, previous_pkg_root)
+    current_result = detect_package_exports(pkg, current_pkg_root)
+
+    if !previous_result.success || !current_result.success
+        errors = String[]
+        if !previous_result.success
+            push!(
+                errors,
+                "previous version ($(previous_result.method)): $(previous_result.message)",
+            )
+        end
+        if !current_result.success
+            push!(
+                errors,
+                "new version ($(current_result.method)): $(current_result.message)",
+            )
+        end
+        return (;
+            success=false,
+            removed_exports=String[],
+            method=:none,
+            message=string(
+                "AutoMerge could not determine whether exports were removed. Manual review is required. ",
+                join(errors, " "),
+            ),
+        )
+    end
+
+    removed_exports = sort!(collect(setdiff(previous_result.exports, current_result.exports)))
+    method = previous_result.method == current_result.method ? previous_result.method : :hybrid
+    return (; success=true, removed_exports, method, message="")
+end
+
+function detect_package_exports(pkg::AbstractString, pkg_root::AbstractString)
+    runtime_result = detect_package_exports_runtime(pkg, pkg_root)
+    runtime_result.success && return runtime_result
+
+    source_result = detect_package_exports_from_source(pkg, pkg_root)
+    source_result.success && return source_result
+
+    return (;
+        success=false,
+        exports=Set{String}(),
+        method=:source,
+        message=string(
+            "runtime inspection failed: ",
+            runtime_result.message,
+            " source parsing failed: ",
+            source_result.message,
+        ),
+    )
+end
+
+function detect_package_exports_runtime(pkg::AbstractString, pkg_root::AbstractString)
+    env = _child_process_environment(String[])
+    pkg_literal = repr(String(pkg))
+    pkg_root_literal = repr(abspath(pkg_root))
+    code = """
+        import Pkg
+        temp_env = mktempdir()
+        Pkg.activate(temp_env)
+        Pkg.develop(Pkg.PackageSpec(path=$pkg_root_literal))
+        Pkg.instantiate()
+        import $(pkg)
+        module_ref = getproperty(Main, Symbol($pkg_literal))
+        exports = sort!(String[
+            s for s in string.(names(module_ref; all=true, imported=true))
+            if Base.isexported(module_ref, Symbol(s)) && Symbol(s) != Symbol($pkg_literal)
+        ])
+        foreach(println, exports)
+        """
+
+    cmd = Cmd(`$(Base.julia_cmd()) -e $(code)`; env=env)
+
+    try
+        output = read(cmd, String)
+        exports = isempty(output) ? String[] : String.(split(chomp(output), '\n'))
+        return (; success=true, exports=Set(exports), method=:runtime, message="")
+    catch err
+        return (; success=false, exports=Set{String}(), method=:runtime, message=sprint(showerror, err))
+    end
+end
+
+function detect_package_exports_from_source(pkg::AbstractString, pkg_root::AbstractString)
+    src_root = joinpath(pkg_root, "src")
+    entrypoint = joinpath(src_root, string(pkg, ".jl"))
+
+    if !isfile(entrypoint)
+        return (;
+            success=false,
+            exports=Set{String}(),
+            method=:source,
+            message="expected source entrypoint $(entrypoint) was not found.",
+        )
+    end
+
+    exports = Set{String}()
+    visited_files = Set{String}()
+    try
+        _collect_exports_from_file!(exports, visited_files, entrypoint, Symbol(pkg); in_package_module=false)
+        return (; success=true, exports, method=:source, message="")
+    catch err
+        return (; success=false, exports=Set{String}(), method=:source, message=sprint(showerror, err))
+    end
+end
+
+function _collect_exports_from_file!(
+    exports::Set{String},
+    visited_files::Set{String},
+    path::AbstractString,
+    pkg_module_name::Symbol;
+    in_package_module::Bool,
+)
+    normalized_path = normpath(path)
+    normalized_path in visited_files && return nothing
+    push!(visited_files, normalized_path)
+
+    expr = Meta.parseall(read(normalized_path, String); filename=normalized_path)
+    base_dir = dirname(normalized_path)
+    return _collect_exports_from_expr!(
+        exports,
+        visited_files,
+        expr,
+        base_dir,
+        pkg_module_name;
+        in_package_module=in_package_module,
+    )
+end
+
+function _collect_exports_from_expr!(
+    exports::Set{String},
+    visited_files::Set{String},
+    expr,
+    base_dir::AbstractString,
+    pkg_module_name::Symbol;
+    in_package_module::Bool,
+)
+    expr isa Expr || return nothing
+
+    if expr.head == :module
+        module_name = expr.args[2]
+        module_body = expr.args[3]
+        next_in_package_module = in_package_module || module_name == pkg_module_name
+        return _collect_exports_from_expr!(
+            exports,
+            visited_files,
+            module_body,
+            base_dir,
+            pkg_module_name;
+            in_package_module=next_in_package_module && module_name == pkg_module_name,
+        )
+    end
+
+    if in_package_module && expr.head == :export
+        for arg in expr.args
+            arg isa Symbol || continue
+            push!(exports, string(arg))
+        end
+        return nothing
+    end
+
+    if in_package_module
+        include_path = _extract_include_path(expr)
+        if include_path !== nothing
+            included_file = normpath(joinpath(base_dir, include_path))
+            if isfile(included_file)
+                _collect_exports_from_file!(
+                    exports,
+                    visited_files,
+                    included_file,
+                    pkg_module_name;
+                    in_package_module=true,
+                )
+            end
+        end
+    end
+
+    for arg in expr.args
+        _collect_exports_from_expr!(
+            exports,
+            visited_files,
+            arg,
+            base_dir,
+            pkg_module_name;
+            in_package_module=in_package_module,
+        )
+    end
+    return nothing
+end
+
+function _extract_include_path(expr::Expr)
+    if expr.head != :call || isempty(expr.args)
+        return nothing
+    end
+
+    callee = expr.args[1]
+    if callee == :include && length(expr.args) >= 2
+        return _string_literal_value(expr.args[2])
+    elseif callee == :joinpath
+        return nothing
+    elseif callee == GlobalRef(Base, :include) && length(expr.args) >= 3
+        return _string_literal_value(expr.args[3])
+    elseif callee == :include && length(expr.args) == 2
+        return _string_literal_value(expr.args[2])
+    end
+
+    if callee == :include && length(expr.args) == 3
+        return _string_literal_value(expr.args[3])
+    end
+
+    return nothing
+end
+
+_string_literal_value(x::String) = x
+function _string_literal_value(x::Expr)
+    if x.head == :call && x.args[1] == :joinpath
+        parts = String[]
+        for arg in x.args[2:end]
+            value = _string_literal_value(arg)
+            value === nothing && return nothing
+            push!(parts, value)
+        end
+        return joinpath(parts...)
+    end
+    return nothing
+end
+_string_literal_value(::Any) = nothing
+
+function _child_process_environment(environment_variables_to_pass::Vector{String})
+    env = Dict(
+        "JULIA_DEPOT_PATH" => mktempdir() * (Sys.iswindows() ? ";" : ":"),
+        "JULIA_PKG_PRECOMPILE_AUTO" => "0",
+        "JULIA_REGISTRYCI_AUTOMERGE" => "true",
+        "PYTHON" => "",
+        "R_HOME" => "*",
+    )
+    default_environment_variables_to_pass = [
+        "HOME",
+        "JULIA_PKG_SERVER",
+        "PATH",
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+    ]
+    for k in vcat(default_environment_variables_to_pass, environment_variables_to_pass)
+        if haskey(ENV, k)
+            env[k] = ENV[k]
+        end
+    end
+    return env
+end
+
+#####
 ##### AutoMerge comment
 #####
 

--- a/AutoMerge/test/automerge-unit.jl
+++ b/AutoMerge/test/automerge-unit.jl
@@ -37,6 +37,96 @@ function create_mock_pr(commit_sha::String)
     )
 end
 
+function write_test_package(
+    pkg_root::AbstractString,
+    pkg::AbstractString;
+    version::VersionNumber=v"0.1.0",
+    project_name::AbstractString=pkg,
+    uuid::UUID=UUID("11111111-1111-1111-1111-111111111111"),
+    entrypoint::AbstractString=string(
+        "module ",
+        pkg,
+        "\n",
+        "export sample\n",
+        "sample() = :sample\n",
+        "end\n",
+    ),
+    extra_files::Dict{String,String}=Dict{String,String}(),
+)
+    mkpath(joinpath(pkg_root, "src"))
+    write(
+        joinpath(pkg_root, "Project.toml"),
+        """
+        name = "$project_name"
+        uuid = "$uuid"
+        version = "$version"
+        """,
+    )
+    write(joinpath(pkg_root, "src", "$pkg.jl"), entrypoint)
+    for (relative_path, contents) in extra_files
+        full_path = joinpath(pkg_root, relative_path)
+        mkpath(dirname(full_path))
+        write(full_path, contents)
+    end
+    return pkg_root
+end
+
+function commit_package_version!(
+    repo_dir::AbstractString,
+    pkg::AbstractString;
+    version::VersionNumber,
+    entrypoint::AbstractString,
+)
+    rm(joinpath(repo_dir, "Project.toml"); force=true)
+    rm(joinpath(repo_dir, "src"); force=true, recursive=true)
+    write_test_package(repo_dir, pkg; version=version, entrypoint=entrypoint)
+
+    git_env = copy(ENV)
+    git_env["GIT_AUTHOR_NAME"] = "Codex"
+    git_env["GIT_AUTHOR_EMAIL"] = "codex@example.com"
+    git_env["GIT_COMMITTER_NAME"] = "Codex"
+    git_env["GIT_COMMITTER_EMAIL"] = "codex@example.com"
+    run(setenv(`git -C $repo_dir add .`, git_env))
+    run(setenv(`git -C $repo_dir commit -m "commit $(version)"`, git_env))
+    return readchomp(Cmd(["git", "-C", repo_dir, "rev-parse", "HEAD^{tree}"]))
+end
+
+function write_test_registry(
+    registry_dir::AbstractString,
+    pkg::AbstractString,
+    uuid::AbstractString,
+    repo::AbstractString,
+    versions::Vector{Pair{VersionNumber,String}},
+)
+    package_path = joinpath(first(pkg), pkg)
+    mkpath(joinpath(registry_dir, package_path))
+
+    write(
+        joinpath(registry_dir, "Registry.toml"),
+        """
+        [packages]
+        "$uuid" = { name = "$pkg", path = "$package_path" }
+        """,
+    )
+    write(
+        joinpath(registry_dir, package_path, "Package.toml"),
+        """
+        name = "$pkg"
+        uuid = "$uuid"
+        repo = "$repo"
+        """,
+    )
+
+    versions_toml = IOBuffer()
+    for (version, tree_hash) in versions
+        println(versions_toml, "[\"$version\"]")
+        println(versions_toml, "git-tree-sha1 = \"$tree_hash\"")
+        println(versions_toml)
+    end
+    write(joinpath(registry_dir, package_path, "Versions.toml"), String(take!(versions_toml)))
+    return registry_dir
+end
+
 REQUIRES_CLONE = mktempdir()
 # Clone the actual Requires.jl repository for diff operations
 run(`git clone https://github.com/MikeInnes/Requires.jl.git $(REQUIRES_CLONE)`)
@@ -730,6 +820,175 @@ end
 
         # Maybe this should fail as the label isn't applied by JuliaRegistrator, so the version isn't breaking?
         @test AutoMerge.meets_breaking_explanation_check([], body_good)[1]
+    end
+    @testset "Removed exports require a breaking version bump" begin
+        mktempdir() do old_pkg_root
+            write_test_package(
+                old_pkg_root,
+                "ExportProbe";
+                entrypoint="""
+                module ExportProbe
+                export alpha, beta
+                alpha() = :alpha
+                beta() = :beta
+                end
+                """,
+            )
+            result = AutoMerge.detect_package_exports("ExportProbe", old_pkg_root)
+            @test result.success
+            @test result.method == :runtime
+            @test result.exports == Set(["alpha", "beta"])
+        end
+
+        mktempdir() do pkg_root
+            write_test_package(
+                pkg_root,
+                "FallbackProbe";
+                entrypoint="""
+                module FallbackProbe
+                export alpha
+                __init__() = error("force runtime fallback")
+                alpha() = :alpha
+                end
+                """,
+            )
+            result = AutoMerge.detect_package_exports("FallbackProbe", pkg_root)
+            @test result.success
+            @test result.method == :source
+            @test result.exports == Set(["alpha"])
+        end
+
+        mktempdir() do pkg_root
+            write_test_package(
+                pkg_root,
+                "IncludeProbe";
+                entrypoint="""
+                module IncludeProbe
+                include("exports.jl")
+                end
+                """,
+                extra_files=Dict(
+                    joinpath("src", "exports.jl") => """
+                    export alpha, beta
+                    alpha() = :alpha
+                    beta() = :beta
+                    """,
+                ),
+            )
+            result = AutoMerge.detect_package_exports_from_source("IncludeProbe", pkg_root)
+            @test result.success
+            @test result.exports == Set(["alpha", "beta"])
+        end
+
+        mktempdir() do pkg_root
+            write_test_package(
+                pkg_root,
+                "BrokenProbe";
+                entrypoint="""
+                module BrokenProbe
+                export alpha
+                alpha() = :alpha
+                end
+                """,
+            )
+            rm(joinpath(pkg_root, "src", "BrokenProbe.jl"))
+            result = AutoMerge.detect_package_exports("BrokenProbe", pkg_root)
+            @test !result.success
+            @test occursin("runtime inspection failed", result.message)
+            @test occursin("source parsing failed", result.message)
+        end
+
+        mktempdir() do old_pkg_root
+            mktempdir() do new_pkg_root
+                write_test_package(
+                    old_pkg_root,
+                    "DiffProbe";
+                    entrypoint="""
+                    module DiffProbe
+                    export alpha, beta
+                    alpha() = :alpha
+                    beta() = :beta
+                    end
+                    """,
+                )
+                write_test_package(
+                    new_pkg_root,
+                    "DiffProbe";
+                    entrypoint="""
+                    module DiffProbe
+                    export alpha, gamma
+                    alpha() = :alpha
+                    gamma() = :gamma
+                    end
+                    """,
+                )
+                result = AutoMerge.detect_removed_exports("DiffProbe", old_pkg_root, new_pkg_root)
+                @test result.success
+                @test result.removed_exports == ["beta"]
+            end
+        end
+
+        mktempdir() do repo_dir
+            run(`git -C $repo_dir init`)
+
+            old_tree = commit_package_version!(
+                repo_dir,
+                "GuidelineProbe";
+                version=v"0.1.0",
+                entrypoint="""
+                module GuidelineProbe
+                export alpha, beta
+                alpha() = :alpha
+                beta() = :beta
+                end
+                """,
+            )
+            new_tree = commit_package_version!(
+                repo_dir,
+                "GuidelineProbe";
+                version=v"0.1.1",
+                entrypoint="""
+                module GuidelineProbe
+                export alpha
+                alpha() = :alpha
+                end
+                """,
+            )
+
+            mktempdir() do registry_master
+                mktempdir() do current_pkg_root
+                    write_test_registry(
+                        registry_master,
+                        "GuidelineProbe",
+                        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                        repo_dir,
+                        [v"0.1.0" => old_tree],
+                    )
+                    write_test_package(
+                        current_pkg_root,
+                        "GuidelineProbe";
+                        version=v"0.1.1",
+                        entrypoint="""
+                        module GuidelineProbe
+                        export alpha
+                        alpha() = :alpha
+                        end
+                        """,
+                    )
+
+                    data = (;
+                        pkg="GuidelineProbe",
+                        version=v"0.1.1",
+                        registry_master=registry_master,
+                        pkg_clone_dir=mktempdir(),
+                        pkg_code_path=current_pkg_root,
+                    )
+                    success, message = AutoMerge.meets_removed_exports_requires_breaking_bump(data)
+                    @test !success
+                    @test occursin("Removed exports: beta", message)
+                end
+            end
+        end
     end
 end
 


### PR DESCRIPTION
@DilumAluthge

Fixes #439.

## Summary

- add an AutoMerge guideline that treats removed exports as requiring a breaking version bump
- compare exports with a runtime-first, source-fallback strategy so removed exports are caught even when runtime inspection is not reliable
- add focused unit coverage for runtime detection, source fallback, removed-export detection, and the new guideline path

🤖 Generated by Codex.
