### PR TITLE
AutoMerge: Don't require "breaking change" release notes when going from `0.a.b` to `1.0.0` (or `1.a.b`)

### DIFF
--- a/AutoMerge/src/guidelines.jl
+++ b/AutoMerge/src/guidelines.jl
@@ -478,7 +478,7 @@ function meets_breaking_explanation_check(data::GitHubAutoMergeData)
     # Look up PR here in case the labels are slow to be applied by the Registrator bot
     # which decides whether to add the BREAKING label
     pr = GitHub.pull_request(data.api, data.registry, data.pr.number; auth=data.auth)
-    return meets_breaking_explanation_check(; pr.labels, pr.body, data.version)
+    return meets_breaking_explanation_check(pr.labels, pr.body, data.version)
 end
 
 function breaking_explanation_message(has_release_notes)
@@ -516,14 +516,13 @@ function breaking_explanation_message(has_release_notes)
     end
 end
 
-function meets_breaking_explanation_check(; labels::Vector, body::AbstractString, version::VersionNumber)
+function meets_breaking_explanation_check(labels::Vector{<:AbstractString}, body::AbstractString, version::VersionNumber)
     if version.major == 1
         # Authors may choose to move directly from 0.x.y to 1.0.0 (or 1.a.b), and we do not
         # want the breaking-change release-notes guideline to add friction to any
         # 1.0.0 (or 1.a.b) registration that is part of that transition.
         return true, ""
     end
-
     if has_label(labels, BREAKING_LABEL)
         release_notes = get_release_notes(body)
         if release_notes === nothing

--- a/AutoMerge/src/guidelines.jl
+++ b/AutoMerge/src/guidelines.jl
@@ -476,9 +476,9 @@ const guideline_breaking_explanation = Guideline(;
 
 function meets_breaking_explanation_check(data::GitHubAutoMergeData)
     if _breaking_explanation_is_exempt(data.version)
-        # Authors may choose to move directly from 0.x.y to 1.0.0, and we do not
+        # Authors may choose to move directly from 0.x.y to 1.0.0 (or 1.a.b), and we do not
         # want the breaking-change release-notes guideline to add friction to any
-        # 1.a.b registration that is part of that transition.
+        # 1.0.0 (or 1.a.b) registration that is part of that transition.
         return true, ""
     end
 

--- a/AutoMerge/src/guidelines.jl
+++ b/AutoMerge/src/guidelines.jl
@@ -475,11 +475,20 @@ const guideline_breaking_explanation = Guideline(;
     check=data -> meets_breaking_explanation_check(data))
 
 function meets_breaking_explanation_check(data::GitHubAutoMergeData)
+    if _breaking_explanation_is_exempt(data.version)
+        # Authors may choose to move directly from 0.x.y to 1.0.0, and we do not
+        # want the breaking-change release-notes guideline to add friction to any
+        # 1.x.y registration that is part of that transition.
+        return true, ""
+    end
+
     # Look up PR here in case the labels are slow to be applied by the Registrator bot
     # which decides whether to add the BREAKING label
     pr = GitHub.pull_request(data.api, data.registry, data.pr.number; auth=data.auth)
-    return meets_breaking_explanation_check(pr.labels, pr.body)
+    return meets_breaking_explanation_check(data.version, pr.labels, pr.body)
 end
+
+_breaking_explanation_is_exempt(version::VersionNumber) = version.major == 1
 
 function breaking_explanation_message(has_release_notes)
     example_detail = """
@@ -531,6 +540,15 @@ function meets_breaking_explanation_check(labels::Vector, body::AbstractString)
     else
         return true, ""
     end
+end
+
+function meets_breaking_explanation_check(
+    version::VersionNumber, labels::Vector, body::AbstractString
+)
+    if _breaking_explanation_is_exempt(version)
+        return true, ""
+    end
+    return meets_breaking_explanation_check(labels, body)
 end
 
 function get_release_notes(body::AbstractString)

--- a/AutoMerge/src/guidelines.jl
+++ b/AutoMerge/src/guidelines.jl
@@ -475,20 +475,11 @@ const guideline_breaking_explanation = Guideline(;
     check=data -> meets_breaking_explanation_check(data))
 
 function meets_breaking_explanation_check(data::GitHubAutoMergeData)
-    if _breaking_explanation_is_exempt(data.version)
-        # Authors may choose to move directly from 0.x.y to 1.0.0 (or 1.a.b), and we do not
-        # want the breaking-change release-notes guideline to add friction to any
-        # 1.0.0 (or 1.a.b) registration that is part of that transition.
-        return true, ""
-    end
-
     # Look up PR here in case the labels are slow to be applied by the Registrator bot
     # which decides whether to add the BREAKING label
     pr = GitHub.pull_request(data.api, data.registry, data.pr.number; auth=data.auth)
-    return meets_breaking_explanation_check(data.version, pr.labels, pr.body)
+    return meets_breaking_explanation_check(; pr.labels, pr.body, data.version)
 end
-
-_breaking_explanation_is_exempt(version::VersionNumber) = version.major == 1
 
 function breaking_explanation_message(has_release_notes)
     example_detail = """
@@ -525,7 +516,14 @@ function breaking_explanation_message(has_release_notes)
     end
 end
 
-function meets_breaking_explanation_check(labels::Vector, body::AbstractString)
+function meets_breaking_explanation_check(; labels::Vector, body::AbstractString, version::VersionNumber)
+    if version.major == 1
+        # Authors may choose to move directly from 0.x.y to 1.0.0 (or 1.a.b), and we do not
+        # want the breaking-change release-notes guideline to add friction to any
+        # 1.0.0 (or 1.a.b) registration that is part of that transition.
+        return true, ""
+    end
+
     if has_label(labels, BREAKING_LABEL)
         release_notes = get_release_notes(body)
         if release_notes === nothing
@@ -540,15 +538,6 @@ function meets_breaking_explanation_check(labels::Vector, body::AbstractString)
     else
         return true, ""
     end
-end
-
-function meets_breaking_explanation_check(
-    version::VersionNumber, labels::Vector, body::AbstractString
-)
-    if _breaking_explanation_is_exempt(version)
-        return true, ""
-    end
-    return meets_breaking_explanation_check(labels, body)
 end
 
 function get_release_notes(body::AbstractString)

--- a/AutoMerge/src/guidelines.jl
+++ b/AutoMerge/src/guidelines.jl
@@ -478,7 +478,7 @@ function meets_breaking_explanation_check(data::GitHubAutoMergeData)
     if _breaking_explanation_is_exempt(data.version)
         # Authors may choose to move directly from 0.x.y to 1.0.0, and we do not
         # want the breaking-change release-notes guideline to add friction to any
-        # 1.x.y registration that is part of that transition.
+        # 1.a.b registration that is part of that transition.
         return true, ""
     end
 

--- a/AutoMerge/test/automerge-unit.jl
+++ b/AutoMerge/test/automerge-unit.jl
@@ -731,11 +731,11 @@ end
         # Maybe this should fail as the label isn't applied by JuliaRegistrator, so the version isn't breaking?
         @test AutoMerge.meets_breaking_explanation_check([], body_good)[1]
 
-        @test AutoMerge.meets_breaking_explanation_check(v"1.0.0", [breaking_label], body_bad)[1]
-        @test AutoMerge.meets_breaking_explanation_check(v"1.2.3", [breaking_label], body_bad_no_notes)[1]
-        @test !AutoMerge.meets_breaking_explanation_check(v"0.3.0", [breaking_label], body_bad)[1]
-        @test !AutoMerge.meets_breaking_explanation_check(v"2.0.0", [breaking_label], body_bad_no_notes)[1]
-        @test AutoMerge.meets_breaking_explanation_check(v"2.0.0", [breaking_label], body_good)[1]
+        @test AutoMerge.meets_breaking_explanation_check([breaking_label], body_bad, v"1.0.0")[1]
+        @test AutoMerge.meets_breaking_explanation_check([breaking_label], body_bad_no_notes, v"1.2.3")[1]
+        @test !AutoMerge.meets_breaking_explanation_check([breaking_label], body_bad, v"0.3.0")[1]
+        @test !AutoMerge.meets_breaking_explanation_check([breaking_label], body_bad_no_notes, v"2.0.0")[1]
+        @test AutoMerge.meets_breaking_explanation_check([breaking_label], body_good, v"2.0.0")[1]
     end
 end
 

--- a/AutoMerge/test/automerge-unit.jl
+++ b/AutoMerge/test/automerge-unit.jl
@@ -730,6 +730,12 @@ end
 
         # Maybe this should fail as the label isn't applied by JuliaRegistrator, so the version isn't breaking?
         @test AutoMerge.meets_breaking_explanation_check([], body_good)[1]
+
+        @test AutoMerge.meets_breaking_explanation_check(v"1.0.0", [breaking_label], body_bad)[1]
+        @test AutoMerge.meets_breaking_explanation_check(v"1.2.3", [breaking_label], body_bad_no_notes)[1]
+        @test !AutoMerge.meets_breaking_explanation_check(v"0.3.0", [breaking_label], body_bad)[1]
+        @test !AutoMerge.meets_breaking_explanation_check(v"2.0.0", [breaking_label], body_bad_no_notes)[1]
+        @test AutoMerge.meets_breaking_explanation_check(v"2.0.0", [breaking_label], body_good)[1]
     end
 end
 


### PR DESCRIPTION
## Summary
- exempt `1.0.0` (and `1.a.b`) versions from the breaking-change release-notes guideline
- keep the guideline unchanged for `0.x.y` and `>= 2.0.0`
- add unit coverage for the new exemption boundaries

## Motivation
Authors may choose to move directly from `0.x.y` to `1.0.0`, and we do not want the breaking-change release-notes guideline to add friction to `1.0.0` (or `1.a.b`) registrations that are part of that transition.

🤖 Generated by Codex.
