### PR TITLE
AutoMerge: Add AutoMerge guideline for Git submodules

### DIFF
--- a/AutoMerge/src/guidelines.jl
+++ b/AutoMerge/src/guidelines.jl
@@ -888,6 +888,16 @@ const guideline_code_can_be_downloaded = Guideline(;
     ),
 )
 
+const guideline_no_git_submodules = Guideline(;
+    info="Package does not use Git submodules.",
+    docs=string(
+        "Git submodules: The package source tree must not contain Git submodules ",
+        "or submodule-related metadata such as a `.gitmodules` file. ",
+        "Registrations that include Git submodules are not eligible for AutoMerge.",
+    ),
+    check=data -> meets_no_git_submodules(data.pkg_code_path),
+)
+
 function _find_lowercase_duplicates(v)
     elts = Dict{String, String}()
     for x in v
@@ -943,6 +953,22 @@ function meets_src_names_ok(pkg_code_path)
             end
         end
     end
+    return true, ""
+end
+
+function meets_no_git_submodules(pkg_code_path)
+    if !(pkg_code_path isa AbstractString) || !isdir(pkg_code_path) || isempty(readdir(pkg_code_path))
+        return false,
+        "Could not check for Git submodules because could not access package code. Perhaps the `can_download_code` check failed earlier."
+    end
+
+    for (root, _, files) in walkdir(pkg_code_path)
+        if ".gitmodules" in files
+            return false,
+            "Git submodules are not allowed for AutoMerge. Found submodule-related metadata at `$(joinpath(root, ".gitmodules"))`."
+        end
+    end
+
     return true, ""
 end
 
@@ -1337,6 +1363,7 @@ function get_automerge_guidelines(
         (:update_status, true),
         (guideline_version_can_be_pkg_added, true),
         (guideline_code_can_be_downloaded, true),
+        (guideline_no_git_submodules, true),
         # `guideline_version_has_osi_license` must be run
         # after `guideline_code_can_be_downloaded` so
         # that it can use the downloaded code!
@@ -1387,6 +1414,7 @@ function get_automerge_guidelines(
         (:update_status, true),
         (guideline_version_can_be_pkg_added, true),
         (guideline_code_can_be_downloaded, true),
+        (guideline_no_git_submodules, true),
         # `guideline_version_has_osi_license` must be run
         # after `guideline_code_can_be_downloaded` so
         # that it can use the downloaded code!

--- a/AutoMerge/test/automerge-unit.jl
+++ b/AutoMerge/test/automerge-unit.jl
@@ -825,6 +825,57 @@ end
         touch(joinpath(tmp, "src", "B", "con"))
         @test !AutoMerge.meets_src_names_ok(tmp)[1]
     end
+    @testset "meets_no_git_submodules" begin
+        @test !AutoMerge.meets_no_git_submodules("DOES NOT EXIST")[1]
+
+        tmp = mktempdir()
+        mkdir(joinpath(tmp, "src"))
+        touch(joinpath(tmp, "src", "Example.jl"))
+        @test AutoMerge.meets_no_git_submodules(tmp)[1]
+
+        touch(joinpath(tmp, ".gitmodules"))
+        success, msg = AutoMerge.meets_no_git_submodules(tmp)
+        @test !success
+        @test occursin("Git submodules", msg)
+        @test occursin(".gitmodules", msg)
+
+        rm(joinpath(tmp, ".gitmodules"))
+        mkpath(joinpath(tmp, "deps", "vendor"))
+        touch(joinpath(tmp, "deps", "vendor", ".gitmodules"))
+        success, msg = AutoMerge.meets_no_git_submodules(tmp)
+        @test !success
+        @test occursin("Git submodules", msg)
+        @test occursin(joinpath("deps", "vendor", ".gitmodules"), msg)
+    end
+    @testset "no git submodules guideline is included" begin
+        new_package_guidelines = AutoMerge.get_automerge_guidelines(
+            AutoMerge.NewPackage();
+            check_license=true,
+            this_is_jll_package=false,
+            this_pr_can_use_special_jll_exceptions=false,
+            use_distance_check=false,
+            package_author_approved=false,
+            check_breaking_explanation=false,
+        )
+        @test any(
+            x -> !(x[1] isa Symbol) && x[1] === AutoMerge.guideline_no_git_submodules,
+            new_package_guidelines,
+        )
+
+        new_version_guidelines = AutoMerge.get_automerge_guidelines(
+            AutoMerge.NewVersion();
+            check_license=true,
+            check_breaking_explanation=false,
+            this_is_jll_package=false,
+            this_pr_can_use_special_jll_exceptions=false,
+            use_distance_check=false,
+            package_author_approved=false,
+        )
+        @test any(
+            x -> !(x[1] isa Symbol) && x[1] === AutoMerge.guideline_no_git_submodules,
+            new_version_guidelines,
+        )
+    end
     @testset "pull-requests.jl" begin
         @testset "regexes" begin
             @testset "new_package_title_regex" begin


### PR DESCRIPTION
## Summary
Add a new AutoMerge guideline that rejects registrations when the extracted package tree contains Git submodule metadata such as `.gitmodules`.

## Motivation

If I recall correctly, Git submodules break the treehashes. But Pkg relies on treehashes. So we shouldn't allow registered packages to have Git submodules.

🤖 Generated by Codex.
