### PR TITLE
TagBot cron: look up subdir before checking for existing tag

### DIFF
--- a/AutoMerge/src/TagBot/TagBot.jl
+++ b/AutoMerge/src/TagBot/TagBot.jl
@@ -8,6 +8,8 @@ using SHA: sha1
 using GitHub: GitHub
 using JSON: JSON
 
+import ..AutoMerge
+
 VERSION >= v"1.11" && eval(Meta.parse("public main"))
 
 const GH = GitHub
@@ -49,17 +51,19 @@ end
 function repo_and_version_of_pull_request_body(body)
     # Return immediately if the pull request's description is empty. In this
     # case no further information can be obtained about a registration
-    isnothing(body) && return (nothing, nothing)
+    isnothing(body) && return (nothing, nothing, nothing)
     if occursin("JLL package", body)
         @info "Skipping JLL package registration"
-        return nothing, nothing
+        return nothing, nothing, nothing
     end
     m = match(r"Repository: .*github\.com[:/](.*)", body)
     repo = m === nothing ? nothing : strip(m[1])
     repo !== nothing && endswith(repo, ".git") && (repo = repo[1:(end - 4)])
     m = match(r"Version: (.*)", body)
     version = m === nothing ? nothing : strip(m[1])
-    return repo, version
+    m = match(r"Registering package: (.*)", body)
+    pkg_name = m === nothing ? nothing : strip(m[1])
+    return repo, version, pkg_name
 end
 
 function tagbot_file(repo; issue_comments=false)
@@ -115,9 +119,10 @@ function notify(repo, issue, body)
     return GH.create_comment(repo, issue, :issue; auth=AUTH[], params=(; body=body))
 end
 
-function tag_exists(repo, version)
+function tag_exists(repo, version; subdir="")
+    tag_name = isempty(subdir) ? version : "$subdir-$version"
     return try
-        GH.tag(repo, version; auth=AUTH[])
+        GH.tag(repo, tag_name; auth=AUTH[])
         true
     catch e
         if !occursin("404", e.msg)
@@ -127,13 +132,24 @@ function tag_exists(repo, version)
     end
 end
 
-function maybe_notify(event, repo, version; cron=false)
+function maybe_notify(event, repo, version, pkg_name=nothing; cron=false)
     @info "Processing version $version of $repo"
     if tagbot_file(repo) === nothing
         @info "TagBot is not enabled on $repo"
         return nothing
     end
-    if cron && tag_exists(repo, version)
+    # Subdir packages are tagged `<subdir>-vX.Y.Z`; look up the package's
+    # `subdir` from the registry checked out at the working directory and
+    # fall back to the bare-version tag check on any failure.
+    subdir = ""
+    if pkg_name !== nothing
+        try
+            subdir = AutoMerge.parse_registry_pkg_info(pwd(), pkg_name).subdir
+        catch e
+            @warn "Failed to look up subdir for $pkg_name in $(pwd())" ex = (e, catch_backtrace())
+        end
+    end
+    if cron && tag_exists(repo, version; subdir=subdir)
         @info "Tag $version already exists for $repo"
         return nothing
     end

--- a/AutoMerge/src/TagBot/cron.jl
+++ b/AutoMerge/src/TagBot/cron.jl
@@ -5,8 +5,8 @@ function handle_cron(event)
     repos_versions = map(pull -> repo_and_version_of_pull_request_body(pull.body), pulls)
     filter!(rv -> first(rv) !== nothing, repos_versions)
     unique!(first, repos_versions)  # Send at most one notification per repo.
-    for (repo, version) in repos_versions
-        maybe_notify(event, repo, version; cron=true)
+    for (repo, version, pkg_name) in repos_versions
+        maybe_notify(event, repo, version, pkg_name; cron=true)
     end
 end
 

--- a/AutoMerge/src/TagBot/pull_request.jl
+++ b/AutoMerge/src/TagBot/pull_request.jl
@@ -3,10 +3,10 @@ is_merged_pull_request(event) = get(get(event, "pull_request", Dict()), "merged"
 function handle_merged_pull_request(event)
     number = event["pull_request"]["number"]
     @info "Processing pull request $number"
-    repo, version = repo_and_version_of_pull_request_body(event["pull_request"]["body"])
+    repo, version, pkg_name = repo_and_version_of_pull_request_body(event["pull_request"]["body"])
     if repo === nothing
         @info "Failed to parse GitHub repository from pull request"
         return nothing
     end
-    return maybe_notify(event, repo, version)
+    return maybe_notify(event, repo, version, pkg_name)
 end

--- a/AutoMerge/test/tagbot-unit.jl
+++ b/AutoMerge/test/tagbot-unit.jl
@@ -31,13 +31,23 @@ end
         - Version: v1.2.3
         """
     github = body("https://github.com/Foo/Bar")
-    @test TB.repo_and_version_of_pull_request_body(github) == ("Foo/Bar", "v1.2.3")
+    @test TB.repo_and_version_of_pull_request_body(github) == ("Foo/Bar", "v1.2.3", nothing)
     ssh = body("git@github.com:Foo/Bar.git")
-    @test TB.repo_and_version_of_pull_request_body(ssh) == ("Foo/Bar", "v1.2.3")
+    @test TB.repo_and_version_of_pull_request_body(ssh) == ("Foo/Bar", "v1.2.3", nothing)
     gitlab = body("https://gitlab.com/Foo/Bar")
-    @test TB.repo_and_version_of_pull_request_body(gitlab) == (nothing, "v1.2.3")
+    @test TB.repo_and_version_of_pull_request_body(gitlab) == (nothing, "v1.2.3", nothing)
     no_body = nothing
-    @test TB.repo_and_version_of_pull_request_body(no_body) == (nothing, nothing)
+    @test TB.repo_and_version_of_pull_request_body(no_body) == (nothing, nothing, nothing)
+    # Subdir packages include `Registering package: <name>` in the body so
+    # the cron can look up the package's `subdir` and check for the prefixed
+    # tag (e.g. `Pkg-v1.2.3` instead of `v1.2.3`).
+    subdir_body = """
+        - Registering package: Pkg
+        - Repository: https://github.com/Foo/Bar
+        - Version: v1.2.3
+        """
+    @test TB.repo_and_version_of_pull_request_body(subdir_body) ==
+          ("Foo/Bar", "v1.2.3", "Pkg")
 end
 
 @testset "tagbot_file" begin


### PR DESCRIPTION
Fixes #710.

I asked Claude to help me write the fix and test locally as much as possible, hopefully someone with better knowledge of this codebase can double check to make sure it is reasonable. The cron now extracts the package name from the registry PR body, looks up the package's `subdir` via `AutoMerge.parse_registry_pkg_info`, and checks for the prefixed tag (`<subdir>-vX.Y.Z`) when a subdir is set. Falls back to the bare version when not, or when the registry isn't checked out at the working directory.