### PR TITLE
AutoMerge: Add an App to locally check naming guidelines

### DIFF
--- a/AutoMerge/Project.toml
+++ b/AutoMerge/Project.toml
@@ -27,9 +27,6 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 VisualStringDistances = "089bb0c6-1854-47b9-96f7-327dbbe09dca"
 juliaup_jll = "038fdbe3-3777-5af9-9568-3738956aeb97"
 
-[sources]
-RegistryCI = {path = "../RegistryCI"}
-
 [compat]
 Base64 = "<0.0.1, 1"
 Dates = "<0.0.1, 1"

--- a/AutoMerge/Project.toml
+++ b/AutoMerge/Project.toml
@@ -1,7 +1,7 @@
 name = "AutoMerge"
 uuid = "c5732277-7834-41e3-8e1f-5f375898cfe1"
 authors = ["Dilum Aluthge <dilum@aluthge.com>", "Fredrik Ekre <ekrefredrik@gmail.com>", "contributors"]
-version = "1.0.0"
+version = "1.1.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
@@ -15,6 +15,7 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RegistryCI = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
+RegistryInstances = "2792f1a3-b283-48e8-9a74-f99dce5104f3"
 RegistryTools = "d1eb7eb1-105f-429d-abf5-b0f65cb9e2c4"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 StringDistances = "88034a9c-02f8-509d-84a9-84ec65e18404"
@@ -41,6 +42,7 @@ Pkg = "<0.0.1, 1"
 Printf = "<0.0.1, 1"
 Random = "<0.0.1, 1"
 RegistryCI = "10, 11"
+RegistryInstances = "0.1.0"
 RegistryTools = "2.2"
 SHA = "<0.0.1, 0.7, 1"
 StringDistances = "0.9, 0.10, 0.11"
@@ -52,6 +54,9 @@ UUIDs = "<0.0.1, 1"
 VisualStringDistances = "0.1"
 julia = "1.10"
 juliaup_jll = "1.17.19"
+
+[apps.general_name_check]
+submodule = "GeneralNameCheck"
 
 [extras]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/AutoMerge/src/AutoMerge.jl
+++ b/AutoMerge/src/AutoMerge.jl
@@ -50,4 +50,7 @@ include("toml.jl")
 include("update_status.jl")
 include("util.jl")
 
+# App
+include("general_name_check.jl")
+
 end # module

--- a/AutoMerge/src/general_name_check.jl
+++ b/AutoMerge/src/general_name_check.jl
@@ -5,7 +5,11 @@ using ..AutoMerge: meets_name_length, meets_name_ascii, meets_julia_name_check,
                    meets_name_match_check, meets_distance_check,
                    meets_name_is_identifier, meets_normal_capitalization
 
-function @main(ARGS)
+@static if VERSION >= v"1.12"
+    @main(ARGS) = _main(ARGS)
+end
+
+function _main(ARGS)
     if length(ARGS) != 1
         return fatal("Usage: general_name_check <Package Name>")
     end
@@ -81,4 +85,6 @@ end
 end
 
 # Speed up the CLI by precompiling the main entry point.
-precompile(Tuple{typeof(AutoMerge.GeneralNameCheck.main), Array{String, 1}})
+@static if VERSION >= v"1.12"
+    precompile(Tuple{typeof(AutoMerge.GeneralNameCheck.main), Array{String, 1}})
+end

--- a/AutoMerge/src/general_name_check.jl
+++ b/AutoMerge/src/general_name_check.jl
@@ -1,0 +1,84 @@
+module GeneralNameCheck
+
+using RegistryInstances: reachable_registries
+using ..AutoMerge: meets_name_length, meets_name_ascii, meets_julia_name_check,
+                   meets_name_match_check, meets_distance_check,
+                   meets_name_is_identifier, meets_normal_capitalization
+
+function @main(ARGS)
+    if length(ARGS) != 1
+        return fatal("Usage: general_name_check <Package Name>")
+    end
+    name = only(ARGS)
+    general = get_general_registry()
+    isnothing(general) && return fatal("Could not find the General registry.")
+    run_name_checks(name, general)
+    return 0
+end
+
+function get_general_registry()
+    general_uuid = Base.UUID("23338594-aafe-5451-b93e-139f81909106")
+    registries = filter(x -> x.uuid == general_uuid, reachable_registries())
+    isempty(registries) && return nothing
+    return only(registries)
+end
+
+const name_checks =
+    [("Name is a valid identifier.",
+      "Name is not a valid identifier:",
+      (pkgname, _) -> meets_name_is_identifier(pkgname)),
+
+     ("Name only contains ascii characters.",
+      "Name contains non-ascii characters:",
+      (pkgname, _) -> meets_name_ascii(pkgname)),
+
+     ("Name is not already registered.",
+      "Name matches registered package up to capitalization:",
+      (pkgname, general) -> meets_name_match_check(pkgname, general)),
+
+     ("Name is at least five characters.",
+      "Name is shorter than five characters:",
+      (pkgname, _) -> meets_name_length(pkgname)),
+
+     ("Name passes julia redundancy check.",
+      "Name fails julia redundancy check:",
+      (pkgname, _) -> meets_julia_name_check(pkgname)),
+
+     ("Name has normal capitalization.",
+      "Name does not have normal capitalization:",
+      (pkgname, _) -> meets_normal_capitalization(pkgname)),
+
+     ("No name similarity found.",
+      "Name similarities found:",
+      (pkgname, general) ->
+          meets_distance_check(pkgname, general;
+                               comment_collapse_cutoff = typemax(Int)))]
+
+function run_name_checks(pkgname, general)
+    for (pass_message, fail_message, func) in name_checks
+        passed, message = func(pkgname, general)
+        if passed
+            printstyled("✔", color = :green)
+            println(" ", pass_message)
+        else
+            printstyled("✖", color = :red)
+            println(" ", fail_message)
+            println(extra_indent(message))
+        end
+    end
+end
+
+function fatal(message::AbstractString)
+    printstyled(stderr, "ERROR: ", color = :red)
+    println(stderr, message)
+    return 1
+end
+
+function extra_indent(s, n = 2)
+    return join(" "^n .* eachsplit(s, "\n"), "\n")
+end
+
+end
+
+# Speed up the CLI by precompiling the main entry point.
+precompile(Tuple{typeof(AutoMerge.GeneralNameCheck.main), Array{String, 1}})

--- a/AutoMerge/src/guidelines.jl
+++ b/AutoMerge/src/guidelines.jl
@@ -300,7 +300,7 @@ const guideline_name_match_check = Guideline(;
     docs = "Packages must not match the name of existing package up-to-case, since on case-insensitive filesystems, this will break the registry.",
     check=data -> meets_name_match_check(data.pkg, data.registry_master))
 
-function meets_name_match_check(pkg_name::AbstractString, registry_master::AbstractString)
+function meets_name_match_check(pkg_name::AbstractString, registry_master)
     other_packages = get_all_pkg_names(registry_master)
     return meets_name_match_check(pkg_name, other_packages)
 end
@@ -563,7 +563,7 @@ These checks can be overridden by applying a label `Override AutoMerge: name sim
 )
 
 function meets_distance_check(
-    pkg_name::AbstractString, registry_master::AbstractString; kwargs...
+    pkg_name::AbstractString, registry_master; kwargs...
 )
     other_packages = get_all_pkg_names(registry_master; keep_jll=false)
     return meets_distance_check(pkg_name, other_packages; kwargs...)

--- a/AutoMerge/test/apps.jl
+++ b/AutoMerge/test/apps.jl
@@ -1,0 +1,30 @@
+using Test
+using AutoMerge
+
+@testset "General name check" begin
+    name_check_main = @static if VERSION >= v"1.12"
+        AutoMerge.GeneralNameCheck.main
+    else
+        AutoMerge.GeneralNameCheck._main
+    end
+
+    # Note: main returns exit codes.
+    redirect_stderr(devnull) do
+        @test name_check_main(String[]) == 1
+        @test name_check_main(["a", "b"]) == 1
+    end
+    mktemp() do path, io
+        redirect_stdout(io) do
+            @test name_check_main(["csv"]) == 0
+        end
+        close(io)
+        output = read(path, String)
+        @test contains(output, "Name is a valid identifier.")
+        @test contains(output, "Name only contains ascii characters.")
+        @test contains(output, "Name matches registered package up to capitalization:")
+        @test contains(output, "Name is shorter than five characters:")
+        @test contains(output, "Name passes julia redundancy check.")
+        @test contains(output, "Name does not have normal capitalization:")
+        @test contains(output, "Name similarities found:")
+    end
+end

--- a/AutoMerge/test/runtests.jl
+++ b/AutoMerge/test/runtests.jl
@@ -53,3 +53,8 @@ end
         end
     end
 end
+
+@testset "Apps" begin
+    @info("Running app tests")
+    include("apps.jl")
+end

--- a/README.md
+++ b/README.md
@@ -29,3 +29,23 @@ This repository contains two Julia packages:
 Starting with RegistryCI v11.0, the automerge and TagBot functionality has been moved to the separate AutoMerge.jl package. RegistryCI.jl now focuses solely on registry testing.
 
 Please see the [documentation](https://JuliaRegistries.github.io/RegistryCI.jl/stable) for both packages.
+
+## Locally Check if a Package Name Passes Automerge Name Checks.
+
+AutoMerge has a number of checks related to the name of a new package,
+including a name similarity check to already registered packages. With
+Julia 1.12 and later, you can run those yourself through a command
+line tool.
+
+Install it with
+
+```
+using Pkg
+Pkg.Apps.add("AutoMerge")
+```
+
+and run it from the terminal with
+
+```
+general_name_check <Package Name>
+```


### PR DESCRIPTION
It's about time AutoMerge gets an app.

```
$ general_name_check csv
✔ Name is a valid identifier.
✔ Name only contains ascii characters.
✖ Name matches registered package up to capitalization:
  Package name matches existing package name CSV up-to-case.
✖ Name is shorter than five characters:
  Name is not at least 5 characters long
✔ Name passes julia redundancy check.
✖ Name does not have normal capitalization:
  Name does not meet all of the following: starts with an upper-case letter, ASCII alphanumerics only, not all letters are upper-case.
✖ Name similarities found:
  Package name similar to 3 existing packages.
    1. Similar to Rsvg. Damerau-Levenshtein distance 2 is at or below cutoff of 2.
    2. Similar to Vcov. Damerau-Levenshtein distance 2 is at or below cutoff of 2.
    3. Similar to uCSV. Damerau-Levenshtein distance 1 between lowercased names is at or below cutoff of 1.

$ general_name_check CommaSeparatedValues
✔ Name is a valid identifier.
✔ Name only contains ascii characters.
✔ Name is not already registered.
✔ Name is at least five characters.
✔ Name passes julia redundancy check.
✔ Name has normal capitalization.
✔ No name similarity found.
```

This PR has been made without AI support and should be fairly easy to review.

To try this out before it's merged, install the app with
```
using Pkg
Pkg.Apps.add(url="https://github.com/JuliaRegistries/RegistryCI.jl.git", subdir="AutoMerge", rev="name_check_app")
```