### PR TITLE
AutoMerge: Allow subdir change in new version

### DIFF
--- a/AutoMerge/src/changed_files.jl
+++ b/AutoMerge/src/changed_files.jl
@@ -12,6 +12,8 @@ function allowed_changed_files(::NewPackage, pkg::String)
     return result
 end
 
+# Package.toml is only allowed to change subdir information, which is
+# checked separately.
 function allowed_changed_files(::NewVersion, pkg::String)
     _package_relpath_per_scheme = _get_package_relpath_per_name_scheme(; package_name=pkg)
     result = String[
@@ -19,6 +21,7 @@ function allowed_changed_files(::NewVersion, pkg::String)
         "$(_package_relpath_per_scheme)/WeakCompat.toml",
         "$(_package_relpath_per_scheme)/Deps.toml",
         "$(_package_relpath_per_scheme)/WeakDeps.toml",
+        "$(_package_relpath_per_scheme)/Package.toml",
         "$(_package_relpath_per_scheme)/Versions.toml",
     ]
     return result
@@ -45,35 +48,46 @@ function pr_only_changes_allowed_files(
     pkg::String;
     auth::GitHub.Authorization,
 )
-    _allowed_changed_files = allowed_changed_files(t, pkg)
-    _num_allowed_changed_files = length(_allowed_changed_files)
-    this_pr_num_changed_files = num_changed_files(pr)
-    if this_pr_num_changed_files > _num_allowed_changed_files
-        g0 = false
-        m0 = "This PR is allowed to modify at most $(_num_allowed_changed_files) files, but it actually modified $(this_pr_num_changed_files) files."
-        return g0, m0
-    else
-        this_pr_changed_files = get_changed_filenames(api, registry, pr; auth=auth)
-        if length(this_pr_changed_files) != this_pr_num_changed_files
-            g0 = false
-            m0 = "Something weird happened when I tried to get the list of changed files"
-            return g0, m0
-        else
-            if issubset(this_pr_changed_files, _allowed_changed_files)
-                g0 = true
-                m0 = ""
-                return g0, m0
-            else
-                g0 = false
-                m0 = string(
-                    "This pull request modified at least one file ",
-                    "that it is not allowed to modify. It is only ",
-                    "allowed to modify the following files ",
-                    "(or a subset thereof): ",
-                    "$(join(_allowed_changed_files, ", "))",
-                )
-                return g0, m0
+    allowed_changed_filenames = allowed_changed_files(t, pkg)
+    changed_files = get_changed_files(api, registry, pr; auth)
+    changed_filenames = [file.filename for file in changed_files]
+
+    if !issubset(changed_filenames, allowed_changed_filenames)
+        message = string(
+            "This pull request modified at least one file ",
+            "that it is not allowed to modify. It is only ",
+            "allowed to modify the following files ",
+            "(or a subset thereof): ",
+            "$(join(_allowed_changed_files, ", "))",
+        )
+        return false, message
+    end
+
+    if !check_package_toml_changes(t, changed_files)
+        message = "This pull request modified Package.toml and changed something other than subdir, which is not allowed."
+        return false, message
+    end
+
+    return true, ""
+end
+
+# No restrictions for new packages.
+check_package_toml_changes(::NewPackage, _) = true
+
+# New versions may only change subdir information in Package.toml.
+#
+# (Currently Registrator wouldn't change anything else, so this is
+# some extra safety belt against future Registrator/RegistryTools
+# changes or someone managing to forge a Registrator PR.)
+function check_package_toml_changes(::NewVersion, changed_files)
+    for file in changed_files
+        if basename(file.filename) == "Package.toml"
+            for line in vcat(get_removed_lines(file), get_added_lines(file))
+                if !startswith(line, "subdir")
+                    return false
+                end
             end
         end
     end
+    return true
 end

--- a/AutoMerge/src/github.jl
+++ b/AutoMerge/src/github.jl
@@ -128,13 +128,22 @@ function get_all_pull_requests(
     return all_pull_requests
 end
 
+function get_changed_files(
+    api::GitHub.GitHubAPI,
+    repo::GitHub.Repo,
+    pull_request::GitHub.PullRequest;
+    auth::GitHub.Authorization,
+)
+    return GitHub.pull_request_files(api, repo, pull_request; auth=auth)
+end
+
 function get_changed_filenames(
     api::GitHub.GitHubAPI,
     repo::GitHub.Repo,
     pull_request::GitHub.PullRequest;
     auth::GitHub.Authorization,
 )
-    files = GitHub.pull_request_files(api, repo, pull_request; auth=auth)
+    files = get_changed_files(api, repo, pull_request; auth)
     return [file.filename for file in files]
 end
 
@@ -225,4 +234,21 @@ title(pull_request::GitHub.PullRequest) = pull_request.title
 function username(api::GitHub.GitHubAPI, auth::GitHub.Authorization)
     user_information = GitHub.gh_get_json(api, "/user"; auth=auth)
     return user_information["login"]::String
+end
+
+# Lines in the patch, starting with " " for unchanged lines, "-" for
+# removed lines, "+" for added lines, and "@@" for position
+# information.
+function get_patch_lines(file::GitHub.PullRequestFile)
+    return split(file.patch, "\n"; keepempty = false)
+end
+
+# Added lines only, without leading "+".
+function get_added_lines(file::GitHub.PullRequestFile)
+    return chopprefix.(filter(startswith("+"), get_patch_lines(file)), "+")
+end
+
+# Removed lines only, without leading "-".
+function get_removed_lines(file::GitHub.PullRequestFile)
+    return chopprefix.(filter(startswith("-"), get_patch_lines(file)), "-")
 end

--- a/AutoMerge/test/automerge-unit.jl
+++ b/AutoMerge/test/automerge-unit.jl
@@ -247,6 +247,60 @@ end
             end
         end
     end
+
+    @testset "check_package_toml_changes" begin
+        # Versions.toml patch from #158607.
+        versions_patch =
+            """
+            @@ -45,3 +45,6 @@ git-tree-sha1 = "f2688afd4eca4609192bba5595bae4a5728396bc"
+             
+             ["0.16.0"]
+             git-tree-sha1 = "07cdfa7961708d19bd016a3f93fd1a41d7c9cd57"
+            +
+            +["0.17.0"]
+            +git-tree-sha1 = "ec5a470161d3c7d14180235c97da219761aa7f94"
+            """
+
+        # Package.toml patch from #158607.
+        package_patch1 =
+            """
+             @@ -1,3 +1,4 @@
+             name = "ADRIA"
+             uuid = "7dc409a7-fbe5-4c9d-b3e2-b0c19a6ba600"
+             repo = "https://github.com/open-AIMS/ADRIA.jl.git"
+            +subdir = "ADRIA"
+            """
+
+        # Modified with a repo change as well.
+        package_patch2 =
+            """
+             @@ -1,3 +1,4 @@
+             name = "ADRIA"
+             uuid = "7dc409a7-fbe5-4c9d-b3e2-b0c19a6ba600"
+            -repo = "https://github.com/open-AIMS/ADRIA.jl.git"
+            +repo = "https://github.com/AIMS/ADRIA.jl.git"
+            +subdir = "ADRIA"
+            """
+
+        files1 = [GitHub.PullRequestFile(filename = "A/ADRIA/Versions.toml";
+                                         patch = versions_patch),
+                  GitHub.PullRequestFile(filename = "A/ADRIA/Package.toml";
+                                         patch = package_patch1)]
+
+        files2 = [GitHub.PullRequestFile(filename = "A/ADRIA/Versions.toml";
+                                         patch = versions_patch),
+                  GitHub.PullRequestFile(filename = "A/ADRIA/Package.toml";
+                                         patch = package_patch2)]
+
+        @test AutoMerge.check_package_toml_changes(AutoMerge.NewPackage(),
+                                                   files1)
+        @test AutoMerge.check_package_toml_changes(AutoMerge.NewPackage(),
+                                                   files2)
+        @test AutoMerge.check_package_toml_changes(AutoMerge.NewVersion(),
+                                                   files1)
+        @test !AutoMerge.check_package_toml_changes(AutoMerge.NewVersion(),
+                                                    files2)
+    end
 end
 
 @testset "juliaup" begin
@@ -1598,4 +1652,31 @@ end
             @test result_with_data == result_no_data
         end
     end
+end
+
+@testset "GitHub" begin
+    # WeakDeps.toml patch from #158607.
+    patch = """
+            @@ -1,4 +1,4 @@
+            -["0.10 - 0"]
+            +["0.10 - 0.16"]
+             Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
+             
+             ["0.11"]
+            @@ -7,7 +7,7 @@ SparseArrayKit = "a9a3c162-d163-4c15-8926-b8794fbefed2"
+             ["0.11 - 0"]
+             BlackBoxOptim = "a134a8b2-14d6-55f6-9291-3336d3ab0209"
+             
+            -["0.6 - 0"]
+            +["0.6 - 0.16"]
+             GeoMakie = "db073c08-6b98-4ee5-b6a4-5efafb3259c6"
+             GraphMakie = "1ecd5474-83a3-4783-bb4f-06765db800d2"
+             
+            """
+    file = GitHub.PullRequestFile(; patch)
+    @test length(AutoMerge.get_patch_lines(file)) == 15
+    removed_lines = AutoMerge.get_removed_lines(file)
+    added_lines = AutoMerge.get_added_lines(file)
+    @test removed_lines == ["""["0.10 - 0"]""", """["0.6 - 0"]"""]
+    @test added_lines == ["""["0.10 - 0.16"]""", """["0.6 - 0.16"]"""]
 end


### PR DESCRIPTION
If someone moves a package to a subdir and then registers a new version, AutoMerge will be upset because there is a change to `Package.toml` in addition to the normally changed registry files. To resolve this we ask the author to make a manual PR for the addition of the subdir only. This works but is a bit silly since it adds

* A strange automerge error that the package author might not understand.
* Extra work for the package author to make a manual PR.
* Extra work for registry maintainers to review and merge that PR.

There is not that much that can go wrong when moving to a subdir (unless you do it with a git history rewrite) and these days we have a treecheck job that runs when `Package.toml` changes.

Hence this PR relaxes the check of changed files for a new version to also allow changes in `Package.toml`, conditional on only adding, removing, or modifying a subdir line.

This also includes simplifying the `pr_only_changes_allowed_files` logic:
* Skip the number of changed files shortcut. This only rarely triggers, and probably never after these changes, and provides obscure diagnostics.
* Skip the consistency check of number of files from different GitHub APIs.
* Don't do a deep if/else nesting when we anyway explicitly return from every branch.
* Get rid of the `g0` and `m0` variable names. What do they mean anyway?