### PR TITLE
AutoMerge: Simplify pr_only_changes_allowed_files.

### DIFF
--- a/AutoMerge/src/changed_files.jl
+++ b/AutoMerge/src/changed_files.jl
@@ -45,27 +45,16 @@ function pr_only_changes_allowed_files(
     pkg::String;
     auth::GitHub.Authorization,
 )
-    _allowed_changed_files = allowed_changed_files(t, pkg)
-    _num_allowed_changed_files = length(_allowed_changed_files)
-    this_pr_num_changed_files = num_changed_files(pr)
-    if this_pr_num_changed_files > _num_allowed_changed_files
-        message = "This PR is allowed to modify at most $(_num_allowed_changed_files) files, but it actually modified $(this_pr_num_changed_files) files."
-        return false, message
-    end
+    allowed_changed_filenames = allowed_changed_files(t, pkg)
+    this_pr_changed_filenames = get_changed_filenames(api, registry, pr; auth=auth)
 
-    this_pr_changed_files = get_changed_filenames(api, registry, pr; auth=auth)
-    if length(this_pr_changed_files) != this_pr_num_changed_files
-        message = "Something weird happened when I tried to get the list of changed files"
-        return false, message
-    end
-
-    if !issubset(this_pr_changed_files, _allowed_changed_files)
+    if !issubset(this_pr_changed_filenames, allowed_changed_filenames)
         message = string(
             "This pull request modified at least one file ",
             "that it is not allowed to modify. It is only ",
             "allowed to modify the following files ",
             "(or a subset thereof): ",
-            "$(join(_allowed_changed_files, ", "))",
+            "$(join(allowed_changed_filenames, ", "))",
         )
         return false, message
     end

--- a/AutoMerge/src/changed_files.jl
+++ b/AutoMerge/src/changed_files.jl
@@ -49,31 +49,26 @@ function pr_only_changes_allowed_files(
     _num_allowed_changed_files = length(_allowed_changed_files)
     this_pr_num_changed_files = num_changed_files(pr)
     if this_pr_num_changed_files > _num_allowed_changed_files
-        g0 = false
-        m0 = "This PR is allowed to modify at most $(_num_allowed_changed_files) files, but it actually modified $(this_pr_num_changed_files) files."
-        return g0, m0
-    else
-        this_pr_changed_files = get_changed_filenames(api, registry, pr; auth=auth)
-        if length(this_pr_changed_files) != this_pr_num_changed_files
-            g0 = false
-            m0 = "Something weird happened when I tried to get the list of changed files"
-            return g0, m0
-        else
-            if issubset(this_pr_changed_files, _allowed_changed_files)
-                g0 = true
-                m0 = ""
-                return g0, m0
-            else
-                g0 = false
-                m0 = string(
-                    "This pull request modified at least one file ",
-                    "that it is not allowed to modify. It is only ",
-                    "allowed to modify the following files ",
-                    "(or a subset thereof): ",
-                    "$(join(_allowed_changed_files, ", "))",
-                )
-                return g0, m0
-            end
-        end
+        message = "This PR is allowed to modify at most $(_num_allowed_changed_files) files, but it actually modified $(this_pr_num_changed_files) files."
+        return false, message
     end
+
+    this_pr_changed_files = get_changed_filenames(api, registry, pr; auth=auth)
+    if length(this_pr_changed_files) != this_pr_num_changed_files
+        message = "Something weird happened when I tried to get the list of changed files"
+        return false, message
+    end
+
+    if !issubset(this_pr_changed_files, _allowed_changed_files)
+        message = string(
+            "This pull request modified at least one file ",
+            "that it is not allowed to modify. It is only ",
+            "allowed to modify the following files ",
+            "(or a subset thereof): ",
+            "$(join(_allowed_changed_files, ", "))",
+        )
+        return false, message
+    end
+
+    return true, ""
 end


### PR DESCRIPTION
NFC part of #722.

Edit: Technically this isn't quite NFC since it gives a different (and much better) error message in one case and skips a GitHub API consistency check. The PR has now been split into two commits where the first is a pure NFC refactorization and the second removes the redundant/useless checks.