### PR TITLE
AutoMerge: recognize files named 'tagbot.yml' as tagbot files

### DIFF
--- a/AutoMerge/src/TagBot/TagBot.jl
+++ b/AutoMerge/src/TagBot/TagBot.jl
@@ -73,7 +73,9 @@ function tagbot_file(repo; issue_comments=false)
         f.typ == "file" || continue
         file = GH.file(repo, f.path; auth=AUTH[])
         contents = String(base64decode(file.content))
-        if occursin("JuliaRegistries/TagBot", contents) || occursin("julia-testitems/testitem-workflow/.github/workflows/juliaci.yml", contents)
+        if lowercase(basename(f.path)) in ("tagbot.yml", "tagbot.yaml") ||
+                occursin("JuliaRegistries/TagBot", contents) ||
+                occursin("julia-testitems/testitem-workflow/.github/workflows/juliaci.yml", contents)
             issue_comments && !occursin("issue_comment", contents) && continue
             return f.path, contents
         end

--- a/AutoMerge/test/tagbot-unit.jl
+++ b/AutoMerge/test/tagbot-unit.jl
@@ -1,3 +1,4 @@
+using Base64: base64encode
 using BrokenRecord: BrokenRecord, HTTP, playback
 using Dates: DateTime, Day, UTC, now
 using AutoMerge: TagBot
@@ -49,6 +50,17 @@ end
         @test occursin("JuliaRegistries/TagBot", contents)
         @test TB.tagbot_file("JuliaWeb/HTTP.jl") !== nothing
         @test TB.tagbot_file("JuliaWeb/HTTP.jl"; issue_comments=true) === nothing
+    end
+    tagbot_yml = (; typ="file", path=".github/workflows/TagBot.yml")
+    unrelated_yml = (; typ="file", path=".github/workflows/CI.yml")
+    mock(
+        GH.directory => Mock(([tagbot_yml, unrelated_yml], Dict())),
+        GH.file => Mock((; content=base64encode("uses: SciML/.github/.github/workflows/tagbot.yml@v1"))),
+    ) do directory, file
+        path, contents = TB.tagbot_file("SciML/CurveFit.jl")
+        @test path == ".github/workflows/TagBot.yml"
+        @test occursin("SciML/.github/.github/workflows/tagbot.yml", contents)
+        @test TB.tagbot_file("SciML/CurveFit.jl"; issue_comments=true) === nothing
     end
 end
 


### PR DESCRIPTION
Currently it only checks for the presence of certain strings in the file, which will not trigger for SciML's new standard tagbot file, e.g.: https://github.com/SciML/CurveFit.jl/blob/master/.github/workflows/TagBot.yml

Checking for 'tagbot.yml' (any case) should be safe since that's the name recommended by the TagBot readme. @ChrisRackauckas, I believe this is why tagbot wasn't running for the recent CurveFit releases.

Debugged and written with Codex :robot: 