### PR TITLE
Backports for RegistryCI 10.x

### DIFF
--- a/src/AutoMerge/guidelines.jl
+++ b/src/AutoMerge/guidelines.jl
@@ -928,7 +928,7 @@ const guideline_version_has_osi_license = Guideline(;
 
 function meets_version_has_osi_license(pkg::String; pkg_code_path)
     pkgdir = pkg_code_path
-    if !isdir(pkgdir) || isempty(readdir(pkgdir))
+    if !(pkgdir isa AbstractString) || !isdir(pkgdir) || isempty(readdir(pkgdir))
         return false,
         "Could not check license because could not access package code. Perhaps the `can_download_code` check failed earlier."
     end

--- a/src/TagBot/TagBot.jl
+++ b/src/TagBot/TagBot.jl
@@ -71,7 +71,7 @@ function tagbot_file(repo; issue_comments=false)
         f.typ == "file" || continue
         file = GH.file(repo, f.path; auth=AUTH[])
         contents = String(base64decode(file.content))
-        if occursin("JuliaRegistries/TagBot", contents) || occursin("julia-vscode/testitem-workflow/.github/workflows/juliaci.yml", contents)
+        if occursin("JuliaRegistries/TagBot", contents) || occursin("julia-testitems/testitem-workflow/.github/workflows/juliaci.yml", contents)
             issue_comments && !occursin("issue_comment", contents) && continue
             return f.path, contents
         end

--- a/src/TagBot/TagBot.jl
+++ b/src/TagBot/TagBot.jl
@@ -71,7 +71,10 @@ function tagbot_file(repo; issue_comments=false)
         f.typ == "file" || continue
         file = GH.file(repo, f.path; auth=AUTH[])
         contents = String(base64decode(file.content))
-        if occursin("JuliaRegistries/TagBot", contents) || occursin("julia-testitems/testitem-workflow/.github/workflows/juliaci.yml", contents)
+        if lowercase(basename(f.path)) in ("tagbot.yml", "tagbot.yaml") ||
+            occursin("JuliaRegistries/TagBot", contents) ||
+            occursin("julia-testitems/testitem-workflow/.github/workflows/juliaci.yml", contents)
+
             issue_comments && !occursin("issue_comment", contents) && continue
             return f.path, contents
         end

--- a/test/automerge-unit.jl
+++ b/test/automerge-unit.jl
@@ -116,12 +116,10 @@ end
         result = AutoMerge.parse_registry_pkg_info(
             registry_path, "SnoopCompileCore", "2.5.2"
         )
-        @test result == (;
-            uuid="e2b509da-e806-4183-be48-004708413034",
-            repo="https://github.com/timholy/SnoopCompile.jl.git",
-            subdir="SnoopCompileCore",
-            tree_hash="bb6d6df44d9aa3494c997aebdee85b713b92c0de",
-        )
+        # Don't test repo field since SnoopCompile.jl has moved repositories (and we don't control it)
+        @test result.uuid == "e2b509da-e806-4183-be48-004708413034"
+        @test result.subdir == "SnoopCompileCore"
+        @test result.tree_hash == "bb6d6df44d9aa3494c997aebdee85b713b92c0de"
     end
 end
 

--- a/test/automerge-unit.jl
+++ b/test/automerge-unit.jl
@@ -26,7 +26,12 @@ function setup_global_depot()::String
     env2 = copy(env1)
     env2["JULIA_PKG_SERVER"] = ""
     run(setenv(`julia -e 'import Pkg; Pkg.Registry.add("General")'`, env2))
-    run(setenv(`julia -e 'import Pkg; Pkg.add(["RegistryCI"])'`, env1))
+    run(
+        setenv(
+            `julia -e 'import Pkg; Pkg.add(["RegistryCI", "UnbalancedOptimalTransport", "VisualStringDistances"])'`,
+            env1,
+        ),
+    )
     TEMP_DEPOT_FOR_TESTING = tmp_depot
     tmp_depot
 end
@@ -98,19 +103,15 @@ end
     @testset "`AutoMerge.parse_registry_pkg_info`" begin
         registry_path = joinpath(DEPOT_PATH[1], "registries", "General")
         result = AutoMerge.parse_registry_pkg_info(registry_path, "RegistryCI", "1.0.0")
-        @test result == (;
-            uuid="0c95cc5f-2f7e-43fe-82dd-79dbcba86b32",
-            repo="https://github.com/JuliaRegistries/RegistryCI.jl.git",
-            subdir="",
-            tree_hash="1036c9c4d600468785fbd9dae87587e59d2f66a9",
-        )
+        @test result.uuid == "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
+        @test result.repo == "https://github.com/JuliaRegistries/RegistryCI.jl.git"
+        @test result.subdir isa String
+        @test result.tree_hash == "1036c9c4d600468785fbd9dae87587e59d2f66a9"
         result = AutoMerge.parse_registry_pkg_info(registry_path, "RegistryCI")
-        @test result == (;
-            uuid="0c95cc5f-2f7e-43fe-82dd-79dbcba86b32",
-            repo="https://github.com/JuliaRegistries/RegistryCI.jl.git",
-            subdir="",
-            tree_hash=nothing,
-        )
+        @test result.uuid == "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
+        @test result.repo == "https://github.com/JuliaRegistries/RegistryCI.jl.git"
+        @test result.subdir isa String
+        @test result.tree_hash === nothing
 
         result = AutoMerge.parse_registry_pkg_info(
             registry_path, "SnoopCompileCore", "2.5.2"
@@ -721,6 +722,12 @@ end
     end
 
     @testset "`AutoMerge.meets_version_has_osi_license`" begin
+        result = AutoMerge.meets_version_has_osi_license(
+            "RegistryCI"; pkg_code_path=nothing
+        )
+        @test !result[1]
+        @test result[2] == "Could not check license because could not access package code. Perhaps the `can_download_code` check failed earlier."
+
         withenv("JULIA_PKG_PRECOMPILE_AUTO" => "0") do
             # Let's install a fresh depot in a temporary directory
             # and add some packages to inspect.

--- a/test/tagbot-unit.jl
+++ b/test/tagbot-unit.jl
@@ -1,3 +1,4 @@
+using Base64: base64encode
 using BrokenRecord: BrokenRecord, HTTP, playback
 using Dates: DateTime, Day, UTC, now
 using RegistryCI: TagBot
@@ -49,6 +50,18 @@ end
         @test occursin("JuliaRegistries/TagBot", contents)
         @test TB.tagbot_file("JuliaWeb/HTTP.jl") !== nothing
         @test TB.tagbot_file("JuliaWeb/HTTP.jl"; issue_comments=true) === nothing
+    end
+
+    tagbot_yml = (; typ="file", path=".github/workflows/TagBot.yml")
+    unrelated_yml = (; typ="file", path=".github/workflows/CI.yml")
+    mock(
+        GH.directory => Mock(([tagbot_yml, unrelated_yml], Dict())),
+        GH.file => Mock((; content=base64encode("uses: SciML/.github/.github/workflows/tagbot.yml@v1"))),
+    ) do directory, file
+        path, contents = TB.tagbot_file("SciML/CurveFit.jl")
+        @test path == ".github/workflows/TagBot.yml"
+        @test occursin("SciML/.github/.github/workflows/tagbot.yml", contents)
+        @test TB.tagbot_file("SciML/CurveFit.jl"; issue_comments=true) === nothing
     end
 end
 


### PR DESCRIPTION
Backported PRs:

- [x] Backported https://github.com/JuliaRegistries/RegistryCI.jl/pull/724.
- [x] Backported https://github.com/JuliaRegistries/RegistryCI.jl/pull/703.
- [x] Backported https://github.com/JuliaRegistries/RegistryCI.jl/pull/684.
- [x] Partially backported https://github.com/JuliaRegistries/RegistryCI.jl/pull/610.