### PR TITLE
Backport #684 ("update testitem-workflow URL") to RegistryCI v10.x

### DIFF
--- a/src/TagBot/TagBot.jl
+++ b/src/TagBot/TagBot.jl
@@ -71,7 +71,7 @@ function tagbot_file(repo; issue_comments=false)
         f.typ == "file" || continue
         file = GH.file(repo, f.path; auth=AUTH[])
         contents = String(base64decode(file.content))
-        if occursin("JuliaRegistries/TagBot", contents) || occursin("julia-vscode/testitem-workflow/.github/workflows/juliaci.yml", contents)
+        if occursin("JuliaRegistries/TagBot", contents) || occursin("julia-testitems/testitem-workflow/.github/workflows/juliaci.yml", contents)
             issue_comments && !occursin("issue_comment", contents) && continue
             return f.path, contents
         end


### PR DESCRIPTION
(cherry picked from commit 7b716c72bad717c31fd06e6ed80a34dd02398bc9)

Backported PRs:
- [x] #684