### PR TITLE
`release-registryci-v10.x`: Bump version from 10.10.4 to 10.10.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryCI"
 uuid = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
 authors = ["Dilum Aluthge <dilum@aluthge.com>", "Fredrik Ekre <ekrefredrik@gmail.com>", "contributors"]
-version = "10.10.4"
+version = "10.10.5"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"


### PR DESCRIPTION
As far as I can tell, all of the new backports (#728) are bug fixes, test fixes, or CI fixes, so I think a patch bump (10.10.4 to 10.10.5) is sufficient.