### PR TITLE
Allow `meets_sequential_version_number` to ignore build metadata

### DIFF
--- a/AutoMerge/src/guidelines.jl
+++ b/AutoMerge/src/guidelines.jl
@@ -813,7 +813,13 @@ function meets_sequential_version_number(
     else
         nextpatch(prv)
     end
-    ver <= nxt || return _invalid_sequential_version("version $ver skips over $nxt")
+
+    # Strip build metadata from `ver` as those fields should be ignored during this
+    # comparison. Without this versions which include build metadata will appear to
+    # skip over `nxt`.
+    clean_ver = VersionNumber(ver.major, ver.minor, ver.patch, ver.prerelease)
+
+    clean_ver <= nxt || return _invalid_sequential_version("version $ver skips over $nxt")
     return _valid_change(prv, ver)
 end
 

--- a/AutoMerge/src/guidelines.jl
+++ b/AutoMerge/src/guidelines.jl
@@ -817,6 +817,10 @@ function meets_sequential_version_number(
     # Strip build metadata from `ver` as those fields should be ignored during this
     # comparison. Without this versions which include build metadata will appear to
     # skip over `nxt`.
+    #
+    # Note: We have a separate guideline for "non-JLL packages should not have
+    # build metadata". That's a separate guideline from this one. So it's okay for
+    # this guideline to strip metadata when doing the version comparison.
     clean_ver = VersionNumber(ver.major, ver.minor, ver.patch, ver.prerelease)
 
     clean_ver <= nxt || return _invalid_sequential_version("version $ver skips over $nxt")

--- a/AutoMerge/test/automerge-unit.jl
+++ b/AutoMerge/test/automerge-unit.jl
@@ -680,6 +680,17 @@ end
             @test AutoMerge.meets_sequential_version_number(vers, v"3")[1]
             @test vers == [v"2", v"1"] # no mutation
         end
+        @testset "Build metadata ignored" begin
+            # `Base.VersionNumber` ordering (unlike strict semver) is affected by build
+            # metadata (e.g. `v"1.2.3" < v"1.2.3+demo"`). A version bump that only adds
+            # build data must not be treated as skipping over the plain next version.
+            @test AutoMerge.meets_sequential_version_number([v"1.2.3+demo"], v"1.2.4+demo")[1]
+            @test AutoMerge.meets_sequential_version_number([v"1.0.0+a"], v"1.0.1+b")[1]
+            @test AutoMerge.meets_sequential_version_number([v"1.0.0+a"], v"1.1.0+b")[1]
+            @test AutoMerge.meets_sequential_version_number([v"1.0.0+a"], v"2.0.0+b")[1]
+            @test !AutoMerge.meets_sequential_version_number([v"1.0.0+a"], v"1.2.0+b")[1]
+            @test !AutoMerge.meets_sequential_version_number([v"1.0.0+a"], v"3.0.0+b")[1]
+        end
     end
     @testset "Patch releases cannot narrow Julia compat" begin
         r1 = Pkg.Types.VersionRange("1.3-1.7")


### PR DESCRIPTION
Split out from #733. Working around what is technically an issue with `VersionNumber` ordering in that build metadata should be ignored with determining precedence:

> Build metadata MUST be ignored when determining version precedence. Thus two versions that differ only in the build metadata, have the same precedence. Examples: 1.0.0-alpha+001, 1.0.0+20130313144700, 1.0.0-beta+exp.sha.5114f85, 1.0.0+21AF26D3----117B344092BD.
> – https://semver.org/#spec-item-10
