### PR TITLE
AutoMerge: Allow package names that are all uppercase

### DIFF
--- a/AutoMerge/src/guidelines.jl
+++ b/AutoMerge/src/guidelines.jl
@@ -694,9 +694,8 @@ end
 const guideline_normal_capitalization = Guideline(;
     info="Normal capitalization",
     docs=string(
-        "The package name should start with an upper-case letter, ",
-        "contain only ASCII alphanumeric characters, ",
-        "and contain at least one lowercase letter.",
+        "The package name should start with an upper-case letter ",
+        "and contain only ASCII alphanumeric characters.",
     ),
     check=data -> meets_normal_capitalization(data.pkg),
 )
@@ -705,7 +704,7 @@ function meets_normal_capitalization(pkg)
     # We intentionally do not use `\w` in this regex.
     # `\w` includes underscores, but we don't want to include underscores.
     # So, instead of `\w`, we use `[A-Za-z0-9]`.
-    meets_this_guideline = occursin(r"^[A-Z][A-Za-z0-9]*[a-z][A-Za-z0-9]*[0-9]?$", pkg)
+    meets_this_guideline = occursin(r"^[A-Z][A-Za-z0-9]*?$", pkg)
     if meets_this_guideline
         return true, ""
     else

--- a/AutoMerge/test/automerge-unit.jl
+++ b/AutoMerge/test/automerge-unit.jl
@@ -294,12 +294,12 @@ end
     @testset "Normal capitalization" begin
         @test AutoMerge.meets_normal_capitalization("Zygote")[1]  # Regular name
         @test AutoMerge.meets_normal_capitalization("Zygote")[1]
-        @test !AutoMerge.meets_normal_capitalization("HTTP")[1]  # All upper-case
-        @test !AutoMerge.meets_normal_capitalization("HTTP")[1]
+        @test AutoMerge.meets_normal_capitalization("HTTP")[1]  # All upper-case (now allowed)
+        @test AutoMerge.meets_normal_capitalization("HTTP")[1]
         @test AutoMerge.meets_normal_capitalization("ForwardDiff2")[1]  # Ends with a number
         @test AutoMerge.meets_normal_capitalization("ForwardDiff2")[1]
-        @test !AutoMerge.meets_normal_capitalization("JSON2")[1]  # All upper-case and ends with number
-        @test !AutoMerge.meets_normal_capitalization("JSON2")[1]
+        @test AutoMerge.meets_normal_capitalization("JSON2")[1]  # All upper-case and ends with number (now allowed)
+        @test AutoMerge.meets_normal_capitalization("JSON2")[1]
         @test AutoMerge.meets_normal_capitalization("RegistryCI")[1]  # Ends with upper-case
         @test AutoMerge.meets_normal_capitalization("RegistryCI")[1]
     end


### PR DESCRIPTION
This is the result of internal discussion among the registry maintainers.