### PR TITLE
Remove duplicated tests in `AutoMerge/test/automerge-unit.jl`

### DIFF
--- a/AutoMerge/test/automerge-unit.jl
+++ b/AutoMerge/test/automerge-unit.jl
@@ -293,20 +293,13 @@ end
     end
     @testset "Normal capitalization" begin
         @test AutoMerge.meets_normal_capitalization("Zygote")[1]  # Regular name
-        @test AutoMerge.meets_normal_capitalization("Zygote")[1]
         @test !AutoMerge.meets_normal_capitalization("HTTP")[1]  # All upper-case
-        @test !AutoMerge.meets_normal_capitalization("HTTP")[1]
         @test AutoMerge.meets_normal_capitalization("ForwardDiff2")[1]  # Ends with a number
-        @test AutoMerge.meets_normal_capitalization("ForwardDiff2")[1]
         @test !AutoMerge.meets_normal_capitalization("JSON2")[1]  # All upper-case and ends with number
-        @test !AutoMerge.meets_normal_capitalization("JSON2")[1]
         @test AutoMerge.meets_normal_capitalization("RegistryCI")[1]  # Ends with upper-case
-        @test AutoMerge.meets_normal_capitalization("RegistryCI")[1]
     end
     @testset "Not too short - at least five letters" begin
         @test AutoMerge.meets_name_length("Zygote")[1]
-        @test AutoMerge.meets_name_length("Zygote")[1]
-        @test !AutoMerge.meets_name_length("Flux")[1]
         @test !AutoMerge.meets_name_length("Flux")[1]
     end
     @testset "Name does not include \"julia\", start with \"Ju\", or end with \"jl\"" begin
@@ -559,7 +552,7 @@ end
         @test AutoMerge.uuid_passes_sanity_check(UUID("00000000-0000-1000-0000-000000000000"))
 
         # Test invalid UUIDs - wrong variant for non-v1
-        # Version 4 but variant = 0 (should fail)
+        # Version 4 but variant = 0 (should fail; variant 0 is only allowed with version 1)
         @test !AutoMerge.uuid_passes_sanity_check(UUID("550e8400-e29b-41d4-0716-446655440000"))
 
         # Test invalid UUIDs - wrong version
@@ -568,9 +561,6 @@ end
 
         # Version 9 with variant 2 (should fail - version must be 1-8)
         @test !AutoMerge.uuid_passes_sanity_check(UUID("550e8400-e29b-91d4-a716-446655440000"))
-
-        # Test variant = 0 with version != 1 (should fail)
-        @test !AutoMerge.uuid_passes_sanity_check(UUID("550e8400-e29b-41d4-0716-446655440000"))
     end
     @testset "`meets_uuid_sanity_check`" begin
         # Test with compliant UUID - should pass
@@ -640,8 +630,6 @@ end
         @test !AutoMerge.meets_sequential_version_number([v"1.0.3"], v"1.1.1")[1]
         @test !AutoMerge.meets_sequential_version_number([v"1.0.0"], v"2.0.1")[1]
         @test !AutoMerge.meets_sequential_version_number([v"1.0.0"], v"2.1.0")[1]
-        @test !AutoMerge.meets_sequential_version_number([v"1.0.0"], v"2.1.0")[1]
-        @test AutoMerge.meets_sequential_version_number([v"0.0.1"], v"0.0.2")[1]
         @test AutoMerge.meets_sequential_version_number([v"0.0.1"], v"0.1.0")[1]
         @test AutoMerge.meets_sequential_version_number([v"0.0.1"], v"1.0.0")[1]
         @test AutoMerge.meets_sequential_version_number([v"0.0.1", v"0.1.0"], v"0.0.2")[1] # issue #49
@@ -675,7 +663,6 @@ end
         @test !AutoMerge.meets_sequential_version_number([v"1", v"2"], v"0.9")[1]
         @test AutoMerge.meets_sequential_version_number([v"1", v"2"], v"2.0.1")[1]
         @test AutoMerge.meets_sequential_version_number([v"1", v"2"], v"2.1")[1]
-        @test AutoMerge.meets_sequential_version_number([v"1", v"2"], v"3")[1]
         let vers = [v"2", v"1"]
             @test AutoMerge.meets_sequential_version_number(vers, v"3")[1]
             @test vers == [v"2", v"1"] # no mutation


### PR DESCRIPTION
🤖 **Claude Code PR description:**

This pull request was written by Claude Code.

## What

Removes 11 `@test` lines from `AutoMerge/test/automerge-unit.jl` that were exact duplicates of other assertions in the same file — same function, same arguments, same expected result. No source changes, no behavior changes, no new test cases.

| Testset | Removed |
|---|---|
| `Normal capitalization` | 5 (`Zygote`, `HTTP`, `ForwardDiff2`, `JSON2`, `RegistryCI`) |
| `Not too short - at least five letters` | 2 (`Zygote`, `Flux`) |
| `` `uuid_passes_sanity_check` `` | 1, plus its redundant comment block |
| `Sequential version number` | 3 (`[v"1.0.0"], v"2.1.0"`; `[v"0.0.1"], v"0.0.2"`; `[v"1", v"2"], v"3"`) |

In `uuid_passes_sanity_check` the two copies sat under comments describing the same rule from different angles, so the surviving comment was widened to `# Version 4 but variant = 0 (should fail; variant 0 is only allowed with version 1)` — the deleted block's intent is preserved, only the redundant assertion is gone.

## How these got there

Worth recording, because three of the eleven were propagated by later well-intentioned changes rather than written by hand:

- **`c74a306`** (2019-10-15, initial import) already contained doubled assertions for `Zygote`/`HTTP`, `Zygote`/`Flux`, and `meets_sequential_version_number(v"1.0.0", v"2.1.0")`.
- **`f1c5f6f`** (2020-05-09) added `ForwardDiff2`/`JSON2`/`LightXML` *each twice*, matching the surrounding doubled style; `643873a` then renamed `LightXML` → `RegistryCI` in both copies.
- **`6caa47a`** ("label tests") added an explanatory comment to only the *first* of each pair. This made the pairs read as deliberately asymmetric, and it means `git blame` credits the commented line of each pair to a **later** commit than its bare twin — actively disguising the duplication.
- **`3b4542b`** ("Fix sequential version criterion") migrated `meets_sequential_version_number(prev, new)` to `(prevs::Vector, new)` by transcribing all 26 lines one-for-one, carrying the `v"2.1.0"` duplicate across intact — and introduced the `[v"1", v"2"], v"3"` duplicate within that same commit.
- **`c5b522a`** appended a block of issue #49 cases opening with `[v"0.0.1"], v"0.0.2"`, which already existed 26 lines above.
- **`9818af3`** (#642) added the `uuid_passes_sanity_check` testset with the same UUID asserted twice under two headings.

The common enabler is unbroken runs of visually near-identical `@test` lines, where a repeated line is invisible in review and every mechanical pass over the block carries it forward.

## Deliberately left alone

These look like duplicates on a quick scan but are not:

- Lines 1546/1554, the repeated `tree_sha_to_commit_sha(subdir_tree, repo_dir; subdir="src")` — the second runs *after* an intervening commit that does not touch `src/`, so it is a real regression check.
- `auto_detect_ci_service()` vs `auto_detect_ci_service(; env=ENV)` — different method calls.
- The `Build metadata ignored` block — parallel in shape to the plain cases, but every input is distinct.
- `meets_version_number_no_prerelease` vs `meets_version_number_no_build` — parallel structure, different functions.

## Verification

- ✅ File parses (`Meta.parseall`, Julia 1.12.7).
- ✅ `@test` count drops by exactly 11 (554 → 543).
- ✅ Diffed the sorted, comment-normalized set of `@test` lines before vs. after: no unique assertion was lost and none was introduced. This is what rules out an accidental over-delete.
- ❌ **The test suite was not executed.** Nothing here confirms the suite still passes end-to-end; that is left to CI, or to running `AUTOMERGE_RUN_INTEGRATION_TESTS=false julia --project=AutoMerge -e 'using Pkg; Pkg.test()'` locally.

## Possible follow-up (not in this PR)

The root cause is the structure of these testsets, not the individual lines. Rewriting the long assertion walls as loops over case tuples would make a recurrence structurally impossible — but that is a real change to the tests, well beyond "remove duplicates", so it is deliberately out of scope here.

🤖 Assisted-by: Claude Code:claude-opus-5[1m]
