### PR TITLE
AutoMerge: Unify the package name rules into a single regular expression

### DIFF
--- a/AutoMerge/src/guidelines.jl
+++ b/AutoMerge/src/guidelines.jl
@@ -242,20 +242,60 @@ end
 
 const _AUTOMERGE_NEW_PACKAGE_MINIMUM_NAME_LENGTH = 5
 
-const guideline_name_length = Guideline(;
-    info="Name not too short",
-    docs="The name is at least $(_AUTOMERGE_NEW_PACKAGE_MINIMUM_NAME_LENGTH) characters long.",
-    check=data -> meets_name_length(data.pkg),
+# A single regular expression that a new (non-JLL) package name has to match.
+# It replaces four separate checks: valid Julia identifier, normal
+# capitalization, minimum length, and ASCII-only.
+#
+# We intentionally do not use `\w` in this regex.
+# `\w` includes underscores, but we don't want to include underscores.
+# So, instead of `\w`, we use `[A-Za-z0-9]`.
+#
+# We anchor with `\A` and `\z` rather than `^` and `$`, because the latter also
+# match around a trailing newline, and we want the *entire* name to match.
+const _AUTOMERGE_NEW_PACKAGE_NAME_REGEX = Regex(
+    "\\A[A-Z][A-Za-z0-9]{$(_AUTOMERGE_NEW_PACKAGE_MINIMUM_NAME_LENGTH - 1),}\\z"
 )
 
-function meets_name_length(pkg)
-    meets_this_guideline = length(pkg) >= _AUTOMERGE_NEW_PACKAGE_MINIMUM_NAME_LENGTH
-    if meets_this_guideline
+const guideline_name_format = Guideline(;
+    info="Name format",
+    docs=string(
+        "The package name matches the regular expression ",
+        "`$(_AUTOMERGE_NEW_PACKAGE_NAME_REGEX.pattern)`; that is, the name starts with ",
+        "an upper-case letter, consists of ASCII alphanumeric characters only, and is ",
+        "at least $(_AUTOMERGE_NEW_PACKAGE_MINIMUM_NAME_LENGTH) characters long.",
+    ),
+    check=data -> meets_name_format(data.pkg),
+)
+
+function meets_name_format(pkg)
+    if occursin(_AUTOMERGE_NEW_PACKAGE_NAME_REGEX, pkg)
         return true, ""
-    else
-        return false,
-        "Name is not at least $(_AUTOMERGE_NEW_PACKAGE_MINIMUM_NAME_LENGTH) characters long"
     end
+    # Spell out every part of the guideline that is violated, so that the author
+    # does not have to discover them one at a time.
+    problems = String[]
+    if !occursin(r"\A[A-Z]", pkg)
+        push!(problems, "it must start with an upper-case ASCII letter (`A-Z`)")
+    end
+    if !occursin(r"\A[A-Za-z0-9]*\z", pkg)
+        push!(
+            problems,
+            "it must consist of ASCII alphanumeric characters only (`A-Z`, `a-z`, `0-9`)",
+        )
+    end
+    if length(pkg) < _AUTOMERGE_NEW_PACKAGE_MINIMUM_NAME_LENGTH
+        push!(
+            problems,
+            "it must be at least $(_AUTOMERGE_NEW_PACKAGE_MINIMUM_NAME_LENGTH) characters long",
+        )
+    end
+    details = isempty(problems) ? "" : string(": ", join(problems, "; "))
+    return false,
+    string(
+        "The package's name ($pkg) does not match the regular expression ",
+        "`$(_AUTOMERGE_NEW_PACKAGE_NAME_REGEX.pattern)`$(details). ",
+        "The package must be renamed to be registered.",
+    )
 end
 
 const guideline_name_ascii = Guideline(;
@@ -688,28 +728,6 @@ function meets_name_is_identifier(pkg)
         return true, ""
     else
         return false, "The package's name ($pkg) is not a valid Julia identifier according to `Base.isidentifier`. Typically this means it contains `-` or other characters that can't be used in defining a variable name or module. The package must be renamed to be registered."
-    end
-end
-
-const guideline_normal_capitalization = Guideline(;
-    info="Normal capitalization",
-    docs=string(
-        "The package name should start with an upper-case letter ",
-        "and contain only ASCII alphanumeric characters.",
-    ),
-    check=data -> meets_normal_capitalization(data.pkg),
-)
-
-function meets_normal_capitalization(pkg)
-    # We intentionally do not use `\w` in this regex.
-    # `\w` includes underscores, but we don't want to include underscores.
-    # So, instead of `\w`, we use `[A-Za-z0-9]`.
-    meets_this_guideline = occursin(r"^[A-Z][A-Za-z0-9]*?$", pkg)
-    if meets_this_guideline
-        return true, ""
-    else
-        return false,
-        "Name does not meet all of the following: starts with an upper-case letter, ASCII alphanumerics only, not all letters are upper-case."
     end
 end
 
@@ -1334,8 +1352,12 @@ function get_automerge_guidelines(
         (guideline_registry_consistency_tests_pass, true),
         (guideline_pr_only_changes_allowed_files, true),
         # (guideline_only_changes_specified_package, true), # not yet implemented
-        (guideline_normal_capitalization, !this_pr_can_use_special_jll_exceptions),
-        (guideline_name_length, !this_pr_can_use_special_jll_exceptions),
+        # `guideline_name_format` subsumes the checks that the name is normally
+        # capitalized, is long enough, and is ASCII-only. JLL package names are
+        # exempt from it (they contain an underscore, and some of them start
+        # with a lower-case letter), so for those the ASCII check below is what
+        # constrains the name.
+        (guideline_name_format, !this_pr_can_use_special_jll_exceptions),
         (guideline_julia_name_check, true),
         (guideline_repo_url_requirement, true),
         (guideline_version_number_no_prerelease, true),
@@ -1346,7 +1368,7 @@ function get_automerge_guidelines(
         (guideline_compat_for_julia, true),
         (guideline_compat_for_all_deps, true),
         (guideline_allowed_jll_nonrecursive_dependencies, this_is_jll_package),
-        (guideline_name_ascii, true),
+        (guideline_name_ascii, this_pr_can_use_special_jll_exceptions),
         (:update_status, true),
         (guideline_version_can_be_pkg_added, true),
         (guideline_code_can_be_downloaded, true),

--- a/AutoMerge/test/automerge-unit.jl
+++ b/AutoMerge/test/automerge-unit.jl
@@ -291,23 +291,30 @@ end
         @test AutoMerge.meets_name_is_identifier("Hello")[1]
         @test !AutoMerge.meets_name_is_identifier("Hello-GoodBye")[1]
     end
-    @testset "Normal capitalization" begin
-        @test AutoMerge.meets_normal_capitalization("Zygote")[1]  # Regular name
-        @test AutoMerge.meets_normal_capitalization("Zygote")[1]
-        @test AutoMerge.meets_normal_capitalization("HTTP")[1]  # All upper-case (now allowed)
-        @test AutoMerge.meets_normal_capitalization("HTTP")[1]
-        @test AutoMerge.meets_normal_capitalization("ForwardDiff2")[1]  # Ends with a number
-        @test AutoMerge.meets_normal_capitalization("ForwardDiff2")[1]
-        @test AutoMerge.meets_normal_capitalization("JSON2")[1]  # All upper-case and ends with number (now allowed)
-        @test AutoMerge.meets_normal_capitalization("JSON2")[1]
-        @test AutoMerge.meets_normal_capitalization("RegistryCI")[1]  # Ends with upper-case
-        @test AutoMerge.meets_normal_capitalization("RegistryCI")[1]
-    end
-    @testset "Not too short - at least five letters" begin
-        @test AutoMerge.meets_name_length("Zygote")[1]
-        @test AutoMerge.meets_name_length("Zygote")[1]
-        @test !AutoMerge.meets_name_length("Flux")[1]
-        @test !AutoMerge.meets_name_length("Flux")[1]
+    @testset "Package name format" begin
+        @test AutoMerge.meets_name_format("Zygote")[1]  # Regular name
+        @test AutoMerge.meets_name_format("ForwardDiff2")[1]  # Ends with a number
+        @test AutoMerge.meets_name_format("RegistryCI")[1]  # Ends with upper-case
+        @test AutoMerge.meets_name_format("GNLSE")[1]  # All upper-case
+        @test AutoMerge.meets_name_format("PETSc")[1]
+        @test AutoMerge.meets_name_format("JSON2")[1]  # All upper-case, ends with number
+        @test !AutoMerge.meets_name_format("HTTP")[1]  # Only four characters
+        @test !AutoMerge.meets_name_format("Flux")[1]  # Only four characters
+        @test !AutoMerge.meets_name_format("ABC")[1]  # Only three characters
+        @test !AutoMerge.meets_name_format("zygote")[1]  # Starts with lower-case
+        @test !AutoMerge.meets_name_format("2Zygote")[1]  # Starts with a number
+        @test !AutoMerge.meets_name_format("Hello-GoodBye")[1]  # Not an identifier
+        @test !AutoMerge.meets_name_format("Hello_World")[1]  # Underscore
+        @test !AutoMerge.meets_name_format("Zygote_jll")[1]  # Non-JLL registration
+        @test !AutoMerge.meets_name_format("Ábcde")[1]  # Not ASCII
+        @test !AutoMerge.meets_name_format("Zygote\n")[1]  # Trailing newline
+        # The failure message spells out every part of the rule that is violated
+        let (passed, message) = AutoMerge.meets_name_format("ábc")
+            @test !passed
+            @test occursin("upper-case", message)
+            @test occursin("ASCII alphanumeric", message)
+            @test occursin("at least 5 characters", message)
+        end
     end
     @testset "Name does not include \"julia\", start with \"Ju\", or end with \"jl\"" begin
         @test AutoMerge.meets_julia_name_check("Zygote")[1]


### PR DESCRIPTION
Stacked on top of #735 (base branch is `dpa/automerge-allow-all-caps-names`); GitHub will retarget this to `master` once #735 merges. Only the last commit belongs to this PR.

## The proposal

AutoMerge constrains the name of a new package with four separate guidelines:

1. The name is a valid Julia identifier (`Base.isidentifier`).
2. "Normal capitalization": starts with an upper-case letter and contains only ASCII alphanumeric characters.
3. The name is at least 5 characters long.
4. The name is composed of ASCII characters only.

With the "at least one lower-case letter" clause gone (#735), rules 2 to 4 say one thing:

> The package name must match `\A[A-Z][A-Za-z0-9]{4,}\z`, or, in plain English, "must start with an upper-case letter, and be a minimum of 5 ASCII alphanumeric characters".

Rule 4 is subsumed, because `[A-Za-z0-9]` is ASCII by construction, and so is rule 1, because every Julia keyword is lower-case, so any name matching the regex is a valid identifier. This PR replaces rules 2 to 4 with that single `guideline_name_format`. Rule 1 stays in place as the early-exit gate it already is, and remains the operative rule for JLL registrations, which are exempt from the format.

This is a pure refactoring on top of #735. The set of names that auto-merge is unchanged:

| Package name | With #735 | This PR |
| --- | --- | --- |
| `Zygote`, `RegistryCI`, `PETSc` | ✅ | ✅ |
| `GNLSE`, `CPLEX`, `MATLAB`, `JSON2` | ✅ | ✅ |
| `HTTP`, `Flux`, `ABC` | ❌ (too short) | ❌ (too short) |
| `zygote` | ❌ (lower-case first letter) | ❌ (lower-case first letter) |
| `Hello-GoodBye`, `Hello_World` | ❌ (not an identifier) | ❌ (not an identifier) |
| `x264_jll`, `Ipopt_jll` (JLL registration) | ✅ | ✅ |

Changing the minimum length is now a one-line change to `_AUTOMERGE_NEW_PACKAGE_MINIMUM_NAME_LENGTH`, since the regex is built from that constant.

## Implementation notes

- `guideline_name_format` sits at exactly the position in the guideline list that `guideline_normal_capitalization` and `guideline_name_length` occupied, that is, after the `:early_exit_if_failed` marker. A package with an unacceptable name therefore still gets its `[compat]` problems, its repo URL problems, and everything else reported in the same comment, as it does today.
- JLL package names are exempt from the format rule (they contain an underscore, and some of them start with a lower-case letter), matching the current behavior, where "normal capitalization" and "name not too short" are disabled for JLL PRs. `guideline_name_ascii` is what constrains a JLL name, and it is now enabled only for JLL registrations, since the format rule already implies it for everyone else.
- The failure message names every part of the rule that is violated, rather than the current lump message:

  > The package's name (ábc) does not match the regular expression `\A[A-Z][A-Za-z0-9]{4,}\z`: it must start with an upper-case ASCII letter (`A-Z`); it must consist of ASCII alphanumeric characters only (`A-Z`, `a-z`, `0-9`); it must be at least 5 characters long. The package must be renamed to be registered.

- The regex is anchored with `\A` and `\z` rather than `^` and `$`, because the latter also match around a trailing newline. The old code used `^`/`$` but relied on the separate `Base.isidentifier` check to reject a name like `"Zygote\n"`. If `\A`/`\z` is too obscure for a user-facing message, I am happy to display `^[A-Z][A-Za-z0-9]{4,}$` in the docs and keep the strict anchors in the code.
- The "Automatic merging guidelines" documentation page now lists two name rules for new packages (identifier and format) instead of three.
